### PR TITLE
bug: convert deploy block env var to number

### DIFF
--- a/constants/deployBlocks.ts
+++ b/constants/deployBlocks.ts
@@ -1,1 +1,1 @@
-export const goerliDeployBlock = process.env.NEXT_PUBLIC_GOERLI_DEPLOY_BLOCK ?? "";
+export const goerliDeployBlock = Number(process.env.NEXT_PUBLIC_GOERLI_DEPLOY_BLOCK ?? "0");


### PR DESCRIPTION
### Summary

Using an env var for the deploy block caused a bug because the env var is a string instead of a number.

* Convert the env var to a number in the constants file.

Signed-off-by: ryanwolhuter <dev@ryanwolhuter.com>