### PR TITLE
improve: use link instead of button for vote status

### DIFF
--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -181,19 +181,17 @@ export function VotesListItem({
   function getRelevantTransactionLink(): ReactNode | string {
     if (phase === "commit") {
       return commitHash ? (
-        <Button
-          href={`https://goerli.etherscan.io/tx/${commitHash}`}
-          label={getCommittedOrRevealed()}
-        />
+        <Link href={`https://goerli.etherscan.io/tx/${commitHash}`}>
+          {getCommittedOrRevealed()}
+        </Link>
       ) : (
         getCommittedOrRevealed()
       );
     }
     return revealHash ? (
-      <Button
-        href={`https://goerli.etherscan.io/tx/${revealHash}`}
-        label={getCommittedOrRevealed()}
-      />
+      <Link href={`https://goerli.etherscan.io/tx/${revealHash}`}>
+        {getCommittedOrRevealed()}
+      </Link>
     ) : (
       getCommittedOrRevealed()
     );
@@ -492,4 +490,13 @@ const RolledLink = styled(NextLink)`
   font: var(--text-sm);
   color: var(--red-500);
   text-decoration: underline;
+`;
+
+const Link = styled(NextLink)`
+  font: var(--text-md);
+  color: var(--black);
+  text-decoration: underline;
+  &:hover {
+    color: var(--black-opacity-50);
+  }
 `;


### PR DESCRIPTION
### Summary

Using a button for the vote status link makes the link red which gives the impression that something is wrong. Rather use a link that's styled to look like a link, its also clearer that its a link to the user.