### PR TITLE
improve: add date and time to votes

### DIFF
--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -6,6 +6,7 @@ import {
   Tooltip,
 } from "components";
 import { green, grey100, red500, tabletAndUnder, tabletMax } from "constant";
+import { format } from "date-fns";
 import {
   formatVoteStringWithPrecision,
   getPrecisionForIdentifier,
@@ -55,6 +56,7 @@ export function VotesListItem({
     voteNumber,
     isRolled,
     isV1,
+    timeAsDate,
   } = vote;
   const maxDecimals = getPrecisionForIdentifier(decodedIdentifier);
   const Icon = origin === "UMA" ? UMAIcon : PolymarketIcon;
@@ -238,7 +240,8 @@ export function VotesListItem({
               ) : null}
               <VoteOrigin>
                 {origin}{" "}
-                {!isV1 && voteNumber && `| Vote #${voteNumber.toString()}`}
+                {!isV1 && voteNumber && `| Vote #${voteNumber.toString()}`} |{" "}
+                {format(timeAsDate, "Pp")}
               </VoteOrigin>
             </VoteDetailsInnerWrapper>
           </VoteDetailsWrapper>


### PR DESCRIPTION
### Summary

Include a formatted date and time in each of the votes in the votes list.

<img width="465" alt="Screenshot 2022-11-17 at 14 51 08" src="https://user-images.githubusercontent.com/39741965/202451237-e7e336ec-0fef-4782-8ccf-5f690432dfaf.png">