### PR TITLE
bug: add whitespace nowrap to rewards

### DIFF
--- a/components/Panel/ClaimPanel.tsx
+++ b/components/Panel/ClaimPanel.tsx
@@ -138,6 +138,7 @@ const Rewards = styled.p`
   width: 50%;
   font: var(--header-lg);
   text-align: center;
+  white-space: nowrap;
 `;
 
 const TokenSymbol = styled.span`


### PR DESCRIPTION
The rewards ticker in the claim panel was shifting around weirdly as the number ticks up. I added css to prevent the line from wrapping over when the number gets bigger which fixes the issue.