### PR TITLE
feat: add close button to main errors

### DIFF
--- a/components/ErrorBanner/ErrorBanner.tsx
+++ b/components/ErrorBanner/ErrorBanner.tsx
@@ -1,9 +1,10 @@
 import { useErrorContext } from "hooks";
 import Warning from "public/assets/icons/warning.svg";
 import styled from "styled-components";
+import Close from "public/assets/icons/close.svg";
 
 export function ErrorBanner(props: { errorType?: string }) {
-  const { errorMessages } = useErrorContext(props.errorType);
+  const { errorMessages, removeErrorMessage } = useErrorContext(props.errorType);
 
   if (!errorMessages.length) return null;
 
@@ -15,6 +16,11 @@ export function ErrorBanner(props: { errorType?: string }) {
             <Warning />
           </IconWrapper>
           <ErrorMessage>{message}</ErrorMessage>
+          <CloseButton onClick={() => removeErrorMessage(message)}>
+            <IconWrapper>
+              <CloseIcon />
+            </IconWrapper>
+          </CloseButton>
         </ErrorMessageWrapper>
       ))}
     </Wrapper>
@@ -49,4 +55,13 @@ const ErrorMessage = styled.p`
 const IconWrapper = styled.div`
   width: 15px;
   height: 15px;
+`;
+const CloseIcon = styled(Close)`
+  path {
+    fill: var(--fill);
+  }
+`;
+const CloseButton = styled.button`
+  background: transparent;
+  fill: var(--white);
 `;

--- a/components/ErrorBanner/ErrorBanner.tsx
+++ b/components/ErrorBanner/ErrorBanner.tsx
@@ -58,7 +58,7 @@ const IconWrapper = styled.div`
 `;
 const CloseIcon = styled(Close)`
   path {
-    fill: var(--fill);
+    fill: var(--white);
   }
 `;
 const CloseButton = styled.button`

--- a/components/Panel/Panel.tsx
+++ b/components/Panel/Panel.tsx
@@ -57,7 +57,9 @@ export function Panel() {
                     } as CSSProperties
                   }
                 >
-                  <CloseIcon />
+                  <IconWrapper>
+                    <CloseIcon />
+                  </IconWrapper>
                 </CloseButton>
               </Content>
             </Overlay>
@@ -98,4 +100,8 @@ const CloseIcon = styled(Close)`
   path {
     fill: var(--fill);
   }
+`;
+const IconWrapper = styled.div`
+  width: 15px;
+  height: 15px;
 `;

--- a/components/PanelErrorBanner/PanelErrorBanner.tsx
+++ b/components/PanelErrorBanner/PanelErrorBanner.tsx
@@ -1,9 +1,10 @@
 import { useErrorContext } from "hooks";
 import Warning from "public/assets/icons/warning.svg";
 import styled from "styled-components";
+import Close from "public/assets/icons/close.svg";
 
 export function PanelErrorBanner({ errorType }: { errorType?: string }) {
-  const { errorMessages } = useErrorContext(errorType);
+  const { errorMessages, clearErrorMessages } = useErrorContext(errorType);
 
   if (errorMessages.length === 0) return null;
 
@@ -17,6 +18,11 @@ export function PanelErrorBanner({ errorType }: { errorType?: string }) {
           <ErrorMessage key={message?.toString()}>{message}</ErrorMessage>
         ))}
       </InnerWrapper>
+      <CloseButton onClick={() => clearErrorMessages()}>
+        <CloseIconWrapper>
+          <CloseIcon />
+        </CloseIconWrapper>
+      </CloseButton>
     </OuterWrapper>
   );
 }
@@ -33,7 +39,9 @@ const OuterWrapper = styled.div`
   gap: 13px;
 `;
 
-const InnerWrapper = styled.div``;
+const InnerWrapper = styled.div`
+  width: 100%;
+`;
 
 const ErrorMessage = styled.p`
   overflow-wrap: anywhere;
@@ -45,4 +53,18 @@ const ErrorMessage = styled.p`
 const IconWrapper = styled.div`
   width: 26px;
   height: 26px;
+`;
+
+const CloseIconWrapper = styled.div`
+  width: 15px;
+  height: 15px;
+`;
+
+const CloseIcon = styled(Close)`
+  path {
+    fill: var(--fill);
+  }
+`;
+const CloseButton = styled.button`
+  background: transparent;
 `;

--- a/components/PanelErrorBanner/PanelErrorBanner.tsx
+++ b/components/PanelErrorBanner/PanelErrorBanner.tsx
@@ -62,7 +62,7 @@ const CloseIconWrapper = styled.div`
 
 const CloseIcon = styled(Close)`
   path {
-    fill: var(--fill);
+    fill: var(--red-500);
   }
 `;
 const CloseButton = styled.button`

--- a/public/assets/icons/close.svg
+++ b/public/assets/icons/close.svg
@@ -1,3 +1,3 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M20 2.01429L17.9857 0L10 7.98571L2.01429 0L0 2.01429L7.98571 10L0 17.9857L2.01429 20L10 12.0143L17.9857 20L20 17.9857L12.0143 10L20 2.01429Z" fill="white"/>
 </svg>


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This adds an X to close error messages

![image](https://user-images.githubusercontent.com/4429761/197857491-36e84435-21d5-4be0-a44a-c5245be8858b.png)
![image](https://user-images.githubusercontent.com/4429761/197857562-49520d9f-b0f1-4641-a35a-30a47dc3740a.png)
