### PR TITLE
fix: dynamically fetch unstake time from contract, update copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -5,17 +5,21 @@ import { useErrorContext } from "hooks";
 import { ChangeEvent, useState } from "react";
 import styled from "styled-components";
 import { PanelSectionText, PanelSectionTitle } from "../styles";
+import formatDuration from "date-fns/formatDuration";
 
 interface Props {
   tokenAllowance: BigNumber | undefined;
   unstakedBalance: BigNumber | undefined;
+  unstakeCoolDown: number | undefined;
   approve: (approveAmount: string) => void;
   stake: (stakeAmount: string, resetStakeAmount: () => void) => void;
 }
-export function Stake({ tokenAllowance, unstakedBalance, approve, stake }: Props) {
+export function Stake({ tokenAllowance, unstakedBalance, approve, stake, unstakeCoolDown }: Props) {
   const [stakeAmount, setStakeAmount] = useState("");
   const [disclaimerChecked, setDisclaimerChecked] = useState(false);
-  const disclaimer = "I understand that Staked tokens cannot be transferred for 7 days after unstaking.";
+  const unstakeCoolDownFormatted = unstakeCoolDown ? formatDuration({ seconds: unstakeCoolDown }) : "0 seconds";
+
+  const disclaimer = `I understand that Staked tokens cannot be transferred for ${unstakeCoolDownFormatted} after unstaking.`;
 
   function isApprove() {
     if (tokenAllowance === undefined || stakeAmount === "") return true;
@@ -40,8 +44,8 @@ export function Stake({ tokenAllowance, unstakedBalance, approve, stake }: Props
     <Wrapper>
       <PanelSectionTitle>Stake</PanelSectionTitle>
       <PanelSectionText>
-        Staked tokens can be used to vote and earn rewards. Staked tokens cannot be transferred for 7 days after
-        unstaking.
+        Staked tokens can be used to vote and earn rewards. Staked tokens cannot be transferred for{" "}
+        {unstakeCoolDownFormatted} after unstaking.
       </PanelSectionText>
       <AmountInputWrapper>
         <AmountInput

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -19,8 +19,15 @@ import { Unstake } from "./Unstake";
 
 export function StakeUnstakePanel() {
   const { voting, votingToken } = useContractsContext();
-  const { tokenAllowance, stakedBalance, unstakedBalance, pendingUnstake, canUnstakeTime, getBalancesFetching } =
-    useBalancesContext();
+  const {
+    tokenAllowance,
+    stakedBalance,
+    unstakedBalance,
+    pendingUnstake,
+    canUnstakeTime,
+    getBalancesFetching,
+    unstakeCoolDown,
+  } = useBalancesContext();
   const { approveMutation } = useApprove("stake");
   const { stakeMutation, isStaking } = useStake("stake");
   const { requestUnstakeMutation, isRequestingUnstake } = useRequestUnstake("unstake");
@@ -60,13 +67,24 @@ export function StakeUnstakePanel() {
     {
       title: "Stake",
       content: (
-        <Stake tokenAllowance={tokenAllowance} unstakedBalance={unstakedBalance} approve={approve} stake={stake} />
+        <Stake
+          tokenAllowance={tokenAllowance}
+          unstakedBalance={unstakedBalance}
+          approve={approve}
+          stake={stake}
+          unstakeCoolDown={unstakeCoolDown}
+        />
       ),
     },
     {
       title: "Unstake",
       content: (
-        <Unstake stakedBalance={stakedBalance} pendingUnstake={pendingUnstake} requestUnstake={requestUnstake} />
+        <Unstake
+          stakedBalance={stakedBalance}
+          pendingUnstake={pendingUnstake}
+          requestUnstake={requestUnstake}
+          unstakeCoolDown={unstakeCoolDown}
+        />
       ),
     },
   ];

--- a/components/Panel/StakeUnstakePanel/Unstake.tsx
+++ b/components/Panel/StakeUnstakePanel/Unstake.tsx
@@ -8,16 +8,19 @@ import Two from "public/assets/icons/two.svg";
 import { useState } from "react";
 import styled from "styled-components";
 import { PanelSectionText, PanelSectionTitle } from "../styles";
+import formatDuration from "date-fns/formatDuration";
 
 interface Props {
   stakedBalance: BigNumber | undefined;
   pendingUnstake: BigNumber | undefined;
+  unstakeCoolDown: number | undefined;
   requestUnstake: (unstakeAmount: string) => void;
 }
-export function Unstake({ stakedBalance, pendingUnstake, requestUnstake }: Props) {
+export function Unstake({ stakedBalance, pendingUnstake, requestUnstake, unstakeCoolDown }: Props) {
   const { phase } = useVoteTimingContext();
   const { hasActiveVotes } = useVotesContext();
   const [unstakeAmount, setUnstakeAmount] = useState("");
+  const unstakeCoolDownFormatted = unstakeCoolDown ? formatDuration({ seconds: unstakeCoolDown }) : "0 seconds";
 
   function canUnstake(stakedBalance: BigNumber | undefined, pendingUnstake: BigNumber | undefined) {
     if (stakedBalance === undefined || pendingUnstake === undefined) return false;
@@ -28,7 +31,8 @@ export function Unstake({ stakedBalance, pendingUnstake, requestUnstake }: Props
     <Wrapper>
       <PanelSectionTitle>Unstake</PanelSectionTitle>
       <PanelSectionText>
-        When you unstake tokens there is a 7 days cool off period and you wont be able to collect rewards text text
+        When you unstake tokens there is a {unstakeCoolDownFormatted} cool off period and you wont be able to collect
+        rewards text text
       </PanelSectionText>
       <HowItWorks>
         <HowItWorksTitle>How it works</HowItWorksTitle>
@@ -38,7 +42,7 @@ export function Unstake({ stakedBalance, pendingUnstake, requestUnstake }: Props
         </UnstakeStep>
         <UnstakeStep>
           <TwoIcon />
-          Cool-off period of 7 days
+          Cool-off period of {unstakeCoolDownFormatted}
         </UnstakeStep>
         <UnstakeStep>
           <ThreeIcon />

--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -15,6 +15,7 @@ export const tokenAllowanceKey = "tokenAllowanceKey";
 export const unstakedBalanceKey = "unstakedBalanceKey";
 export const outstandingRewardsKey = "outstandingRewardsKey";
 export const stakerDetailsKey = "stakerDetailsKey";
+export const unstakeCoolDownKey = "unstakeCoolDownKey";
 // user
 export const userDataKey = "userDataKey";
 

--- a/contexts/BalancesContext.tsx
+++ b/contexts/BalancesContext.tsx
@@ -5,6 +5,7 @@ import {
   useStakerDetails,
   useTokenAllowance,
   useUnstakedBalance,
+  useUnstakeCoolDown,
 } from "hooks";
 import { createContext, ReactNode } from "react";
 
@@ -16,6 +17,7 @@ export interface BalancesContextState {
   tokenAllowance: BigNumber | undefined;
   unstakeRequestTime: Date | undefined;
   canUnstakeTime: Date | undefined;
+  unstakeCoolDown: number | undefined;
   getBalancesLoading: () => boolean;
   getBalancesFetching: () => boolean;
 }
@@ -28,6 +30,7 @@ export const defaultBalancesContextState: BalancesContextState = {
   tokenAllowance: undefined,
   unstakeRequestTime: undefined,
   canUnstakeTime: undefined,
+  unstakeCoolDown: undefined,
   getBalancesLoading: () => false,
   getBalancesFetching: () => false,
 };
@@ -56,17 +59,34 @@ export function BalancesProvider({ children }: { children: ReactNode }) {
     isFetching: tokenAllowanceFetching,
   } = useTokenAllowance();
   const { address } = useAccountDetails();
+  const {
+    data: { unstakeCoolDown },
+    isLoading: unstakeCoolDownLoading,
+    isFetching: unstakeCoolDownFetching,
+  } = useUnstakeCoolDown();
 
   function getBalancesLoading() {
     if (!address) return false;
 
-    return stakerDetailsLoading || unstakedBalanceLoading || outstandingRewardsLoading || tokenAllowanceLoading;
+    return (
+      stakerDetailsLoading ||
+      unstakedBalanceLoading ||
+      outstandingRewardsLoading ||
+      tokenAllowanceLoading ||
+      unstakeCoolDownLoading
+    );
   }
 
   function getBalancesFetching() {
     if (!address) return false;
 
-    return stakerDetailsFetching || unstakedBalanceFetching || outstandingRewardsFetching || tokenAllowanceFetching;
+    return (
+      stakerDetailsFetching ||
+      unstakedBalanceFetching ||
+      outstandingRewardsFetching ||
+      tokenAllowanceFetching ||
+      unstakeCoolDownFetching
+    );
   }
 
   return (
@@ -75,6 +95,7 @@ export function BalancesProvider({ children }: { children: ReactNode }) {
         stakedBalance,
         unstakedBalance,
         pendingUnstake,
+        unstakeCoolDown,
         outstandingRewards,
         tokenAllowance,
         unstakeRequestTime,

--- a/helpers/getCanUnstakeTime.ts
+++ b/helpers/getCanUnstakeTime.ts
@@ -1,5 +1,8 @@
-import { addDays } from "date-fns";
+import addSeconds from "date-fns/addSeconds";
 
-export function getCanUnstakeTime(unstakeRequestTimeAsDate: Date) {
-  return addDays(unstakeRequestTimeAsDate, 7);
+// set 7 day cooldown as default
+const defaultUnstakeCoolDown = 7 * 24 * 60 * 60;
+
+export function getCanUnstakeTime(unstakeRequestTimeAsDate: Date, unstakeCooldownS = defaultUnstakeCoolDown) {
+  return addSeconds(unstakeRequestTimeAsDate, unstakeCooldownS);
 }

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -24,6 +24,7 @@ export { useOutstandingRewards } from "./queries/balances/useOutstandingRewards"
 export { useStakerDetails } from "./queries/balances/useStakerDetails";
 export { useTokenAllowance } from "./queries/balances/useTokenAllowance";
 export { useUnstakedBalance } from "./queries/balances/useUnstakedBalance";
+export { useUnstakeCoolDown } from "./queries/balances/useUnstakeCoolDown";
 export { useAccountDetails } from "./queries/user/useAccountDetails";
 export { useUserVotingAndStakingDetails as useUserData } from "./queries/user/useUserVotingAndStakingDetails";
 export { useActiveVotes } from "./queries/votes/useActiveVotes";

--- a/hooks/queries/balances/useUnstakeCoolDown.ts
+++ b/hooks/queries/balances/useUnstakeCoolDown.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { unstakeCoolDownKey } from "constants/queryKeys";
+import { useContractsContext, useHandleError } from "hooks";
+import { getUnstakeCoolDown } from "web3";
+
+export function useUnstakeCoolDown() {
+  const { voting } = useContractsContext();
+  const onError = useHandleError();
+  // only need to fetch this one time
+  const queryResult = useQuery([unstakeCoolDownKey], () => getUnstakeCoolDown(voting), {
+    initialData: {
+      unstakeCoolDown: 0,
+    },
+    onError,
+  });
+
+  return queryResult;
+}

--- a/web3/index.ts
+++ b/web3/index.ts
@@ -12,6 +12,7 @@ export { default as getOutstandingRewards } from "./queries/balances/getOutstand
 export { default as getStakerDetails } from "./queries/balances/getStakerDetails";
 export { default as getTokenAllowance } from "./queries/balances/getTokenAllowance";
 export { default as getUnstakedBalance } from "./queries/balances/getUnstakedBalance";
+export { default as getUnstakeCoolDown } from "./queries/balances/getUnstakeCoolDown";
 export { default as getActiveVotes } from "./queries/votes/getActiveVotes";
 export { default as getCommittedVotes } from "./queries/votes/getCommittedVotes";
 export { default as getEncryptedVotes } from "./queries/votes/getEncryptedVotes";

--- a/web3/queries/balances/getStakerDetails.ts
+++ b/web3/queries/balances/getStakerDetails.ts
@@ -1,12 +1,13 @@
 import { VotingV2Ethers } from "@uma/contracts-frontend";
+import getUnstakeCoolDown from "./getUnstakeCoolDown";
 import { getCanUnstakeTime } from "helpers";
 
 export default async function getStakerDetails(votingContract: VotingV2Ethers, address: string) {
   const result = await votingContract.voterStakes(address);
+  const { unstakeCoolDown } = await getUnstakeCoolDown(votingContract);
   const { stake: stakedBalance, pendingUnstake, unstakeRequestTime } = result ?? {};
-
   const unstakeRequestTimeAsDate = new Date(Number(unstakeRequestTime) * 1000);
-  const canUnstakeTime = getCanUnstakeTime(unstakeRequestTimeAsDate);
+  const canUnstakeTime = getCanUnstakeTime(unstakeRequestTimeAsDate, unstakeCoolDown);
 
   return {
     stakedBalance,

--- a/web3/queries/balances/getUnstakeCoolDown.ts
+++ b/web3/queries/balances/getUnstakeCoolDown.ts
@@ -1,0 +1,6 @@
+import { VotingV2Ethers } from "@uma/contracts-frontend";
+
+export default async function getUnstakeCoolDown(votingContract: VotingV2Ethers) {
+  const unstakeCoolDown = await votingContract.unstakeCoolDown();
+  return { unstakeCoolDown: unstakeCoolDown.toNumber() };
+}


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This fetches the cooldown time from the contract and updates relevant places in code to reflect time. 