### PR TITLE
bug: check if vote exists before setting is custom

### DIFF
--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -65,7 +65,8 @@ export function VotesListItem({
 
     // if options exist but the existing decrypted vote is not one from the list,
     // then we must be using a custom input
-    if (!findVoteInOptions(getDecryptedVoteAsFormattedString())) {
+    const decryptedVote = getDecryptedVoteAsFormattedString();
+    if (decryptedVote && !findVoteInOptions(decryptedVote)) {
       setIsCustomInput(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### Summary

The logic for detecting custom votes will always return true when the decrypted vote does not exist.

* Check that the decrypted vote exists when detecting a custom vote