### PR TITLE
improve: increase default pagination results per page

### DIFF
--- a/components/Panel/HistoryPanel.tsx
+++ b/components/Panel/HistoryPanel.tsx
@@ -4,7 +4,13 @@ import {
   Pagination,
   VoteHistoryTable,
 } from "components";
-import { black, green, mobileAndUnder, red500 } from "constant";
+import {
+  black,
+  defaultResultsPerPage,
+  green,
+  mobileAndUnder,
+  red500,
+} from "constant";
 import { formatNumberForDisplay, getEntriesForPage } from "helpers";
 import { usePaginationContext, useUserContext, useVotesContext } from "hooks";
 import styled, { CSSProperties } from "styled-components";
@@ -96,7 +102,7 @@ export function HistoryPanel() {
               <VoteHistoryTable votes={votesToShow} />
             )}
           </HistoryWrapper>
-          {numberOfPastVotes > 20 && (
+          {numberOfPastVotes > defaultResultsPerPage && (
             <PaginationWrapper>
               <Pagination
                 paginateFor="voteHistoryPage"

--- a/components/Panel/HistoryPanel.tsx
+++ b/components/Panel/HistoryPanel.tsx
@@ -97,7 +97,7 @@ export function HistoryPanel() {
           <PanelSectionTitle>Voting history</PanelSectionTitle>
           <HistoryWrapper>
             {isLoading() ? (
-              <LoadingSpinner size={250} />
+              <LoadingSpinner size={40} />
             ) : (
               <VoteHistoryTable votes={votesToShow} />
             )}

--- a/components/Panel/HistoryPanel.tsx
+++ b/components/Panel/HistoryPanel.tsx
@@ -96,7 +96,7 @@ export function HistoryPanel() {
               <VoteHistoryTable votes={votesToShow} />
             )}
           </HistoryWrapper>
-          {numberOfPastVotes > 10 && (
+          {numberOfPastVotes > 20 && (
             <PaginationWrapper>
               <Pagination
                 paginateFor="voteHistoryPage"

--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -289,5 +289,5 @@ const CommitVotesButtonWrapper = styled.div`
 `;
 
 const PaginationWrapper = styled.div`
-  margin-top: 10px;
+  margin-top: 30px;
 `;

--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -255,7 +255,7 @@ export function Votes() {
           )}
         </CommitVotesButtonWrapper>
       ) : null}
-      {determineVotesToShow().length > 10 && (
+      {determineVotesToShow().length > 20 && (
         <PaginationWrapper>
           <Pagination
             paginateFor="activeVotesPage"

--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -7,6 +7,7 @@ import {
   VotesTableHeadings,
   VoteTimeline,
 } from "components";
+import { defaultResultsPerPage } from "constant";
 import { formatVotesToCommit, getEntriesForPage } from "helpers";
 import {
   useAccountDetails,
@@ -255,7 +256,7 @@ export function Votes() {
           )}
         </CommitVotesButtonWrapper>
       ) : null}
-      {determineVotesToShow().length > 20 && (
+      {determineVotesToShow().length > defaultResultsPerPage && (
         <PaginationWrapper>
           <Pagination
             paginateFor="activeVotesPage"

--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -289,5 +289,5 @@ const CommitVotesButtonWrapper = styled.div`
 `;
 
 const PaginationWrapper = styled.div`
-  margin-top: 30px;
+  margin-block: 30px;
 `;

--- a/components/pages/PastVotes.tsx
+++ b/components/pages/PastVotes.tsx
@@ -65,7 +65,7 @@ export function PastVotes() {
                   ))}
                 />
               </VotesTableWrapper>
-              {numberOfPastVotes > 10 && (
+              {numberOfPastVotes > 20 && (
                 <PaginationWrapper>
                   <Pagination
                     paginateFor="pastVotesPage"

--- a/components/pages/PastVotes.tsx
+++ b/components/pages/PastVotes.tsx
@@ -9,6 +9,7 @@ import {
   VotesListItem,
   VotesTableHeadings,
 } from "components";
+import { defaultResultsPerPage } from "constant";
 import { getEntriesForPage } from "helpers";
 import {
   usePaginationContext,
@@ -65,7 +66,7 @@ export function PastVotes() {
                   ))}
                 />
               </VotesTableWrapper>
-              {numberOfPastVotes > 20 && (
+              {numberOfPastVotes > defaultResultsPerPage && (
                 <PaginationWrapper>
                   <Pagination
                     paginateFor="pastVotesPage"

--- a/components/pages/PastVotes.tsx
+++ b/components/pages/PastVotes.tsx
@@ -87,5 +87,5 @@ const VotesTableWrapper = styled.div`
 `;
 
 const PaginationWrapper = styled.div`
-  margin-top: 10px;
+  margin-block: 30px;
 `;

--- a/components/pages/UpcomingVotes.tsx
+++ b/components/pages/UpcomingVotes.tsx
@@ -114,7 +114,7 @@ const VotesTableWrapper = styled.div`
 `;
 
 const PaginationWrapper = styled.div`
-  margin-top: 10px;
+  margin-block: 30px;
 `;
 
 const NoVotesWrapper = styled.div`

--- a/components/pages/UpcomingVotes.tsx
+++ b/components/pages/UpcomingVotes.tsx
@@ -51,7 +51,7 @@ export function UpcomingVotes() {
         <PageInnerWrapper>
           {getUserIndependentIsLoading() ? (
             <LoadingSpinnerWrapper>
-              <LoadingSpinner size={300} variant="black" />
+              <LoadingSpinner size={30} variant="black" />
             </LoadingSpinnerWrapper>
           ) : (
             <>
@@ -80,7 +80,7 @@ export function UpcomingVotes() {
                       ))}
                     />
                   </VotesTableWrapper>
-                  {numberOfUpcomingVotes > 10 && (
+                  {numberOfUpcomingVotes > 20 && (
                     <PaginationWrapper>
                       <Pagination
                         paginateFor="upcomingVotesPage"

--- a/components/pages/UpcomingVotes.tsx
+++ b/components/pages/UpcomingVotes.tsx
@@ -10,6 +10,7 @@ import {
   VotesListItem,
   VotesTableHeadings,
 } from "components";
+import { defaultResultsPerPage } from "constant";
 import { getEntriesForPage } from "helpers";
 import {
   usePaginationContext,
@@ -51,7 +52,7 @@ export function UpcomingVotes() {
         <PageInnerWrapper>
           {getUserIndependentIsLoading() ? (
             <LoadingSpinnerWrapper>
-              <LoadingSpinner size={30} variant="black" />
+              <LoadingSpinner size={40} variant="black" />
             </LoadingSpinnerWrapper>
           ) : (
             <>
@@ -80,7 +81,7 @@ export function UpcomingVotes() {
                       ))}
                     />
                   </VotesTableWrapper>
-                  {numberOfUpcomingVotes > 20 && (
+                  {numberOfUpcomingVotes > defaultResultsPerPage && (
                     <PaginationWrapper>
                       <Pagination
                         paginateFor="upcomingVotesPage"

--- a/constant/index.ts
+++ b/constant/index.ts
@@ -1,3 +1,4 @@
+export * from "./misc/defaultResultsPerPage";
 export * from "./misc/errorMessages";
 export * from "./misc/maximumApprovalAmountString";
 export * from "./misc/siteMetaData";

--- a/constant/misc/defaultResultsPerPage.ts
+++ b/constant/misc/defaultResultsPerPage.ts
@@ -1,0 +1,1 @@
+export const defaultResultsPerPage = 20;

--- a/contexts/PaginationContext.tsx
+++ b/contexts/PaginationContext.tsx
@@ -1,3 +1,4 @@
+import { defaultResultsPerPage } from "constant";
 import { createContext, ReactNode, useState } from "react";
 import { PageStatesT, PaginateForT } from "types";
 
@@ -16,7 +17,7 @@ export interface PaginationContextState {
 
 export const defaultPageState = {
   pageNumber: 1,
-  resultsPerPage: 20,
+  resultsPerPage: defaultResultsPerPage,
 };
 
 export const defaultPageStates = {

--- a/contexts/PaginationContext.tsx
+++ b/contexts/PaginationContext.tsx
@@ -16,7 +16,7 @@ export interface PaginationContextState {
 
 export const defaultPageState = {
   pageNumber: 1,
-  resultsPerPage: 10,
+  resultsPerPage: 20,
 };
 
 export const defaultPageStates = {


### PR DESCRIPTION
### Summary

Increase the default number of results per page in paginated data from 10 to 20.