### PR TITLE
bug: loading skeleton placeholder

### DIFF
--- a/components/LoadingSkeleton/LoadingSkeleton.tsx
+++ b/components/LoadingSkeleton/LoadingSkeleton.tsx
@@ -1,5 +1,4 @@
 import { loadingSkeletonOpacity100, white, whiteOpacity10 } from "constant";
-import { cloneElement } from "react";
 import styled, { CSSProperties, keyframes } from "styled-components";
 
 interface Props {
@@ -27,10 +26,6 @@ export function LoadingSkeleton({
     "--height": getDimension(height),
   } as CSSProperties;
 
-  const placeholder = cloneElement(children, {
-    children: <Placeholder>INVISIBLE</Placeholder>,
-  });
-
   function getDimension(dimension: number | string | undefined) {
     if (dimension === undefined) return;
 
@@ -38,7 +33,9 @@ export function LoadingSkeleton({
   }
 
   return isLoading ? (
-    <Wrapper style={style}>{placeholder}</Wrapper>
+    <Wrapper style={style}>
+      <Placeholder>{children}</Placeholder>
+    </Wrapper>
   ) : (
     <>{children}</>
   );

--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -267,7 +267,7 @@ export function VotesListItem({
         <VoteStatusWrapper as={isTabletAndUnder ? "div" : "td"}>
           <VoteLabel>Vote status</VoteLabel>
           <VoteStatus>
-            <LoadingSkeleton isLoading={isFetching} width={100}>
+            <LoadingSkeleton isLoading={isFetching} width={100} height={24}>
               <>
                 <DotIcon
                   style={


### PR DESCRIPTION
### Summary

I had some unnecessary logic in the loading skeleton that caused a bug where the previous content of the loading skeleton would show through underneath the loader. 

* Simplify the loading skeleton placeholder logic which also fixes the bug