### PR TITLE
feat: show vote rolled

### DIFF
--- a/components/VotesTable/VotesTableRow.tsx
+++ b/components/VotesTable/VotesTableRow.tsx
@@ -153,7 +153,8 @@ export function VotesTableRow({
                   <RolledIconWrapper>
                     <RolledIcon />
                   </RolledIconWrapper>
-                  <Link href="todo" passHref>
+                  {/* todo: add link to explanation of rolled votes in the docs once its written */}
+                  <Link href="https://docs.umaproject.org" passHref>
                     <RolledLink target="_blank">Rolled</RolledLink>
                   </Link>
                 </RolledWrapper>

--- a/components/VotesTable/VotesTableRow.tsx
+++ b/components/VotesTable/VotesTableRow.tsx
@@ -2,8 +2,10 @@ import { Button, Dropdown, LoadingSkeleton, TextInput } from "components";
 import { green, red500 } from "constants/colors";
 import { formatVoteStringWithPrecision, getPrecisionForIdentifier } from "helpers";
 import { useWalletContext } from "hooks";
+import Link from "next/link";
 import Dot from "public/assets/icons/dot.svg";
 import Polymarket from "public/assets/icons/polymarket.svg";
+import Rolled from "public/assets/icons/rolled.svg";
 import UMA from "public/assets/icons/uma.svg";
 import styled, { CSSProperties } from "styled-components";
 import { ActivityStatusT, VotePhaseT, VoteT } from "types";
@@ -28,7 +30,18 @@ export function VotesTableRow({
 }: Props) {
   const { signer } = useWalletContext();
 
-  const { decodedIdentifier, title, origin, options, isCommitted, isRevealed, decryptedVote, correctVote } = vote;
+  const {
+    decodedIdentifier,
+    title,
+    origin,
+    options,
+    isCommitted,
+    isRevealed,
+    decryptedVote,
+    correctVote,
+    voteNumber,
+    isRolled,
+  } = vote;
   const maxDecimals = getPrecisionForIdentifier(decodedIdentifier);
   const Icon = origin === "UMA" ? UMAIcon : PolymarketIcon;
 
@@ -134,7 +147,21 @@ export function VotesTableRow({
           </VoteIconWrapper>
           <VoteDetailsWrapper>
             <VoteTitle>{formatTitle(title)}</VoteTitle>
-            <VoteOrigin>{origin}</VoteOrigin>
+            <VoteDetailsInnerWrapper>
+              {isRolled ? (
+                <RolledWrapper>
+                  <RolledIconWrapper>
+                    <RolledIcon />
+                  </RolledIconWrapper>
+                  <Link href="todo" passHref>
+                    <RolledLink target="_blank">Rolled</RolledLink>
+                  </Link>
+                </RolledWrapper>
+              ) : null}
+              <VoteOrigin>
+                {origin} | Vote #{voteNumber.toString()}
+              </VoteOrigin>
+            </VoteDetailsInnerWrapper>
           </VoteDetailsWrapper>
         </VoteTitleWrapper>
       </VoteTitleOuterWrapper>
@@ -209,6 +236,12 @@ const VoteTitleWrapper = styled.div`
 
 const VoteDetailsWrapper = styled.div``;
 
+const VoteDetailsInnerWrapper = styled.div`
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+`;
+
 const VoteIconWrapper = styled.div`
   width: 40px;
   height: 40px;
@@ -261,4 +294,23 @@ const DotIcon = styled(Dot)`
   circle {
     fill: var(--dot-color);
   }
+`;
+
+const RolledWrapper = styled.div`
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+`;
+
+const RolledIconWrapper = styled.div`
+  width: 7px;
+  height: 7px;
+`;
+
+const RolledIcon = styled(Rolled)``;
+
+const RolledLink = styled.a`
+  font: var(--text-sm);
+  color: var(--red-500);
+  text-decoration: underline;
 `;

--- a/helpers/getVoteMetaData.ts
+++ b/helpers/getVoteMetaData.ts
@@ -18,6 +18,8 @@ export function getVoteMetaData(
   transactionHash: string,
   umipDataFromContentful: ContentfulDataT | undefined
 ): VoteMetaDataT {
+  // rolled votes have no transaction hash — the value for `transactionHash` will be `"rolled"`
+  const isRolled = transactionHash === "rolled";
   // if we are dealing with a UMIP, get the title, description and UMIP url from Contentful
   const isUmip = decodedIdentifier.includes("Admin");
   if (isUmip) {
@@ -37,6 +39,7 @@ export function getVoteMetaData(
       origin: "UMA",
       isGovernance: true,
       discordLink,
+      isRolled,
     };
   }
 
@@ -59,6 +62,7 @@ export function getVoteMetaData(
       origin: "Polymarket",
       isGovernance: false,
       discordLink,
+      isRolled,
     };
   }
 
@@ -82,6 +86,7 @@ export function getVoteMetaData(
       origin: "UMA",
       isGovernance: false,
       discordLink,
+      isRolled,
     };
   }
 
@@ -96,6 +101,7 @@ export function getVoteMetaData(
     origin: "UMA",
     isGovernance: false,
     discordLink,
+    isRolled,
   };
 }
 

--- a/public/assets/icons/rolled.svg
+++ b/public/assets/icons/rolled.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 7 7" xmlns="http://www.w3.org/2000/svg">
+<circle cx="3.5" cy="3.5" r="3" stroke="#FF4A4A"/>
+<circle cx="3.5" cy="3.5" r="1" stroke="#FF4A4A"/>
+</svg>

--- a/stories/mocks/votes.ts
+++ b/stories/mocks/votes.ts
@@ -3,6 +3,7 @@ import { BigNumber } from "ethers";
 
 export const voteWithoutUserVote = {
   isCommitted: false,
+  isRolled: false,
   title: "SuperUMAn DAO KPI Options funding proposal",
   origin: "UMA" as const,
   description: "Some description",

--- a/types/global.ts
+++ b/types/global.ts
@@ -81,6 +81,7 @@ export type VoteMetaDataT = {
   discordLink: string;
   links: LinkT[];
   options: DropdownItemT[] | undefined;
+  isRolled: boolean;
 };
 
 export type VoteResultT = {


### PR DESCRIPTION
### Summary

We have a function that gets transaction hashes for votes from the chain. When there is no transaction hash available, we know that particular vote was rolled. Add an indicator in the UI that shows when a vote was rolled.

* Add an `isRolled` property to vote metadata
* Add a "rolled" indicator to the votes in the votes table