### PR TITLE
feat: add votes from prev contract to vote history

### DIFF
--- a/components/Panel/HistoryPanel.tsx
+++ b/components/Panel/HistoryPanel.tsx
@@ -3,7 +3,6 @@ import { black, green, red500 } from "constant";
 import { formatNumberForDisplay } from "helpers";
 import { useUserContext, useVotesContext } from "hooks";
 import styled, { CSSProperties } from "styled-components";
-import { VoteT } from "types";
 import { PanelFooter } from "./PanelFooter";
 import { PanelTitle } from "./PanelTitle";
 import { PanelSectionText, PanelSectionTitle, PanelWrapper } from "./styles";
@@ -83,9 +82,7 @@ export function HistoryPanel() {
             {isLoading() ? (
               <LoadingSpinner size={250} />
             ) : (
-              <VoteHistoryTable
-                votes={getPastVotes().sort(sortVotesByVoteNumber)}
-              />
+              <VoteHistoryTable votes={getPastVotes()} />
             )}
           </HistoryWrapper>
         </SectionWrapper>
@@ -93,10 +90,6 @@ export function HistoryPanel() {
       <PanelFooter />
     </PanelWrapper>
   );
-}
-
-function sortVotesByVoteNumber(a: VoteT, b: VoteT) {
-  return a.voteNumber.toNumber() - b.voteNumber.toNumber();
 }
 
 const AprWrapper = styled.div`

--- a/components/Panel/PanelTitle.tsx
+++ b/components/Panel/PanelTitle.tsx
@@ -48,7 +48,8 @@ function SubTitleText({
   voteNumber?: string;
   origin?: VoteOriginT;
 }) {
-  if (!voteNumber || !origin) return null;
+  // vote number of -1 signifies this is a vote from previous contract which does not have this field
+  if (!voteNumber || !origin || voteNumber === "-1") return null;
 
   return (
     <>

--- a/components/Panel/PanelTitle.tsx
+++ b/components/Panel/PanelTitle.tsx
@@ -48,12 +48,14 @@ function SubTitleText({
   voteNumber?: string;
   origin?: VoteOriginT;
 }) {
-  // vote number of -1 signifies this is a vote from previous contract which does not have this field
-  if (!voteNumber || !origin || voteNumber === "-1") return null;
-
   return (
     <>
-      {origin} | Vote number <Strong>#{voteNumber}</Strong>
+      {origin && origin} {origin && voteNumber && "|"}{" "}
+      {voteNumber && (
+        <>
+          Vote number <Strong>#{voteNumber}</Strong>
+        </>
+      )}
     </>
   );
 }

--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -54,7 +54,7 @@ export function VotePanel({ content }: Props) {
       <PanelTitle
         title={title ?? decodedIdentifier}
         origin={origin}
-        voteNumber={voteNumber.toString()}
+        voteNumber={voteNumber?.toString()}
       />
       {hasResults ? (
         <Tabs tabs={tabs} />

--- a/components/VoteHistoryTable/VoteHistoryTableRow.tsx
+++ b/components/VoteHistoryTable/VoteHistoryTableRow.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "components/Tooltip/Tooltip";
 import { green, grey500, red500 } from "constant";
 import { formatNumberForDisplay } from "helpers";
 import { CSSProperties } from "react";
@@ -18,9 +19,15 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
   return (
     <Tr>
       <VoteNumberTd>
-        <VoteNumberButton onClick={onVoteClicked}>
-          #{formatNumberForDisplay(voteNumber, { isFormatEther: false })}
-        </VoteNumberButton>
+        {voteNumber ? (
+          <VoteNumberButton onClick={onVoteClicked}>
+            #{formatNumberForDisplay(voteNumber, { isFormatEther: false })}
+          </VoteNumberButton>
+        ) : (
+          <Tooltip label="This vote is from version one (previous version) of the voting contract. Sequential vote numbers were introduced in version two (current version).">
+            <VoteNumberV1>V1</VoteNumberV1>
+          </Tooltip>
+        )}
       </VoteNumberTd>
       <StakingTd>
         <Staking>
@@ -47,7 +54,6 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
 function getBarColor(value: boolean) {
   return value ? green : grey500;
 }
-
 const BarInnerWrapper = styled.div`
   padding-block: 4px;
   border-top: 1px solid var(--grey-500);
