### PR TITLE
improve: left align text in error banner

### DIFF
--- a/components/Banner/Banner.tsx
+++ b/components/Banner/Banner.tsx
@@ -24,7 +24,7 @@ const InnerWrapper = styled.div`
   height: var(--banner-height);
   display: flex;
   align-items: center;
-  padding-left: clamp(10px, 45px, 4vw);
+  padding-left: var(--page-padding);
   @media ${tabletAndUnder} {
     padding: 0;
   }

--- a/components/ErrorBanner/ErrorBanner.tsx
+++ b/components/ErrorBanner/ErrorBanner.tsx
@@ -48,6 +48,7 @@ const ErrorMessageWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 5px;
+  padding-block: 5px;
   &:not(:last-child) {
     margin-bottom: 5px;
   }
@@ -72,7 +73,7 @@ const CloseIcon = styled(Close)`
 `;
 const CloseButton = styled.button`
   position: absolute;
-  top: 4px;
+  top: 8px;
   right: 0;
   background: transparent;
   fill: var(--white);

--- a/components/ErrorBanner/ErrorBanner.tsx
+++ b/components/ErrorBanner/ErrorBanner.tsx
@@ -39,9 +39,12 @@ const Wrapper = styled.div`
   align-items: center;
   justify-content: center;
   padding-block: 15px;
+  padding-inline: var(--page-padding);
 `;
 
 const ErrorMessageWrapper = styled.div`
+  width: 100%;
+  position: relative;
   display: flex;
   align-items: center;
   gap: 5px;
@@ -51,7 +54,6 @@ const ErrorMessageWrapper = styled.div`
 `;
 
 const ErrorMessage = styled.p`
-  max-width: min(75vw, 500px);
   font: var(--text-md);
 
   @media ${mobileAndUnder} {
@@ -69,6 +71,9 @@ const CloseIcon = styled(Close)`
   }
 `;
 const CloseButton = styled.button`
+  position: absolute;
+  top: 4px;
+  right: 0;
   background: transparent;
   fill: var(--white);
 `;

--- a/components/GlobalStyle/GlobalStyle.ts
+++ b/components/GlobalStyle/GlobalStyle.ts
@@ -255,6 +255,7 @@ a:not([class]) {
     --mobile-banner-height: ${mobileBannerHeight}px;
     --desktop-banner-height: ${desktopBannerHeight}px;
     --page-width: var(--desktop-page-width);
+    --page-padding: clamp(10px, 45px, 4vw);
     --header-height: var(--desktop-header-height);
     --banner-height: var(--desktop-banner-height);
     @media ${tabletAndUnder} {

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -110,7 +110,7 @@ const OuterWrapper = styled.header``;
 const InnerWrapper = styled.div`
   max-width: var(--page-width);
   height: var(--header-height);
-  padding-inline: clamp(10px, 45px, 4vw);
+  padding-inline: var(--page-padding);
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -147,7 +147,7 @@ const OuterWrapper = styled.section`
 `;
 
 const InnerWrapper = styled.div`
-  padding-inline: clamp(10px, 45px, 4vw);
+  padding-inline: var(--page-padding);
   padding-block: 30px;
   max-width: var(--page-width);
   margin-inline: auto;

--- a/components/pages/styles.tsx
+++ b/components/pages/styles.tsx
@@ -8,7 +8,7 @@ export const PageOuterWrapper = styled.div`
 
 export const PageInnerWrapper = styled.div`
   max-width: var(--page-width);
-  padding-inline: clamp(10px, 45px, 4vw);
+  padding-inline: var(--page-padding);
   padding-block: 45px;
   margin-inline: auto;
 


### PR DESCRIPTION
### Summary

Slight alignment change in the error banner as requested by Jesper.

<img width="1045" alt="Screenshot 2022-11-21 at 15 14 38" src="https://user-images.githubusercontent.com/39741965/203064432-08858f74-b92d-4eb4-9974-4d89222da34d.png">
