### PR TITLE
fix: have button links detect when to open new tab

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -2,6 +2,7 @@ import { red100, red500, red600, white } from "constants/colors";
 import Link from "next/link";
 import { ReactNode } from "react";
 import styled, { CSSProperties } from "styled-components";
+import { isExternalLink } from "helpers";
 
 interface Props {
   /**
@@ -126,7 +127,9 @@ interface LinkProps {
 function _Link({ href, children, style }: LinkProps) {
   return (
     <Link href={href} passHref>
-      <A style={style}>{children}</A>
+      <A style={style} target={isExternalLink(href) ? "_blank" : undefined}>
+        {children}
+      </A>
     </Link>
   );
 }

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { ReactNode } from "react";
 import styled, { CSSProperties } from "styled-components";
+import { isExternalLink } from "helpers";
 
 interface Props {
   links: {
@@ -13,7 +14,6 @@ interface Props {
 export function Nav({ links }: Props) {
   const { pathname } = useRouter();
   const isActive = (href: string) => pathname === href;
-  const isExternalLink = (href: string) => !href.startsWith("/");
 
   return (
     <Wrapper>

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -43,3 +43,4 @@ export {
   computeRoundId,
   getPhase,
 } from "./voteTiming";
+export { isExternalLink } from "./misc";

--- a/helpers/misc.ts
+++ b/helpers/misc.ts
@@ -1,0 +1,1 @@
+export const isExternalLink = (href: string) => !href.startsWith("/");


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Takes external link detection, puts it as a utility and uses it in a link button. This should fix the issue, but I wasnt able to identify the particular local in the bug report. 