### PR TITLE
fix: catch ether parsing errors from user input

### DIFF
--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -1,6 +1,6 @@
 import { AmountInput, Button, Checkbox, PanelErrorBanner } from "components";
 import { BigNumber, constants } from "ethers";
-import { formatEther, parseEther } from "helpers";
+import { formatEther, parseEtherSafe } from "helpers";
 import { useState } from "react";
 import styled from "styled-components";
 import { PanelSectionText, PanelSectionTitle } from "../styles";
@@ -24,13 +24,13 @@ export function Stake({ tokenAllowance, unstakedBalance, approve, stake, unstake
 
   function isApprove() {
     if (tokenAllowance === undefined || stakeAmount === "") return true;
-    const parsedStakeAmount = parseEther(stakeAmount);
+    const parsedStakeAmount = parseEtherSafe(stakeAmount);
     if (parsedStakeAmount.eq(0)) return true;
     return parsedStakeAmount.gt(tokenAllowance);
   }
 
   function isButtonDisabled() {
-    return !disclaimerChecked || stakeAmount === "" || parseEther(stakeAmount).eq(0);
+    return !disclaimerChecked || stakeAmount === "" || parseEtherSafe(stakeAmount).eq(0);
   }
 
   function onApprove() {

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -1,6 +1,5 @@
 import { LoadingSkeleton, Tabs } from "components";
-import { parseEther } from "ethers/lib/utils";
-import { formatNumberForDisplay } from "helpers";
+import { formatNumberForDisplay, parseEtherSafe } from "helpers";
 import {
   useApprove,
   useBalancesContext,
@@ -43,12 +42,12 @@ export function StakeUnstakePanel() {
   }
 
   function approve(approveAmount: string) {
-    approveMutation({ votingToken, approveAmount: parseEther(approveAmount) });
+    approveMutation({ votingToken, approveAmount: parseEtherSafe(approveAmount) });
   }
 
   function stake(stakeAmount: string, resetStakeAmount: () => void) {
     stakeMutation(
-      { voting, stakeAmount: parseEther(stakeAmount) },
+      { voting, stakeAmount: parseEtherSafe(stakeAmount) },
       {
         onSuccess: () => resetStakeAmount(),
       }
@@ -56,12 +55,7 @@ export function StakeUnstakePanel() {
   }
 
   function requestUnstake(unstakeAmount: string) {
-    try {
-      requestUnstakeMutation({ voting, unstakeAmount: parseEther(unstakeAmount) });
-    } catch (err) {
-      // parse ether failed, lets not crash app. this can happen if theres no input or NaN input
-      console.error(err);
-    }
+    requestUnstakeMutation({ voting, unstakeAmount: parseEtherSafe(unstakeAmount) });
   }
 
   function executeUnstake() {

--- a/helpers/ethers.ts
+++ b/helpers/ethers.ts
@@ -4,6 +4,15 @@ export const formatEther = ethers.utils.formatEther;
 
 export const parseEther = ethers.utils.parseEther;
 
+// This catches any potential errors form parsing an unknown string value, returns 0 if error happens.
+export function parseEtherSafe(value: string, decimals = 18): ethers.BigNumber {
+  try {
+    return ethers.utils.parseUnits(Number(value).toFixed(decimals), decimals);
+  } catch (err) {
+    return ethers.BigNumber.from(0);
+  }
+}
+
 export const solidityKeccak256 = ethers.utils.solidityKeccak256;
 
 export const randomBytes = ethers.utils.randomBytes;

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -16,6 +16,7 @@ export {
   formatBytes32String,
   formatEther,
   parseEther,
+  parseEtherSafe,
   randomBytes,
   solidityKeccak256,
   toUtf8String,


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This adds a second ether parsing function which catches an error and returns 0. A better but more work solution would be to validate user input before passing it to be parsed, but I don't think the extra work is justified, as this should work fine. 