### PR TITLE
bug: maximum approve shows huge number that overflows input

### DIFF
--- a/components/Input/AmountInput.tsx
+++ b/components/Input/AmountInput.tsx
@@ -1,7 +1,7 @@
 import { Button } from "components";
 import UmaToken from "public/assets/icons/uma-token.svg";
 import styled from "styled-components";
-import { useOnChange } from "hooks";
+import { useHandleDecimalInput } from "hooks";
 import { Input, Wrapper } from "./Input";
 
 interface Props {
@@ -22,7 +22,7 @@ export function AmountInput({
   allowNegative = true,
   maxDecimals = 18,
 }: Props) {
-  const onChange = useOnChange(onInput, maxDecimals, allowNegative);
+  const onChange = useHandleDecimalInput(onInput, maxDecimals, allowNegative);
 
   return (
     <_Wrapper aria-disabled={disabled}>

--- a/components/Input/TextInput.tsx
+++ b/components/Input/TextInput.tsx
@@ -1,5 +1,5 @@
+import { useHandleDecimalInput } from "hooks";
 import styled from "styled-components";
-import { useOnChange } from "hooks";
 import { Input, Wrapper } from "./Input";
 
 interface Props {
@@ -25,7 +25,12 @@ export function TextInput({
     type === "text" ? "text" : type === "number" ? "decimal" : "email";
   // treat numbers as text inputs
   const _type = type === "number" ? "text" : type;
-  const onChange = useOnChange(onInput, maxDecimals, allowNegative, _type);
+  const onChange = useHandleDecimalInput(
+    onInput,
+    maxDecimals,
+    allowNegative,
+    _type
+  );
 
   return (
     <_Wrapper aria-disabled={disabled}>

--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -1,7 +1,8 @@
 import { AmountInput, Button, Checkbox, PanelErrorBanner } from "components";
 import { mobileAndUnder } from "constant";
+import { maximumApprovalAmountString } from "constant";
 import formatDuration from "date-fns/formatDuration";
-import { BigNumber, constants } from "ethers";
+import { BigNumber } from "ethers";
 import { formatEther, parseEtherSafe } from "helpers";
 import { useState } from "react";
 import styled from "styled-components";
@@ -10,8 +11,6 @@ import {
   PanelSectionTitle,
   PanelWarningText,
 } from "../styles";
-
-const MaxApproval = formatEther(constants.MaxUint256);
 
 interface Props {
   tokenAllowance: BigNumber | undefined;
@@ -38,13 +37,15 @@ export function Stake({
   const disclaimer = `I understand that Staked tokens cannot be transferred for ${unstakeCoolDownFormatted} after unstaking.`;
 
   function isApprove() {
-    if (tokenAllowance === undefined || inputAmount === "") return true;
+    if (tokenAllowance === undefined || tokenAllowance.eq(0)) return true;
     const parsedStakeAmount = parseEtherSafe(inputAmount);
-    if (parsedStakeAmount.eq(0)) return true;
     return parsedStakeAmount.gt(tokenAllowance);
   }
 
   function isButtonDisabled() {
+    if (inputAmount === maximumApprovalAmountString && disclaimerChecked)
+      return false;
+
     return (
       !disclaimerChecked ||
       inputAmount === "" ||
@@ -54,6 +55,7 @@ export function Stake({
 
   function onApprove() {
     approve(inputAmount);
+    setInputAmount("");
   }
 
   function onStake() {
@@ -62,7 +64,7 @@ export function Stake({
 
   function onMax() {
     if (isApprove()) {
-      setInputAmount(MaxApproval);
+      setInputAmount(maximumApprovalAmountString);
     } else {
       setInputAmount(formatEther(unstakedBalance ?? 0));
     }

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -1,5 +1,7 @@
 import { LoadingSkeleton, Tabs } from "components";
+import { maximumApprovalAmountString } from "constant";
 import { formatNumberForDisplay, parseEtherSafe } from "helpers";
+import { maximumApprovalAmount } from "helpers/web3/ethers";
 import {
   useApprove,
   useContractsContext,
@@ -53,7 +55,10 @@ export function StakeUnstakePanel() {
   }
 
   function approve(approveAmountInput: string) {
-    const approveAmount = parseEtherSafe(approveAmountInput);
+    const approveAmount =
+      approveAmountInput === maximumApprovalAmountString
+        ? maximumApprovalAmount
+        : parseEtherSafe(approveAmountInput);
     approveMutation({ votingToken, approveAmount });
   }
 

--- a/constant/index.ts
+++ b/constant/index.ts
@@ -1,4 +1,5 @@
 export * from "./misc/errorMessages";
+export * from "./misc/maximumApprovalAmountString";
 export * from "./misc/siteMetaData";
 export * from "./query/graphEndpoint";
 export * from "./query/queryKeys";

--- a/constant/misc/maximumApprovalAmountString.ts
+++ b/constant/misc/maximumApprovalAmountString.ts
@@ -1,0 +1,1 @@
+export const maximumApprovalAmountString = "Unlimited approval";

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -43,20 +43,7 @@ export {
   recoverPublicKey,
 } from "./web3/crypto";
 export { decodeHexString } from "./web3/decodeHexString";
-export {
-  commify,
-  formatBytes32String,
-  formatEther,
-  formatTransactionError,
-  getAddress,
-  isAddress,
-  parseEther,
-  parseEtherSafe,
-  randomBytes,
-  solidityKeccak256,
-  toUtf8String,
-  zeroAddress,
-} from "./web3/ethers";
+export * from "./web3/ethers";
 export {
   emitErrorEvent,
   emitPendingEvent,

--- a/helpers/web3/ethers.ts
+++ b/helpers/web3/ethers.ts
@@ -35,3 +35,5 @@ export const zeroAddress = ethers.constants.AddressZero;
 export const getAddress = ethers.utils.getAddress;
 
 export const isAddress = ethers.utils.isAddress;
+
+export const maximumApprovalAmount = ethers.constants.MaxUint256;

--- a/hooks/helpers/useHandleDecimalInput.ts
+++ b/hooks/helpers/useHandleDecimalInput.ts
@@ -1,7 +1,8 @@
+import { maximumApprovalAmountString } from "constant/misc/maximumApprovalAmountString";
 import { useErrorContext } from "hooks";
 import { ChangeEvent } from "react";
 
-export function useOnChange(
+export function useHandleDecimalInput(
   onInput: (value: string) => void,
   maxDecimals: number,
   allowNegative: boolean,
@@ -10,11 +11,15 @@ export function useOnChange(
   const { addErrorMessage, removeErrorMessage } = useErrorContext();
 
   return (event: ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
+    let value = event.target.value;
 
     if (type !== "number") {
       onInput(value);
       return;
+    }
+
+    if (value.includes(maximumApprovalAmountString)) {
+      value = value.replace(maximumApprovalAmountString, "");
     }
 
     const decimalsErrorMessage = `Cannot have more than ${maxDecimals} decimals.`;

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -14,7 +14,7 @@ export { useInitializeVoteTiming } from "./helpers/useInitializeVoteTiming";
 export { useInterval } from "./helpers/useInterval";
 export { useIsomorphicLayoutEffect } from "./helpers/useIsomorphicLayoutEffect";
 export { useMounted } from "./helpers/useMounted";
-export { useOnChange } from "./helpers/useOnChange";
+export { useHandleDecimalInput } from "./helpers/useHandleDecimalInput";
 export { usePanelWidth } from "./helpers/usePanelWidth";
 export { useWindowSize } from "./helpers/useWindowSize";
 export { useAcceptReceivedRequestToBeDelegate } from "./mutations/delegation/useAcceptReceivedRequestToBeDelegate";

--- a/web3/mutations/staking/approve.ts
+++ b/web3/mutations/staking/approve.ts
@@ -1,7 +1,11 @@
 import { VotingTokenEthers } from "@uma/contracts-frontend";
 import { votingContractAddress } from "constant";
 import { BigNumber } from "ethers";
-import { formatNumberForDisplay, handleNotifications } from "helpers";
+import {
+  formatNumberForDisplay,
+  handleNotifications,
+  maximumApprovalAmount,
+} from "helpers";
 
 export async function approve({
   votingToken,
@@ -14,9 +18,14 @@ export async function approve({
     votingContractAddress,
     approveAmount
   );
+
+  const amountToDisplay = approveAmount.eq(maximumApprovalAmount)
+    ? "unlimited"
+    : formatNumberForDisplay(approveAmount);
+
   return handleNotifications(tx, {
-    pending: `Approving ${formatNumberForDisplay(approveAmount)} UMA...`,
-    success: `Approved ${formatNumberForDisplay(approveAmount)} UMA`,
-    error: `Failed to approve ${formatNumberForDisplay(approveAmount)} UMA`,
+    pending: `Approving ${amountToDisplay} UMA...`,
+    success: `Approved ${amountToDisplay} UMA`,
+    error: `Failed to approve ${amountToDisplay} UMA`,
   });
 }


### PR DESCRIPTION
### Summary

When clicking "max" in the approve input, we use the largest allowed uint256 as the value (essentially the same as approving an unlimited amount). However, this shows a very large number in the input which is ugly and confusing to the user.

* Add a string value for "unlimited approval" and show that in the input instead
* Handle this string as a possible input for the approve mutation