### PR TITLE
bug: should show across v2 as identifier

### DIFF
--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -18,7 +18,6 @@ export async function getPastVotesV1() {
         orderBy: time
         orderDirection: desc
       ) {
-        id
         identifier {
           id
         }
@@ -29,21 +28,23 @@ export async function getPastVotesV1() {
     }
   `;
   const result = await request<PastVotesQuery>(endpoint, pastVotesQuery);
-  return result?.priceRequests?.map(({ id, time, price, ancillaryData }) => {
-    const identifier = getIdentifierFromPriceRequestId(id);
-    const correctVote = Number(
-      formatVoteStringWithPrecision(parseEtherSafe(price), identifier)
-    );
+  return result?.priceRequests?.map(
+    ({ identifier: { id }, time, price, ancillaryData }) => {
+      const identifier = formatBytes32String(id);
+      const correctVote = Number(
+        formatVoteStringWithPrecision(parseEtherSafe(price), identifier)
+      );
 
-    return {
-      identifier,
-      time: Number(time),
-      correctVote,
-      ancillaryData,
-      priceRequestIndex: undefined,
-      isV1: true,
-    };
-  });
+      return {
+        identifier,
+        time: Number(time),
+        correctVote,
+        ancillaryData,
+        priceRequestIndex: undefined,
+        isV1: true,
+      };
+    }
+  );
 }
 
 export async function getPastVotesV2() {
@@ -55,7 +56,6 @@ export async function getPastVotesV2() {
         orderBy: requestIndex
         orderDirection: desc
       ) {
-        id
         identifier {
           id
         }
@@ -82,7 +82,7 @@ export async function getPastVotesV2() {
   const result = await request<PastVotesQuery>(endpoint, pastVotesQuery);
   return result?.priceRequests?.map(
     ({
-      id,
+      identifier: { id },
       time,
       price,
       ancillaryData,
@@ -91,7 +91,7 @@ export async function getPastVotesV2() {
       committedVotes,
       revealedVotes,
     }) => {
-      const identifier = getIdentifierFromPriceRequestId(id);
+      const identifier = formatBytes32String(id);
       const correctVote = Number(
         formatVoteStringWithPrecision(parseEtherSafe(price), identifier)
       );
@@ -130,8 +130,4 @@ export async function getPastVotesAllVersions() {
   return makePriceRequestsByKey(
     (await Promise.all([getPastVotesV2(), getPastVotesV1()])).flat()
   );
-}
-
-function getIdentifierFromPriceRequestId(priceRequestId: string) {
-  return formatBytes32String(priceRequestId.split("-")[0]);
 }

--- a/types/queries.ts
+++ b/types/queries.ts
@@ -1,6 +1,5 @@
 export type PastVotesQuery = {
   priceRequests: {
-    id: string;
     identifier: {
       id: string;
     };


### PR DESCRIPTION
### Summary

For reasons I cannot remember, I decided to use the internal graphql id for votes to get the identifiers of past votes. This makes no sense because we literally already get the actual value from the graph, and also because it introduced a bug where we split the internal identifier string which doesn't work consistently.

* Remove the query for the internal ID
* Use the identifier returned from the graph as-is