### PR TITLE
fix: dont let staking balance go below 0

### DIFF
--- a/hooks/mutations/balances/useExecuteUnstake.ts
+++ b/hooks/mutations/balances/useExecuteUnstake.ts
@@ -5,6 +5,11 @@ import { useAccountDetails, useHandleError } from "hooks";
 import { StakerDetailsT } from "types";
 import { executeUnstake } from "web3";
 
+function max(a: BigNumber, b: BigNumber) {
+  if (a.gt(b)) return a;
+  return b;
+}
+
 export function useExecuteUnstake(errorType?: string) {
   const queryClient = useQueryClient();
   const { address } = useAccountDetails();
@@ -24,8 +29,10 @@ export function useExecuteUnstake(errorType?: string) {
 
       queryClient.setQueryData<StakerDetailsT>([stakerDetailsKey, address], (oldStakerDetails) => {
         if (!oldStakerDetails) return;
-
-        const newStakedBalance = oldStakerDetails.stakedBalance.sub(oldStakerDetails.pendingUnstake);
+        const newStakedBalance = max(
+          BigNumber.from(0),
+          oldStakerDetails.stakedBalance.sub(oldStakerDetails.pendingUnstake)
+        );
         return {
           stakedBalance: newStakedBalance,
           pendingUnstake: BigNumber.from(0),


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Looks like there is a bit of a race condition when doing this subtraction. When unstaking we somtimes see an negative value, this is due to the state of staked balance changing before we do the subtraction.  we just make sure here to only show 0 if the number goes negative. 