### PR TITLE
fix: format ethers tx errors for user

### DIFF
--- a/components/PanelErrorBanner/PanelErrorBanner.tsx
+++ b/components/PanelErrorBanner/PanelErrorBanner.tsx
@@ -42,4 +42,7 @@ const ErrorMessage = styled.p`
   }
 `;
 
-const IconWrapper = styled.div``;
+const IconWrapper = styled.div`
+  width: 26px;
+  height: 26px;
+`;

--- a/helpers/ethers.ts
+++ b/helpers/ethers.ts
@@ -1,4 +1,5 @@
 import { ethers } from "ethers";
+import { capitalizeFirstLetter } from "./misc";
 
 export const formatEther = ethers.utils.formatEther;
 
@@ -22,3 +23,12 @@ export const toUtf8String = ethers.utils.toUtf8String;
 export const formatBytes32String = ethers.utils.formatBytes32String;
 
 export const commify = ethers.utils.commify;
+
+export const formatTransactionError = (error: unknown): string | unknown => {
+  if (error instanceof Error) {
+    // ethers transactions put all call data and debug data between parens, so we will filter it out
+    const message = error.message.split("(")[0] || error.message;
+    return capitalizeFirstLetter(message);
+  }
+  return error;
+};

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -20,6 +20,7 @@ export {
   randomBytes,
   solidityKeccak256,
   toUtf8String,
+  formatTransactionError,
 } from "./ethers";
 export { formatNumberForDisplay, truncateDecimals } from "./formatNumber";
 export {

--- a/helpers/initOnboard.ts
+++ b/helpers/initOnboard.ts
@@ -39,7 +39,6 @@ export const initOnboard = init({
     position: "topLeft",
     enabled: true,
     transactionHandler: (transaction) => {
-      console.log({ transaction });
       if (transaction.eventCode === "txPool") {
         return {
           // autoDismiss set to zero will persist the notification until the user excuses it

--- a/helpers/misc.ts
+++ b/helpers/misc.ts
@@ -1,1 +1,4 @@
 export const isExternalLink = (href: string) => !href.startsWith("/");
+export function capitalizeFirstLetter(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/hooks/helpers/useHandleError.ts
+++ b/hooks/helpers/useHandleError.ts
@@ -6,6 +6,8 @@ export function useHandleError(errorType?: string) {
   return (error: unknown) => {
     if (error instanceof Error) {
       addErrorMessage(error.message);
+    } else if (typeof error === "string") {
+      addErrorMessage(error);
     } else {
       addErrorMessage("Unknown error");
     }

--- a/hooks/mutations/balances/useApprove.ts
+++ b/hooks/mutations/balances/useApprove.ts
@@ -3,6 +3,7 @@ import { tokenAllowanceKey } from "constants/queryKeys";
 import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError } from "hooks";
 import { approve } from "web3";
+import { formatTransactionError } from "helpers";
 
 export function useApprove(errorType?: string) {
   const queryClient = useQueryClient();
@@ -18,7 +19,9 @@ export function useApprove(errorType?: string) {
         return newTokenAllowance;
       });
     },
-    onError,
+    onError(error: unknown) {
+      onError(formatTransactionError(error));
+    },
   });
   return {
     approveMutation: mutate,

--- a/hooks/mutations/balances/useExecuteUnstake.ts
+++ b/hooks/mutations/balances/useExecuteUnstake.ts
@@ -4,6 +4,7 @@ import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError } from "hooks";
 import { StakerDetailsT } from "types";
 import { executeUnstake } from "web3";
+import { formatTransactionError } from "helpers";
 
 function max(a: BigNumber, b: BigNumber) {
   if (a.gt(b)) return a;
@@ -41,7 +42,9 @@ export function useExecuteUnstake(errorType?: string) {
         };
       });
     },
-    onError,
+    onError(error: unknown) {
+      onError(formatTransactionError(error));
+    },
   });
 
   return {

--- a/hooks/mutations/balances/useRequestUnstake.ts
+++ b/hooks/mutations/balances/useRequestUnstake.ts
@@ -4,6 +4,7 @@ import { getCanUnstakeTime } from "helpers";
 import { useAccountDetails, useHandleError } from "hooks";
 import { StakerDetailsT } from "types";
 import { requestUnstake } from "web3";
+import { formatTransactionError } from "helpers";
 
 export function useRequestUnstake(errorType?: string) {
   const queryClient = useQueryClient();
@@ -29,7 +30,9 @@ export function useRequestUnstake(errorType?: string) {
         };
       });
     },
-    onError,
+    onError(error: unknown) {
+      onError(formatTransactionError(error));
+    },
   });
   return {
     requestUnstakeMutation: mutate,

--- a/hooks/mutations/balances/useStake.ts
+++ b/hooks/mutations/balances/useStake.ts
@@ -4,6 +4,7 @@ import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError } from "hooks";
 import { StakerDetailsT } from "types";
 import { stake } from "web3";
+import { formatTransactionError } from "helpers";
 
 export function useStake(errorType?: string) {
   const queryClient = useQueryClient();
@@ -31,7 +32,9 @@ export function useStake(errorType?: string) {
         return newUnstakedBalance;
       });
     },
-    onError,
+    onError(error: unknown) {
+      onError(formatTransactionError(error));
+    },
   });
   return {
     stakeMutation: mutate,

--- a/hooks/mutations/balances/useWithdrawAndRestake.ts
+++ b/hooks/mutations/balances/useWithdrawAndRestake.ts
@@ -4,6 +4,7 @@ import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError } from "hooks";
 import { StakerDetailsT } from "types";
 import { withdrawAndRestake } from "web3";
+import { formatTransactionError } from "helpers";
 
 export function useWithdrawAndRestake(errorType?: string) {
   const queryClient = useQueryClient();
@@ -27,7 +28,9 @@ export function useWithdrawAndRestake(errorType?: string) {
 
       queryClient.setQueryData<BigNumber>([outstandingRewardsKey, address], () => BigNumber.from(0));
     },
-    onError,
+    onError(error: unknown) {
+      onError(formatTransactionError(error));
+    },
   });
   return {
     withdrawAndRestakeMutation: mutate,

--- a/hooks/mutations/balances/useWithdrawRewards.ts
+++ b/hooks/mutations/balances/useWithdrawRewards.ts
@@ -3,6 +3,7 @@ import { outstandingRewardsKey, unstakedBalanceKey } from "constants/queryKeys";
 import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError } from "hooks";
 import { withdrawRewards } from "web3";
+import { formatTransactionError } from "helpers";
 
 export function useWithdrawRewards(errorType?: string) {
   const queryClient = useQueryClient();
@@ -23,7 +24,9 @@ export function useWithdrawRewards(errorType?: string) {
 
       queryClient.setQueryData<BigNumber>([outstandingRewardsKey, address], () => BigNumber.from(0));
     },
-    onError,
+    onError(error: unknown) {
+      onError(formatTransactionError(error));
+    },
   });
 
   return {


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>
Transaction errors now get formatted to only include the message part. previously it would include call data.
![image](https://user-images.githubusercontent.com/4429761/197254834-4c589d7f-323c-4a36-82bb-b6de90cde85c.png)

This may not cover all transactions, so please comment if there needs to be more covered. 