### PR TITLE
fix: claim button now visible

### DIFF
--- a/components/Panel/StakeUnstakePanel/CooldownTimer.tsx
+++ b/components/Panel/StakeUnstakePanel/CooldownTimer.tsx
@@ -6,7 +6,7 @@ import Time from "public/assets/icons/time.svg";
 import styled from "styled-components";
 
 interface Props {
-  cooldownEnds: Date | null;
+  cooldownEnds: Date | null | undefined;
   pendingUnstake: BigNumber | undefined;
   canClaim: boolean;
   onClaim: () => void;

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -35,8 +35,8 @@ export function StakeUnstakePanel() {
   const cooldownEnds = canUnstakeTime;
   const hasCooldownTimeRemaining = !!cooldownEnds && cooldownEnds > new Date();
   const hasClaimableTokens = pendingUnstake?.gt(0) ?? false;
-  const showCooldownTimer = hasCooldownTimeRemaining && hasClaimableTokens;
   const canClaim = !hasCooldownTimeRemaining && hasClaimableTokens;
+  const showCooldownTimer = canClaim || (hasCooldownTimeRemaining && hasClaimableTokens);
 
   function isLoading() {
     return getBalancesFetching() || isStaking || isRequestingUnstake || isExecutingUnstake;
@@ -56,7 +56,12 @@ export function StakeUnstakePanel() {
   }
 
   function requestUnstake(unstakeAmount: string) {
-    requestUnstakeMutation({ voting, unstakeAmount: parseEther(unstakeAmount) });
+    try {
+      requestUnstakeMutation({ voting, unstakeAmount: parseEther(unstakeAmount) });
+    } catch (err) {
+      // parse ether failed, lets not crash app. this can happen if theres no input or NaN input
+      console.error(err);
+    }
   }
 
   function executeUnstake() {
@@ -84,6 +89,7 @@ export function StakeUnstakePanel() {
           pendingUnstake={pendingUnstake}
           requestUnstake={requestUnstake}
           unstakeCoolDown={unstakeCoolDown}
+          canClaim={canClaim}
         />
       ),
     },

--- a/components/Panel/StakeUnstakePanel/Unstake.tsx
+++ b/components/Panel/StakeUnstakePanel/Unstake.tsx
@@ -14,9 +14,10 @@ interface Props {
   stakedBalance: BigNumber | undefined;
   pendingUnstake: BigNumber | undefined;
   unstakeCoolDown: number | undefined;
+  canClaim: boolean;
   requestUnstake: (unstakeAmount: string) => void;
 }
-export function Unstake({ stakedBalance, pendingUnstake, requestUnstake, unstakeCoolDown }: Props) {
+export function Unstake({ stakedBalance, pendingUnstake, requestUnstake, unstakeCoolDown, canClaim }: Props) {
   const { phase } = useVoteTimingContext();
   const { hasActiveVotes } = useVotesContext();
   const [unstakeAmount, setUnstakeAmount] = useState("");
@@ -24,7 +25,7 @@ export function Unstake({ stakedBalance, pendingUnstake, requestUnstake, unstake
 
   function canUnstake(stakedBalance: BigNumber | undefined, pendingUnstake: BigNumber | undefined) {
     if (stakedBalance === undefined || pendingUnstake === undefined) return false;
-    return stakedBalance.gt(0) && pendingUnstake.eq(0);
+    return !canClaim && stakedBalance.gt(0) && pendingUnstake.eq(0);
   }
 
   return (
@@ -70,7 +71,8 @@ export function Unstake({ stakedBalance, pendingUnstake, requestUnstake, unstake
         </>
       )}
       <PanelErrorBanner errorType="unstake" />
-      {phase === "reveal" && hasActiveVotes && <p>Cannot request unstake in active reveal phase</p>}
+      {!canClaim && phase === "reveal" && hasActiveVotes && <p>Cannot request unstake in active reveal phase</p>}
+      {canClaim && <p>Cannot request to unstake until you claim unstaked tokens</p>}
     </Wrapper>
   );
 }


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

claim button was previously hidden when you had tokens to claim
![image](https://user-images.githubusercontent.com/4429761/195352486-e5cfaf2f-7c97-489c-963e-cb37eb70588b.png)

this enables the button and lets user know why they cant unstake more if they have unclaimed tokens