### PR TITLE
improve: get vote result labels from options if possible

### DIFF
--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -32,7 +32,14 @@ export function VotePanel({ content }: Props) {
   const tabs = [
     {
       title: "Result",
-      content: <Result participation={participation} results={results} />,
+      content: (
+        <Result
+          decodedIdentifier={decodedIdentifier}
+          participation={participation}
+          results={results}
+          options={options}
+        />
+      ),
     },
     {
       title: "Details",


### PR DESCRIPTION
Use the same logic that we use to show the names of vote options (like "yes", "no", etc.) in the results graph.