### PR TITLE
fix: errors now fit in panel

### DIFF
--- a/components/PanelErrorBanner/PanelErrorBanner.tsx
+++ b/components/PanelErrorBanner/PanelErrorBanner.tsx
@@ -36,12 +36,10 @@ const OuterWrapper = styled.div`
 const InnerWrapper = styled.div``;
 
 const ErrorMessage = styled.p`
+  overflow-wrap: anywhere;
   &:not(:last-child) {
     margin-bottom: 8px;
   }
 `;
 
-const IconWrapper = styled.div`
-  width: 26px;
-  height: 26px;
-`;
+const IconWrapper = styled.div``;


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

The reason why these were expanding the panel is because globally paragraphs are set to break on word. errors that include the vote have long unbreakable strings, so we need to set this to break anywhere. 

you can quickly test this by opening stake/unstake, requesting to stake then cancelling the metamask popup.

![image](https://user-images.githubusercontent.com/4429761/194620705-8cc011fe-c0ed-469b-a09f-eabc6b57c377.png)