@@ -103,3 +109,11 @@ const Correctness = styled(BarInnerWrapper)`
 `;
 
 const Tr = styled.tr``;
+
+const VoteNumberV1 = styled.span`
+  font: var(--text-sm);
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
+`;

--- a/components/VotesTable/VotesTableRow.tsx
+++ b/components/VotesTable/VotesTableRow.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from "react";
 import {
   Button,
   Dropdown,
@@ -17,6 +16,7 @@ import Dot from "public/assets/icons/dot.svg";
 import Polymarket from "public/assets/icons/polymarket.svg";
 import Rolled from "public/assets/icons/rolled.svg";
 import UMA from "public/assets/icons/uma.svg";
+import { ReactNode } from "react";
 import styled, { CSSProperties } from "styled-components";
 import { ActivityStatusT, VotePhaseT, VoteT } from "types";
 
@@ -53,6 +53,7 @@ export function VotesTableRow({
     correctVote,
     voteNumber,
     isRolled,
+    isV1,
   } = vote;
   const maxDecimals = getPrecisionForIdentifier(decodedIdentifier);
   const Icon = origin === "UMA" ? UMAIcon : PolymarketIcon;
@@ -186,7 +187,7 @@ export function VotesTableRow({
           <VoteDetailsWrapper>
             <VoteTitle>{formatTitle(title)}</VoteTitle>
             <VoteDetailsInnerWrapper>
-              {isRolled ? (
+              {isRolled && !isV1 ? (
                 <Tooltip label="This vote was included in the previous voting cycle, but did not get enough votes to resolve.">
                   <RolledWrapper>
                     <RolledIconWrapper>
@@ -200,7 +201,8 @@ export function VotesTableRow({
                 </Tooltip>
               ) : null}
               <VoteOrigin>
-                {origin} | Vote #{voteNumber.toString()}
+                {origin}{" "}
+                {!isV1 && voteNumber && `| Vote #${voteNumber.toString()}`}
               </VoteOrigin>
             </VoteDetailsInnerWrapper>
           </VoteDetailsWrapper>

--- a/constant/index.ts
+++ b/constant/index.ts
@@ -1,4 +1,4 @@
-export { graphEndpoint } from "./query/graphEndpoint";
+export { graphEndpoint, graphEndpointV1 } from "./query/graphEndpoint";
 export {
   activeVotesKey,
   balancesQueryKeys,

--- a/constant/query/graphEndpoint.ts
+++ b/constant/query/graphEndpoint.ts
@@ -1,1 +1,2 @@
-export const graphEndpoint = process.env.NEXT_PUBLIC_GRAPH_ENDPOINT ?? "";
+export const graphEndpoint:string = process.env.NEXT_PUBLIC_GRAPH_ENDPOINT ?? "";
+export const graphEndpointV1:string = process.env.NEXT_PUBLIC_GRAPH_ENDPOINT_V1 ?? "";

--- a/graph/index.ts
+++ b/graph/index.ts
@@ -1,2 +1,2 @@
-export { getPastVotes } from "./queries/getPastVotes";
+export { getPastVotes, getPastVotesAllVersions } from "./queries/getPastVotes";
 export { getUserVotingAndStakingDetails as getUserData } from "./queries/getUserVotingAndStakingDetails";

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -52,7 +52,7 @@ export async function getPastVotesV2() {
     {
       priceRequests(
         where: { isResolved: true }
-        orderBy: time
+        orderBy: requestIndex
         orderDirection: desc
       ) {
         id

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -40,8 +40,8 @@ export async function getPastVotesV1() {
       time: Number(time),
       correctVote,
       ancillaryData,
-      // v1 votes do not have a price request index. we will use -1 to signify this and handle the case in view.
-      priceRequestIndex: BigNumber.from(-1),
+      priceRequestIndex: undefined,
+      isV1: true,
     };
   });
 }
@@ -81,6 +81,7 @@ export async function getPastVotesV2() {
         correctVote,
         ancillaryData,
         priceRequestIndex,
+        isV1: false,
       };
     }
   );

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -1,4 +1,4 @@
-import { graphEndpoint } from "constant";
+import { graphEndpoint, graphEndpointV1 } from "constant";
 import { BigNumber } from "ethers";
 import request, { gql } from "graphql-request";
 import {
@@ -9,7 +9,45 @@ import {
 } from "helpers";
 import { PastVotesQuery } from "types";
 
-export async function getPastVotes() {
+export async function getPastVotesV1() {
+  const endpoint = graphEndpointV1;
+  const pastVotesQuery = gql`
+    {
+      priceRequests(
+        where: { isResolved: true }
+        orderBy: time
+        orderDirection: desc
+      ) {
+        id
+        identifier {
+          id
+        }
+        price
+        time
+        ancillaryData
+      }
+    }
+  `;
+  const result = await request<PastVotesQuery>(endpoint, pastVotesQuery);
+  return result?.priceRequests?.map(({ id, time, price, ancillaryData }) => {
+    const identifier = getIdentifierFromPriceRequestId(id);
+    const correctVote = Number(
+      formatVoteStringWithPrecision(parseEther(price), identifier)
+    );
+
+    return {
+      identifier,
+      time: Number(time),
+      correctVote,
+      ancillaryData,
+      // v1 votes do not have a price request index. we will use -1 to signify this and handle the case in view.
+      priceRequestIndex: BigNumber.from(-1),
+    };
+  });
+}
+
+export async function getPastVotesV2() {
+  const endpoint = graphEndpoint;
   const pastVotesQuery = gql`
     {
       priceRequests(
@@ -28,8 +66,8 @@ export async function getPastVotes() {
       }
     }
   `;
-  const result = await request<PastVotesQuery>(graphEndpoint, pastVotesQuery);
-  const parsedData = result?.priceRequests?.map(
+  const result = await request<PastVotesQuery>(endpoint, pastVotesQuery);
+  return result?.priceRequests?.map(
     ({ id, time, price, ancillaryData, requestIndex }) => {
       const identifier = getIdentifierFromPriceRequestId(id);
       const correctVote = Number(
@@ -46,10 +84,16 @@ export async function getPastVotes() {
       };
     }
   );
+}
 
-  const pastVotes = makePriceRequestsByKey(parsedData ?? []);
+export async function getPastVotes() {
+  return makePriceRequestsByKey(await getPastVotesV2());
+}
 
-  return pastVotes;
+export async function getPastVotesAllVersions() {
+  return makePriceRequestsByKey(
+    (await Promise.all([getPastVotesV2(), getPastVotesV1()])).flat()
+  );
 }
 
 function getIdentifierFromPriceRequestId(priceRequestId: string) {

--- a/helpers/voting/getVoteMetaData.ts
+++ b/helpers/voting/getVoteMetaData.ts
@@ -1,7 +1,7 @@
 import { discordLink, earlyRequestMagicNumber } from "constant";
 import approvedIdentifiers from "data/approvedIdentifiersTable";
 import { checkIfIsPolymarket } from "helpers";
-import { ContentfulDataT, VoteMetaDataT } from "types";
+import { ContentfulDataT, TransactionHashT, VoteMetaDataT } from "types";
 
 /** Finds a title and description, and UMIP link (if it exists) for a decodedIdentifier.
  *
@@ -14,7 +14,7 @@ import { ContentfulDataT, VoteMetaDataT } from "types";
 export function getVoteMetaData(
   decodedIdentifier: string,
   decodedAncillaryData: string,
-  transactionHash: string,
+  transactionHash: TransactionHashT,
   umipDataFromContentful: ContentfulDataT | undefined
 ): VoteMetaDataT {
   // rolled votes have no transaction hash — the value for `transactionHash` will be `"rolled"`
@@ -187,10 +187,10 @@ function makeVoteOptions(voteType: "umip" | "yesNoQuery") {
   }
 }
 
-function makeVoteLinks(transactionHash: string, umipNumber?: number) {
+function makeVoteLinks(transactionHash: TransactionHashT, umipNumber?: number) {
   const links = [];
 
-  if (transactionHash !== "rolled") {
+  if (transactionHash !== "rolled" && transactionHash !== "v1") {
     links.push({
       label: "Vote transaction",
       href: `https://goerli.etherscan.io/tx/${transactionHash}`,

--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -48,6 +48,7 @@ function formatPriceRequest(priceRequest: RawPriceRequestDataT) {
     time,
     ancillaryData
   );
+  const isV1 = priceRequest.isV1;
 
   return {
     time,
@@ -60,5 +61,6 @@ function formatPriceRequest(priceRequest: RawPriceRequestDataT) {
     decodedAncillaryData,
     correctVote,
     uniqueKey,
+    isV1,
   } as PriceRequestT;
 }

--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -31,7 +31,17 @@ function formatPriceRequest(priceRequest: RawPriceRequestDataT) {
   const ancillaryData = priceRequest.ancillaryData;
   const voteNumber = priceRequest.priceRequestIndex;
   const decodedIdentifier = decodeHexString(identifier);
-  const decodedAncillaryData = decodeHexString(ancillaryData);
+  let decodedAncillaryData = ancillaryData;
+  try {
+    // this will fail expecially with data from previous contracts. So catch and warn.
+    decodedAncillaryData = decodeHexString(ancillaryData);
+  } catch (err) {
+    console.warn(
+      "unable to format price request, ancillary data decode failed:",
+      err,
+      priceRequest
+    );
+  }
   const correctVote = priceRequest.correctVote;
   const uniqueKey = makeUniqueKeyForVote(
     decodedIdentifier,

--- a/hooks/queries/votes/usePastVotes.ts
+++ b/hooks/queries/votes/usePastVotes.ts
@@ -1,17 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
 import { pastVotesKey } from "constant";
-import { getPastVotes } from "graph";
+import { getPastVotesAllVersions } from "graph";
 import { useHandleError, useVoteTimingContext } from "hooks";
 
 export function usePastVotes() {
   const { roundId } = useVoteTimingContext();
   const onError = useHandleError();
 
-  const queryResult = useQuery([pastVotesKey, roundId], () => getPastVotes(), {
-    refetchInterval: (data) => (data ? false : 100),
-    initialData: {},
-    onError,
-  });
+  const queryResult = useQuery(
+    [pastVotesKey, roundId],
+    () => getPastVotesAllVersions(),
+    {
+      refetchInterval: (data) => (data ? false : 100),
+      initialData: {},
+      onError,
+    }
+  );
 
   return queryResult;
 }

--- a/stories/mocks/votes.ts
+++ b/stories/mocks/votes.ts
@@ -47,6 +47,7 @@ export const voteWithoutUserVote = {
   isGovernance: false,
   isRevealed: false,
   revealHash: undefined,
+  isV1: false,
   voteHistory: {
     uniqueKey: "0x1234567890",
     voted: false,

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -17,7 +17,7 @@ export type PriceRequestT = {
   time: number;
   identifier: string;
   ancillaryData: string;
-  voteNumber: BigNumber;
+  voteNumber: BigNumber | undefined;
   correctVote?: number;
   // computed values
   timeMilliseconds: number;
@@ -25,14 +25,16 @@ export type PriceRequestT = {
   decodedIdentifier: string;
   decodedAncillaryData: string;
   uniqueKey: UniqueKeyT;
+  isV1: boolean;
 };
 
 export type RawPriceRequestDataT = {
   time: BigNumber | number;
   identifier: string;
   ancillaryData: string;
-  priceRequestIndex: BigNumber;
+  priceRequestIndex: BigNumber | undefined;
   correctVote?: number;
+  isV1: boolean;
 };
 
 export type VoteTransactionDataT = {

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -34,11 +34,13 @@ export type RawPriceRequestDataT = {
   ancillaryData: string;
   priceRequestIndex: BigNumber | undefined;
   correctVote?: number;
-  isV1: boolean;
+  isV1?: boolean;
 };
 
+export type TransactionHashT = string | "rolled" | "v1";
+
 export type VoteTransactionDataT = {
-  transactionHash: string;
+  transactionHash: TransactionHashT;
 };
 
 export type VoteHistoryDataT = {


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This adds votes from a previous contract to our past-votes page. It requires a new env variable to point to the v1 voting contractact : NEXT_PUBLIC_GRAPH_ENDPOINT_V1.

![image](https://user-images.githubusercontent.com/4429761/200334175-ce31a330-5e59-4a28-b084-f22246416bcc.png)
