### PR TITLE
improve: add min heights to panel titles

### DIFF
--- a/components/Panel/ClaimPanel.tsx
+++ b/components/Panel/ClaimPanel.tsx
@@ -121,7 +121,7 @@ const InnerWrapper = styled.div`
 `;
 
 const RewardsWrapper = styled.div`
-  height: 120px;
+  min-height: var(--banner-height);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/components/Panel/MenuPanel/MenuPanel.tsx
+++ b/components/Panel/MenuPanel/MenuPanel.tsx
@@ -210,7 +210,7 @@ const Wrapper = styled.div`
 `;
 
 const AccountWrapper = styled(Wrapper)`
-  min-height: 160px;
+  min-height: calc(var(--banner-height) + var(--header-height));
 `;
 
 const SecondaryWrapper = styled(Wrapper)`

--- a/components/Panel/PanelTitle.tsx
+++ b/components/Panel/PanelTitle.tsx
@@ -69,6 +69,7 @@ function SubTitleText({
 }
 
 const Wrapper = styled.div`
+  min-height: var(--header-height);
   background: var(--black);
   color: var(--white);
   display: flex;

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -162,6 +162,7 @@ export function StakeUnstakePanel() {
 
 const SectionsWrapper = styled.div``;
 const BalancesWrapper = styled.div`
+  min-height: var(--banner-height);
   background: var(--red-500);
   color: var(--white);
   padding-top: 25px;


### PR DESCRIPTION
It's really satisfying when things line up perfectly.

<img width="342" alt="Screenshot 2022-11-22 at 09 08 46" src="https://user-images.githubusercontent.com/39741965/203248126-25082467-7abc-4be0-96a2-1d4a8479bf26.png">
