### PR TITLE
feat: update request augmentation and add cache warming endpoint

### DIFF
--- a/pages/api/augment-request.ts
+++ b/pages/api/augment-request.ts
@@ -30,6 +30,7 @@ function constructOoUiLink(
   chainId: number,
   oracleType: string
 ) {
+  if (!txHash || !chainId || !oracleType) return null;
   return `https://oracle.umaproject.org/request?transactionHash=${txHash}&chainId=${chainId}&oracleType=${oracleType}`;
 }
 
@@ -161,6 +162,8 @@ async function getAugmentingRequestInformation(l1Requests: Request[]) {
         requestTransactions[index].chainId,
         requestTransactions[index].oracleType
       ),
+      originatingChainId: requestTransactions[index].chainId || null,
+      originatingOracleType: requestTransactions[index].oracleType || null,
     };
   });
 }

--- a/pages/api/warm-cache.ts
+++ b/pages/api/warm-cache.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { constructContractOnChain } from "./_common";
+
+async function warmAugmentedDataCache() {
+  const votingV1 = await constructContractOnChain(1, "Voting");
+  // todo: add voting v2 when released.
+  // const votingV2 = await constructContractOnChain(1, "VotingV2");
+  const l1RequestEvents = (
+    await Promise.all([
+      votingV1.queryFilter(votingV1.filters.PriceRequestAdded()),
+      // votingV2.queryFilter(votingV2.filters.PriceRequestAdded())
+    ])
+  ).flat();
+
+  const warmingPayload = l1RequestEvents.map((l1RequestEvent) => {
+    return {
+      identifier: l1RequestEvent?.args?.identifier,
+      time: Number(l1RequestEvent?.args?.time),
+    };
+  });
+
+  const rawResponse = await fetch(
+    `${process.env.DEPLOYMENT_URL}/api/augment-request`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ l1Requests: warmingPayload }),
+    }
+  );
+
+  await rawResponse.json();
+}
+
+async function warmCache() {
+  await warmAugmentedDataCache();
+}
+
+export default async function handler(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000"); // Cache for 30 days and re-build cache if re-deployed.
+
+  try {
+    await warmCache();
+
+    response.status(200).send("done");
+  } catch (e) {
+    console.error(e);
+    response.status(500).send({
+      message: "Error in decoding admin call",
+      error: e instanceof Error ? e.message : e,
+    });
+  }
+}


### PR DESCRIPTION
This PR adds a serverless function endpoint used to warm the other heavy endpoints to speed up the cache of heavy operations. Vercel will cache the responces for a given request for 30 days. therefor we simply need to run this endpoint once after deployment and the cache will be built and be fast!
