### PR TITLE
fix: unstaking max button sets an amount higher than staked balance

### DIFF
--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -15,7 +15,7 @@ import {
 interface Props {
   tokenAllowance: BigNumber | undefined;
   unstakedBalance: BigNumber | undefined;
-  unstakeCoolDown: number | undefined;
+  unstakeCoolDown: BigNumber | undefined;
   isDelegate: boolean;
   approve: (approveAmount: string) => void;
   stake: (stakeAmount: string, resetStakeAmount: () => void) => void;
@@ -31,7 +31,7 @@ export function Stake({
   const [inputAmount, setInputAmount] = useState("");
   const [disclaimerChecked, setDisclaimerChecked] = useState(false);
   const unstakeCoolDownFormatted = unstakeCoolDown
-    ? formatDuration({ seconds: unstakeCoolDown })
+    ? formatDuration({ seconds: unstakeCoolDown.toNumber() })
     : "0 seconds";
 
   const disclaimer = `I understand that Staked tokens cannot be transferred for ${unstakeCoolDownFormatted} after unstaking.`;

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -1,5 +1,4 @@
-import { Tabs } from "components";
-import { LoadingSkeleton } from "components";
+import { LoadingSkeleton, Tabs } from "components";
 import { maximumApprovalAmountString } from "constant";
 import { formatNumberForDisplay, parseEtherSafe } from "helpers";
 import { maximumApprovalAmount } from "helpers/web3/ethers";
@@ -64,7 +63,13 @@ export function StakeUnstakePanel() {
   }
 
   function stake(stakeAmountInput: string, resetStakeAmount: () => void) {
-    const stakeAmount = parseEtherSafe(stakeAmountInput);
+    if (!unstakedBalance) return;
+    const parsedStakeAmountInput = parseEtherSafe(stakeAmountInput);
+    // with lots of decimal places the casting from string input to BigNumber can cause the amount to be slightly off when using the unstaked balance as the max
+    // make sure the parsed stake amount is not greater than the unstaked balance or the contract will revert
+    const stakeAmount = parsedStakeAmountInput.gt(unstakedBalance)
+      ? unstakedBalance
+      : parsedStakeAmountInput;
     stakeMutation(
       { voting, stakeAmount },
       {

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -1,5 +1,6 @@
 import { LoadingSkeleton, Tabs } from "components";
 import { maximumApprovalAmountString } from "constant";
+import { parseEther } from "helpers";
 import { formatNumberForDisplay, parseEtherSafe } from "helpers";
 import { maximumApprovalAmount } from "helpers/web3/ethers";
 import {
@@ -63,13 +64,7 @@ export function StakeUnstakePanel() {
   }
 
   function stake(stakeAmountInput: string, resetStakeAmount: () => void) {
-    if (!unstakedBalance) return;
-    const parsedStakeAmountInput = parseEtherSafe(stakeAmountInput);
-    // with lots of decimal places the casting from string input to BigNumber can cause the amount to be slightly off when using the unstaked balance as the max
-    // make sure the parsed stake amount is not greater than the unstaked balance or the contract will revert
-    const stakeAmount = parsedStakeAmountInput.gt(unstakedBalance)
-      ? unstakedBalance
-      : parsedStakeAmountInput;
+    const stakeAmount = parseEther(stakeAmountInput);
     stakeMutation(
       { voting, stakeAmount },
       {
@@ -81,13 +76,7 @@ export function StakeUnstakePanel() {
   }
 
   function requestUnstake(unstakeAmountInput: string) {
-    if (!stakedBalance) return;
-    const parsedUnstakeAmountInput = parseEtherSafe(unstakeAmountInput);
-    // with lots of decimal places the casting from string input to BigNumber can cause the amount to be slightly off when using the staked balance as the max
-    // make sure the parsed unstake amount is not greater than the staked balance or the contract will revert
-    const unstakeAmount = parsedUnstakeAmountInput.gt(stakedBalance)
-      ? stakedBalance
-      : parsedUnstakeAmountInput;
+    const unstakeAmount = parseEther(unstakeAmountInput);
     requestUnstakeMutation({ voting, unstakeAmount });
   }
 

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -81,7 +81,13 @@ export function StakeUnstakePanel() {
   }
 
   function requestUnstake(unstakeAmountInput: string) {
-    const unstakeAmount = parseEtherSafe(unstakeAmountInput);
+    if (!stakedBalance) return;
+    const parsedUnstakeAmountInput = parseEtherSafe(unstakeAmountInput);
+    // with lots of decimal places the casting from string input to BigNumber can cause the amount to be slightly off when using the staked balance as the max
+    // make sure the parsed unstake amount is not greater than the staked balance or the contract will revert
+    const unstakeAmount = parsedUnstakeAmountInput.gt(stakedBalance)
+      ? stakedBalance
+      : parsedUnstakeAmountInput;
     requestUnstakeMutation({ voting, unstakeAmount });
   }
 

--- a/components/Panel/StakeUnstakePanel/Unstake.tsx
+++ b/components/Panel/StakeUnstakePanel/Unstake.tsx
@@ -18,7 +18,7 @@ import {
 interface Props {
   stakedBalance: BigNumber | undefined;
   pendingUnstake: BigNumber | undefined;
-  unstakeCoolDown: number | undefined;
+  unstakeCoolDown: BigNumber | undefined;
   canClaim: boolean;
   isDelegate: boolean;
   requestUnstake: (unstakeAmount: string) => void;
@@ -35,7 +35,7 @@ export function Unstake({
   const { hasActiveVotes } = useVotesContext();
   const [unstakeAmount, setUnstakeAmount] = useState("");
   const unstakeCoolDownFormatted = unstakeCoolDown
-    ? formatDuration({ seconds: unstakeCoolDown })
+    ? formatDuration({ seconds: unstakeCoolDown.toNumber() })
     : "0 seconds";
 
   function canUnstake(

--- a/constant/query/queryKeys.ts
+++ b/constant/query/queryKeys.ts
@@ -14,6 +14,7 @@ export const revealedVotesKey = "revealedVotesKey";
 export const contentfulDataKey = "contentfulDataKey";
 // staking
 export const tokenAllowanceKey = "tokenAllowanceKey";
+export const stakedBalanceKey = "stakedBalanceKey";
 export const unstakedBalanceKey = "unstakedBalanceKey";
 export const stakerDetailsKey = "stakerDetailsKey";
 export const unstakeCoolDownKey = "unstakeCoolDownKey";

--- a/constant/query/queryKeys.ts
+++ b/constant/query/queryKeys.ts
@@ -1,9 +1,7 @@
 // voting - not user dependent
-export const hasActiveVotesKey = "hasActiveVotesKey";
 export const activeVotesKey = "activeVotesKey";
 export const upcomingVotesKey = "upcomingVotesKey";
 export const pastVotesKey = "pastVotesKey";
-export const voteTransactionHashesKey = "voteTransactionHashesKey";
 export const decodedAdminTransactionsKey = "decodedAdminTransactionsKey";
 export const augmentedVoteDataKey = "augmentedVoteDataKey";
 // voting - user dependent
@@ -19,7 +17,6 @@ export const unstakedBalanceKey = "unstakedBalanceKey";
 export const stakerDetailsKey = "stakerDetailsKey";
 export const unstakeCoolDownKey = "unstakeCoolDownKey";
 // rewards
-export const outstandingRewardsKey = "outstandingRewardsKey";
 export const rewardsCalculationInputsKey = "rewardsCalculationInputsKey";
 // user
 export const userDataKey = "userDataKey";

--- a/contexts/StakingContext.tsx
+++ b/contexts/StakingContext.tsx
@@ -20,7 +20,8 @@ export interface StakingContextState {
   tokenAllowance: BigNumber | undefined;
   unstakeRequestTime: Date | undefined;
   canUnstakeTime: Date | undefined;
-  unstakeCoolDown: number | undefined;
+  unstakeCoolDown: BigNumber | undefined;
+  resetOutstandingRewards: () => void;
   getStakingDataLoading: () => boolean;
   getStakingDataFetching: () => boolean;
 }
@@ -34,6 +35,7 @@ export const defaultStakingContextState: StakingContextState = {
   unstakeRequestTime: undefined,
   canUnstakeTime: undefined,
   unstakeCoolDown: undefined,
+  resetOutstandingRewards: () => null,
   getStakingDataLoading: () => false,
   getStakingDataFetching: () => false,
 };
@@ -80,7 +82,7 @@ export function StakingProvider({ children }: { children: ReactNode }) {
   } = useTokenAllowance();
   const { address } = useAccountDetails();
   const {
-    data: { unstakeCoolDown },
+    data: unstakeCoolDown,
     isLoading: unstakeCoolDownLoading,
     isFetching: unstakeCoolDownFetching,
   } = useUnstakeCoolDown();
@@ -103,6 +105,10 @@ export function StakingProvider({ children }: { children: ReactNode }) {
     });
 
     setOutstandingRewards(calculatedOutstandingRewards);
+  }
+
+  function resetOutstandingRewards() {
+    setOutstandingRewards(BigNumber.from(0));
   }
 
   function getStakingDataLoading() {
@@ -142,6 +148,7 @@ export function StakingProvider({ children }: { children: ReactNode }) {
         tokenAllowance,
         unstakeRequestTime,
         canUnstakeTime,
+        resetOutstandingRewards,
         getStakingDataLoading,
         getStakingDataFetching,
       }}

--- a/contexts/StakingContext.tsx
+++ b/contexts/StakingContext.tsx
@@ -4,6 +4,7 @@ import {
   useAccountDetails,
   useInterval,
   useRewardsCalculationInputs,
+  useStakedBalance,
   useStakerDetails,
   useTokenAllowance,
   useUnstakeCoolDown,
@@ -44,7 +45,6 @@ export const StakingContext = createContext<StakingContextState>(
 export function StakingProvider({ children }: { children: ReactNode }) {
   const {
     data: {
-      stakedBalance,
       pendingUnstake,
       unstakeRequestTime,
       canUnstakeTime,
@@ -53,6 +53,11 @@ export function StakingProvider({ children }: { children: ReactNode }) {
     isLoading: stakerDetailsLoading,
     isFetching: stakerDetailsFetching,
   } = useStakerDetails();
+  const {
+    data: stakedBalance,
+    isLoading: stakedBalanceLoading,
+    isFetching: stakedBalanceFetching,
+  } = useStakedBalance();
   const {
     data: unstakedBalance,
     isLoading: unstakedBalanceLoading,
@@ -105,6 +110,7 @@ export function StakingProvider({ children }: { children: ReactNode }) {
 
     return (
       stakerDetailsLoading ||
+      stakedBalanceLoading ||
       unstakedBalanceLoading ||
       tokenAllowanceLoading ||
       unstakeCoolDownLoading ||
@@ -117,6 +123,7 @@ export function StakingProvider({ children }: { children: ReactNode }) {
 
     return (
       stakerDetailsFetching ||
+      stakedBalanceFetching ||
       unstakedBalanceFetching ||
       tokenAllowanceFetching ||
       unstakeCoolDownFetching ||

--- a/helpers/staking/getCanUnstakeTime.ts
+++ b/helpers/staking/getCanUnstakeTime.ts
@@ -5,7 +5,7 @@ const defaultUnstakeCoolDown = 7 * 24 * 60 * 60;
 
 export function getCanUnstakeTime(
   unstakeRequestTimeAsDate: Date,
-  unstakeCooldownS = defaultUnstakeCoolDown
+  unstakeCoolDown = defaultUnstakeCoolDown
 ) {
-  return addSeconds(unstakeRequestTimeAsDate, unstakeCooldownS);
+  return addSeconds(unstakeRequestTimeAsDate, unstakeCoolDown);
 }

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -41,6 +41,7 @@ export { useReceivedRequestsToBeDelegate } from "./queries/delegation/useReceive
 export { useSentRequestsToBeDelegate } from "./queries/delegation/useSentRequestsToBeDelegate";
 export { useVoterFromDelegate } from "./queries/delegation/useVoterFromDelegate";
 export { useRewardsCalculationInputs } from "./queries/rewards/useRewardsCalculationInputs";
+export { useStakedBalance } from "./queries/staking/useStakedBalance";
 export { useStakerDetails } from "./queries/staking/useStakerDetails";
 export { useTokenAllowance } from "./queries/staking/useTokenAllowance";
 export { useUnstakeCoolDown } from "./queries/staking/useUnstakeCoolDown";

--- a/hooks/mutations/staking/useRequestUnstake.ts
+++ b/hooks/mutations/staking/useRequestUnstake.ts
@@ -17,7 +17,7 @@ export function useRequestUnstake(errorOrigin?: ErrorOriginT) {
 
   const { mutate, isLoading } = useMutation(requestUnstake, {
     onError,
-    onSuccess: (_data, { unstakeAmount }) => {
+    onSuccess: (_contractReceipt, { unstakeAmount }) => {
       clearErrors();
 
       queryClient.setQueryData<BigNumber>(
@@ -25,9 +25,9 @@ export function useRequestUnstake(errorOrigin?: ErrorOriginT) {
         (oldStakedBalance) => {
           if (oldStakedBalance === undefined) return;
 
-          const newUnstakedBalance = oldStakedBalance.sub(unstakeAmount);
+          const newStakedBalance = oldStakedBalance.sub(unstakeAmount);
 
-          return newUnstakedBalance;
+          return newStakedBalance;
         }
       );
 
@@ -36,15 +36,11 @@ export function useRequestUnstake(errorOrigin?: ErrorOriginT) {
         (oldStakerDetails) => {
           if (oldStakerDetails === undefined) return;
 
-          const unstakeCoolDown = queryClient.getQueryData<{
-            unstakeCoolDown: number;
-          }>([unstakeCoolDownKey]);
+          const unstakeCoolDown = queryClient.getQueryData<BigNumber>([
+            unstakeCoolDownKey,
+          ]);
 
-          if (
-            unstakeCoolDown === undefined ||
-            unstakeCoolDown.unstakeCoolDown === undefined
-          )
-            return;
+          if (unstakeCoolDown === undefined) return;
 
           return {
             ...oldStakerDetails,
@@ -52,7 +48,7 @@ export function useRequestUnstake(errorOrigin?: ErrorOriginT) {
             unstakeRequestTime: new Date(),
             canUnstakeTime: getCanUnstakeTime(
               new Date(),
-              unstakeCoolDown.unstakeCoolDown
+              unstakeCoolDown.toNumber()
             ),
           };
         }

--- a/hooks/mutations/staking/useStake.ts
+++ b/hooks/mutations/staking/useStake.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { stakerDetailsKey, unstakedBalanceKey } from "constant";
+import { stakedBalanceKey, unstakedBalanceKey } from "constant";
 import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError } from "hooks";
-import { ErrorOriginT, StakerDetailsT } from "types";
+import { ErrorOriginT } from "types";
 import { stake } from "web3";
 
 export function useStake(errorOrigin?: ErrorOriginT) {
@@ -15,18 +15,14 @@ export function useStake(errorOrigin?: ErrorOriginT) {
     onSuccess: (_data, { stakeAmount }) => {
       clearErrors();
 
-      queryClient.setQueryData<StakerDetailsT>(
-        [stakerDetailsKey, address],
-        (oldStakerDetails) => {
-          if (oldStakerDetails === undefined) return;
+      queryClient.setQueryData<BigNumber>(
+        [stakedBalanceKey, address],
+        (oldStakedBalance) => {
+          if (oldStakedBalance === undefined) return;
 
-          const newStakedBalance =
-            oldStakerDetails.stakedBalance.add(stakeAmount);
+          const newStakedBalance = oldStakedBalance.add(stakeAmount);
 
-          return {
-            ...oldStakerDetails,
-            stakedBalance: newStakedBalance,
-          };
+          return newStakedBalance;
         }
       );
 

--- a/hooks/mutations/staking/useWithdrawAndRestake.ts
+++ b/hooks/mutations/staking/useWithdrawAndRestake.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { outstandingRewardsKey, stakerDetailsKey } from "constant";
+import { outstandingRewardsKey, stakedBalanceKey } from "constant";
 import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError } from "hooks";
-import { ErrorOriginT, StakerDetailsT } from "types";
+import { ErrorOriginT } from "types";
 import { withdrawAndRestake } from "web3";
 
 export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
@@ -15,26 +15,22 @@ export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
     onSuccess: () => {
       clearErrors();
 
-      queryClient.setQueryData<StakerDetailsT>(
-        [stakerDetailsKey, address],
-        (oldStakerDetails) => {
+      queryClient.setQueryData<BigNumber>(
+        [stakedBalanceKey, address],
+        (oldStakedBalance) => {
           const outstandingRewards = queryClient.getQueryData<BigNumber>([
             outstandingRewardsKey,
           ]);
 
           if (
             outstandingRewards === undefined ||
-            oldStakerDetails === undefined
+            oldStakedBalance === undefined
           )
             return;
 
-          const newStakedBalance =
-            oldStakerDetails.stakedBalance.add(outstandingRewards);
+          const newStakedBalance = oldStakedBalance.add(outstandingRewards);
 
-          return {
-            ...oldStakerDetails,
-            stakedBalance: newStakedBalance,
-          };
+          return newStakedBalance;
         }
       );
 

--- a/hooks/mutations/staking/useWithdrawAndRestake.ts
+++ b/hooks/mutations/staking/useWithdrawAndRestake.ts
@@ -1,13 +1,14 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { outstandingRewardsKey, stakedBalanceKey } from "constant";
+import { stakedBalanceKey } from "constant";
 import { BigNumber } from "ethers";
-import { useAccountDetails, useHandleError } from "hooks";
+import { useAccountDetails, useHandleError, useStakingContext } from "hooks";
 import { ErrorOriginT } from "types";
 import { withdrawAndRestake } from "web3";
 
 export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
   const queryClient = useQueryClient();
   const { address } = useAccountDetails();
+  const { outstandingRewards, resetOutstandingRewards } = useStakingContext();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 
   const { mutate, isLoading } = useMutation(withdrawAndRestake, {
@@ -18,10 +19,6 @@ export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
       queryClient.setQueryData<BigNumber>(
         [stakedBalanceKey, address],
         (oldStakedBalance) => {
-          const outstandingRewards = queryClient.getQueryData<BigNumber>([
-            outstandingRewardsKey,
-          ]);
-
           if (
             outstandingRewards === undefined ||
             oldStakedBalance === undefined
@@ -34,10 +31,7 @@ export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
         }
       );
 
-      queryClient.setQueryData<BigNumber>(
-        [outstandingRewardsKey, address],
-        () => BigNumber.from(0)
-      );
+      resetOutstandingRewards();
     },
   });
   return {

--- a/hooks/mutations/staking/useWithdrawRewards.ts
+++ b/hooks/mutations/staking/useWithdrawRewards.ts
@@ -1,13 +1,14 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { outstandingRewardsKey, unstakedBalanceKey } from "constant";
+import { unstakedBalanceKey } from "constant";
 import { BigNumber } from "ethers";
-import { useAccountDetails, useHandleError } from "hooks";
+import { useAccountDetails, useHandleError, useStakingContext } from "hooks";
 import { ErrorOriginT } from "types";
 import { withdrawRewards } from "web3";
 
 export function useWithdrawRewards(errorOrigin?: ErrorOriginT) {
   const queryClient = useQueryClient();
   const { address } = useAccountDetails();
+  const { outstandingRewards, resetOutstandingRewards } = useStakingContext();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 
   const { mutate, isLoading } = useMutation(withdrawRewards, {
@@ -18,13 +19,9 @@ export function useWithdrawRewards(errorOrigin?: ErrorOriginT) {
       queryClient.setQueryData<BigNumber>(
         [unstakedBalanceKey, address],
         (oldUnstakedBalance) => {
-          const outstandingRewards = queryClient.getQueryData<BigNumber>([
-            outstandingRewardsKey,
-          ]);
-
           if (
-            outstandingRewards === undefined ||
-            oldUnstakedBalance === undefined
+            oldUnstakedBalance === undefined ||
+            outstandingRewards === undefined
           )
             return;
 
@@ -34,10 +31,7 @@ export function useWithdrawRewards(errorOrigin?: ErrorOriginT) {
         }
       );
 
-      queryClient.setQueryData<BigNumber>(
-        [outstandingRewardsKey, address],
-        () => BigNumber.from(0)
-      );
+      resetOutstandingRewards();
     },
   });
 

--- a/hooks/queries/staking/useStakedBalance.ts
+++ b/hooks/queries/staking/useStakedBalance.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { stakedBalanceKey } from "constant";
+import { BigNumber } from "ethers";
+import { useContractsContext } from "hooks/contexts/useContractsContext";
+import { useHandleError } from "hooks/helpers/useHandleError";
+import { getStakedBalance } from "web3";
+import { useAccountDetails } from "../user/useAccountDetails";
+
+export function useStakedBalance() {
+  const { voting } = useContractsContext();
+  const { address } = useAccountDetails();
+  const { onError, clearErrors } = useHandleError({ isDataFetching: true });
+
+  const queryResult = useQuery({
+    queryKey: [stakedBalanceKey, address],
+    queryFn: () => getStakedBalance(voting, address),
+    enabled: !!address,
+    initialData: BigNumber.from(0),
+    onError,
+    onSuccess: clearErrors,
+  });
+
+  return queryResult;
+}

--- a/hooks/queries/staking/useStakerDetails.ts
+++ b/hooks/queries/staking/useStakerDetails.ts
@@ -28,7 +28,6 @@ export function useStakerDetails() {
     {
       enabled: !!address,
       initialData: {
-        stakedBalance: BigNumber.from(0),
         pendingUnstake: BigNumber.from(0),
         unstakeRequestTime: new Date(0),
         canUnstakeTime: new Date(0),

--- a/hooks/queries/staking/useUnstakeCoolDown.ts
+++ b/hooks/queries/staking/useUnstakeCoolDown.ts
@@ -1,22 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
 import { unstakeCoolDownKey } from "constant";
+import { BigNumber } from "ethers";
 import { useContractsContext, useHandleError } from "hooks";
 import { getUnstakeCoolDown } from "web3";
 
 export function useUnstakeCoolDown() {
   const { voting } = useContractsContext();
-  const { onError } = useHandleError({ isDataFetching: true });
+  const { onError, clearErrors } = useHandleError({ isDataFetching: true });
   // only need to fetch this one time
-  const queryResult = useQuery(
-    [unstakeCoolDownKey],
-    () => getUnstakeCoolDown(voting),
-    {
-      initialData: {
-        unstakeCoolDown: 0,
-      },
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [unstakeCoolDownKey],
+    queryFn: () => getUnstakeCoolDown(voting),
+    initialData: BigNumber.from(0),
+    onError,
+    onSuccess: clearErrors,
+  });
 
   return queryResult;
 }

--- a/types/staking.ts
+++ b/types/staking.ts
@@ -1,7 +1,6 @@
 import { BigNumber } from "ethers";
 
 export type StakerDetailsT = {
-  stakedBalance: BigNumber;
   pendingUnstake: BigNumber;
   canUnstakeTime: Date | undefined;
   unstakeRequestTime: Date | undefined;

--- a/web3/index.ts
+++ b/web3/index.ts
@@ -18,6 +18,7 @@ export { getDelegatorSetEvents } from "./queries/delegation/getDelegatorSetEvent
 export { getIgnoredRequestToBeDelegateAddresses } from "./queries/delegation/getIgnoredRequestToBeDelegateAddresses";
 export { getVoterFromDelegate } from "./queries/delegation/getVoterFromDelegate";
 export { getRewardsCalculationInputs } from "./queries/rewards/getRewardsCalculationInputs";
+export { getStakedBalance } from "./queries/staking/getStakedBalance";
 export { getStakerDetails } from "./queries/staking/getStakerDetails";
 export { getTokenAllowance } from "./queries/staking/getTokenAllowance";
 export { getUnstakeCoolDown } from "./queries/staking/getUnstakeCoolDown";

--- a/web3/queries/staking/getStakedBalance.ts
+++ b/web3/queries/staking/getStakedBalance.ts
@@ -1,0 +1,8 @@
+import { VotingV2Ethers } from "@uma/contracts-frontend";
+
+export function getStakedBalance(
+  votingContract: VotingV2Ethers,
+  address: string
+) {
+  return votingContract.callStatic.getVoterStakePostUpdate(address);
+}

--- a/web3/queries/staking/getStakerDetails.ts
+++ b/web3/queries/staking/getStakerDetails.ts
@@ -8,13 +8,8 @@ export async function getStakerDetails(
 ) {
   const result = await votingContract.voterStakes(address);
   const { unstakeCoolDown } = await getUnstakeCoolDown(votingContract);
-  const {
-    stake: stakedBalance,
-    pendingUnstake,
-    unstakeRequestTime,
-    delegate,
-    rewardsPaidPerToken,
-  } = result ?? {};
+  const { pendingUnstake, unstakeRequestTime, delegate, rewardsPaidPerToken } =
+    result ?? {};
   const unstakeRequestTimeAsDate = new Date(Number(unstakeRequestTime) * 1000);
   const canUnstakeTime = getCanUnstakeTime(
     unstakeRequestTimeAsDate,
@@ -22,7 +17,6 @@ export async function getStakerDetails(
   );
 
   return {
-    stakedBalance,
     pendingUnstake,
     unstakeRequestTime: unstakeRequestTimeAsDate,
     canUnstakeTime,

--- a/web3/queries/staking/getStakerDetails.ts
+++ b/web3/queries/staking/getStakerDetails.ts
@@ -7,13 +7,13 @@ export async function getStakerDetails(
   address: string
 ) {
   const result = await votingContract.voterStakes(address);
-  const { unstakeCoolDown } = await getUnstakeCoolDown(votingContract);
+  const unstakeCoolDown = await getUnstakeCoolDown(votingContract);
   const { pendingUnstake, unstakeRequestTime, delegate, rewardsPaidPerToken } =
     result ?? {};
   const unstakeRequestTimeAsDate = new Date(Number(unstakeRequestTime) * 1000);
   const canUnstakeTime = getCanUnstakeTime(
     unstakeRequestTimeAsDate,
-    unstakeCoolDown
+    unstakeCoolDown.toNumber()
   );
 
   return {

--- a/web3/queries/staking/getUnstakeCoolDown.ts
+++ b/web3/queries/staking/getUnstakeCoolDown.ts
@@ -1,6 +1,5 @@
 import { VotingV2Ethers } from "@uma/contracts-frontend";
 
-export async function getUnstakeCoolDown(votingContract: VotingV2Ethers) {
-  const unstakeCoolDown = await votingContract.unstakeCoolDown();
-  return { unstakeCoolDown: unstakeCoolDown.toNumber() };
+export function getUnstakeCoolDown(votingContract: VotingV2Ethers) {
+  return votingContract.unstakeCoolDown();
 }


### PR DESCRIPTION
### Summary

There was some trouble with the max button for staking / unstaking. Fix these issues by getting the staked balance by calling `getVoterStakePostUpdate()` to make sure its accurate, and also add some guard logic to make sure that we never attempt to stake / unstake more than the staked / unstaked balance when using the max button.

