### PR TITLE
feat: add transaction links to commit reveal txs

### DIFF
--- a/components/VotesTable/VotesTableRow.tsx
+++ b/components/VotesTable/VotesTableRow.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import {
   Button,
   Dropdown,
@@ -45,7 +46,9 @@ export function VotesTableRow({
     origin,
     options,
     isCommitted,
+    commitHash,
     isRevealed,
+    revealHash,
     decryptedVote,
     correctVote,
     voteNumber,
@@ -152,6 +155,27 @@ export function VotesTableRow({
     }
   }
 
+  function getRelevantTransactionLink(): ReactNode | string {
+    if (phase === "commit") {
+      return commitHash ? (
+        <Button
+          href={`https://goerli.etherscan.io/tx/${commitHash}`}
+          label={getCommittedOrRevealed()}
+        />
+      ) : (
+        getCommittedOrRevealed()
+      );
+    }
+    return revealHash ? (
+      <Button
+        href={`https://goerli.etherscan.io/tx/${revealHash}`}
+        label={getCommittedOrRevealed()}
+      />
+    ) : (
+      getCommittedOrRevealed()
+    );
+  }
+
   return (
     <Wrapper>
       <VoteTitleOuterWrapper>
@@ -234,7 +258,7 @@ export function VotesTableRow({
                     } as CSSProperties
                   }
                 />{" "}
-                {getCommittedOrRevealed()}
+                {getRelevantTransactionLink()}
               </>
             )}
           </VoteStatus>

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -206,8 +206,10 @@ export function VotesProvider({ children }: { children: ReactNode }) {
       return {
         ...vote,
         uniqueKey,
-        isCommitted: committedVotes[uniqueKey] ?? false,
-        isRevealed: revealedVotes[uniqueKey] ?? false,
+        isCommitted: committedVotes[uniqueKey] ? true : false,
+        commitHash: committedVotes[uniqueKey],
+        isRevealed: revealedVotes[uniqueKey] ? true : false,
+        revealHash: revealedVotes[uniqueKey],
         encryptedVote: encryptedVotes[uniqueKey],
         decryptedVote: decryptedVotes[uniqueKey],
         contentfulData: contentfulData[uniqueKey],

--- a/hooks/mutations/votes/useCommitVotes.ts
+++ b/hooks/mutations/votes/useCommitVotes.ts
@@ -12,13 +12,16 @@ export function useCommitVotes() {
 
   const { mutate, isLoading } = useMutation(commitVotes, {
     onSuccess: (_data, { formattedVotes }) => {
+      console.log({ _data });
       queryClient.setQueryData<VoteExistsByKeyT>(
         [committedVotesKey, address, roundId],
         (oldCommittedVotes) => {
           const newCommittedVotes = { ...oldCommittedVotes };
 
           for (const { uniqueKey } of formattedVotes) {
-            newCommittedVotes[uniqueKey] = true;
+            if (_data?.transactionHash) {
+              newCommittedVotes[uniqueKey] = _data.transactionHash;
+            }
           }
 
           return newCommittedVotes;

--- a/hooks/mutations/votes/useCommitVotes.ts
+++ b/hooks/mutations/votes/useCommitVotes.ts
@@ -11,16 +11,15 @@ export function useCommitVotes() {
   const onError = useHandleError();
 
   const { mutate, isLoading } = useMutation(commitVotes, {
-    onSuccess: (_data, { formattedVotes }) => {
-      console.log({ _data });
+    onSuccess: (data, { formattedVotes }) => {
       queryClient.setQueryData<VoteExistsByKeyT>(
         [committedVotesKey, address, roundId],
         (oldCommittedVotes) => {
           const newCommittedVotes = { ...oldCommittedVotes };
 
           for (const { uniqueKey } of formattedVotes) {
-            if (_data?.transactionHash) {
-              newCommittedVotes[uniqueKey] = _data.transactionHash;
+            if (data?.transactionHash) {
+              newCommittedVotes[uniqueKey] = data.transactionHash;
             }
           }
 

--- a/hooks/mutations/votes/useRevealVotes.ts
+++ b/hooks/mutations/votes/useRevealVotes.ts
@@ -11,15 +11,15 @@ export function useRevealVotes() {
   const onError = useHandleError();
 
   const { mutate, isLoading } = useMutation(revealVotes, {
-    onSuccess: (_data, { votesToReveal }) => {
+    onSuccess: (data, { votesToReveal }) => {
       queryClient.setQueryData<VoteExistsByKeyT>(
         [revealedVotesKey, address, roundId],
         (oldRevealedVotes) => {
           const newRevealedVotes = { ...oldRevealedVotes };
 
           for (const { uniqueKey } of votesToReveal) {
-            if (_data?.transactionHash) {
-              newRevealedVotes[uniqueKey] = _data.transactionHash;
+            if (data?.transactionHash) {
+              newRevealedVotes[uniqueKey] = data.transactionHash;
             }
           }
 

--- a/hooks/mutations/votes/useRevealVotes.ts
+++ b/hooks/mutations/votes/useRevealVotes.ts
@@ -18,7 +18,9 @@ export function useRevealVotes() {
           const newRevealedVotes = { ...oldRevealedVotes };
 
           for (const { uniqueKey } of votesToReveal) {
-            newRevealedVotes[uniqueKey] = true;
+            if (_data?.transactionHash) {
+              newRevealedVotes[uniqueKey] = _data.transactionHash;
+            }
           }
 
           return newRevealedVotes;

--- a/stories/mocks/votes.ts
+++ b/stories/mocks/votes.ts
@@ -5,6 +5,7 @@ import { VoteT } from "types";
 
 export const voteWithoutUserVote = {
   isCommitted: false,
+  commitHash: undefined,
   isRolled: false,
   title: "SuperUMAn DAO KPI Options funding proposal",
   origin: "UMA" as const,
@@ -45,6 +46,7 @@ export const voteWithoutUserVote = {
   discordLink: "https://www.todo.com",
   isGovernance: false,
   isRevealed: false,
+  revealHash: undefined,
   voteHistory: {
     uniqueKey: "0x1234567890",
     voted: false,
@@ -70,6 +72,9 @@ export const voteWithUserVote = {
 export const voteCommitted = {
   ...voteWithUserVote,
   isCommitted: true,
+  commitHash:
+    "0xb7013512cb5f4e59fd08c299d8534373457f0f02aeb294e4f61611bfc8f43286",
+  revealHash: undefined,
 };
 
 export const voteCommittedButNotRevealed = { ...voteCommitted };
@@ -77,6 +82,10 @@ export const voteCommittedButNotRevealed = { ...voteCommitted };
 export const voteRevealed = {
   ...voteCommittedButNotRevealed,
   isRevealed: true,
+  revealHash:
+    "0xb7013512cb5f4e59fd08c299d8534373457f0f02aeb294e4f61611bfc8f43286",
+  commitHash:
+    "0xb7013512cb5f4e59fd08c299d8534373457f0f02aeb294e4f61611bfc8f43286",
 };
 
 export const voteWithCorrectVoteWithoutUserVote = {

--- a/types/user.ts
+++ b/types/user.ts
@@ -14,7 +14,9 @@ export type UserDataT = {
 
 export type UserVoteDataT = {
   isCommitted: boolean;
+  commitHash: string | undefined;
   isRevealed: boolean;
+  revealHash: string | undefined;
   encryptedVote: EncryptedVoteT | undefined;
   decryptedVote: DecryptedVoteT | undefined;
 };

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -104,7 +104,7 @@ export type DecryptedVotesByKeyT = Record<
   DecryptedVoteT | undefined
 >;
 
-export type VoteExistsByKeyT = Record<UniqueKeyT, boolean | undefined>;
+export type VoteExistsByKeyT = Record<UniqueKeyT, string | undefined>;
 
 export type SelectedVotesByKeyT = Record<UniqueKeyT, string | undefined>;
 

--- a/web3/queries/votes/getCommittedVotes.ts
+++ b/web3/queries/votes/getCommittedVotes.ts
@@ -16,15 +16,16 @@ export async function getCommittedVotes(
     null
   );
   const result = await votingContract.queryFilter(filter);
-  const eventData = result
-    ?.map(({ args }) => args)
-    .filter((args) => args.roundId.toNumber() === roundId);
+  const eventData = result?.filter(
+    ({ args }) => args.roundId.toNumber() === roundId
+  );
   const committedVotes: VoteExistsByKeyT = {};
-  eventData?.forEach(({ identifier, time, ancillaryData }) => {
+  eventData?.forEach(({ args, transactionHash }) => {
+    const { identifier, time, ancillaryData } = args;
     const decodedIdentifier = decodeHexString(identifier);
     committedVotes[
       makeUniqueKeyForVote(decodedIdentifier, time, ancillaryData)
-    ] = true;
+    ] = transactionHash;
   });
   return committedVotes;
 }

--- a/web3/queries/votes/getRevealedVotes.ts
+++ b/web3/queries/votes/getRevealedVotes.ts
@@ -18,16 +18,17 @@ export async function getRevealedVotes(
     null
   );
   const result = await votingContract.queryFilter(filter);
-  const eventData = result
-    ?.map(({ args }) => args)
-    .filter((args) => args.roundId.toNumber() === roundId);
+  const eventData = result.filter(
+    ({ args }) => args.roundId.toNumber() === roundId
+  );
   const revealedVotes: VoteExistsByKeyT = {};
 
-  eventData?.forEach(({ identifier, time, ancillaryData }) => {
+  eventData?.forEach(({ args, transactionHash }) => {
+    const { identifier, time, ancillaryData } = args;
     const decodedIdentifier = decodeHexString(identifier);
     revealedVotes[
       makeUniqueKeyForVote(decodedIdentifier, time, ancillaryData)
-    ] = true;
+    ] = transactionHash;
   });
 
   return revealedVotes;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10020,12 +10020,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz"
   integrity sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==
 
-lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lodash@^4.17.21:
+lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This adds transaction hash to the reveal/commit data when we get that data for the user. this is used to create a clickable button to go to etherscan when those exist. 

this is now a link:
![image](https://user-images.githubusercontent.com/4429761/199563194-df354b35-1f45-42b6-8a20-e3630c224420.png)
