### PR TITLE
fix: use max approval when setting stake

### DIFF
--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -1,9 +1,11 @@
 import { AmountInput, Button, Checkbox, PanelErrorBanner } from "components";
-import { BigNumber } from "ethers";
+import { BigNumber, constants } from "ethers";
 import { formatEther, parseEther } from "helpers";
 import { useState } from "react";
 import styled from "styled-components";
 import { PanelSectionText, PanelSectionTitle } from "../styles";
+
+const MaxApproval = formatEther(constants.MaxUint256);
 
 interface Props {
   tokenAllowance: BigNumber | undefined;
@@ -28,7 +30,7 @@ export function Stake({ tokenAllowance, unstakedBalance, approve, stake }: Props
   }
 
   function onApprove() {
-    approve(stakeAmount);
+    approve(MaxApproval);
   }
 
   function onStake() {


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

There was an issue where staking multiple times wihtout wiating for previous transactions to go through would cause transactions to revert. this was because approvals were only set for the stake amount.  this sets unlimited approvals to prevent those reverts and prevent user from needing to re-approve. 
![image](https://user-images.githubusercontent.com/4429761/194908935-8a97b3ab-0eb9-4a3e-ac8b-c586fb7c0e2b.png)
