### PR TITLE
feat: add total rewards fetched

### DIFF
--- a/pages/api/_common.ts
+++ b/pages/api/_common.ts
@@ -17,7 +17,7 @@ export function getNodeUrls() {
   return JSON.parse(process.env.NODE_URLS) as NodeUrls;
 }
 
-export async function constructContractOnChain(
+export async function constructContract(
   chainId: SupportedChainIdsWithGoerli,
   contractName: ContractName
 ) {

--- a/pages/api/augment-request.ts
+++ b/pages/api/augment-request.ts
@@ -6,7 +6,7 @@ import {
 } from "@uma/contracts-node";
 import { NextApiRequest, NextApiResponse } from "next";
 import { OracleTypeT, PriceRequestT, SupportedChainIds } from "types";
-import { constructContractOnChain, getNodeUrls } from "./_common";
+import { constructContract, getNodeUrls } from "./_common";
 
 enum OracleType {
   OptimisticOracle,
@@ -43,11 +43,11 @@ function castOracleNameForOOUi(oracleType: string): string {
 }
 
 async function constructOptimisticOraclesByChain(chainId: SupportedChainIds) {
-  const optimisticOracle = (await constructContractOnChain(
+  const optimisticOracle = (await constructContract(
     chainId,
     "OptimisticOracle"
   )) as OptimisticOracleEthers;
-  const optimisticOracleV2 = (await constructContractOnChain(
+  const optimisticOracleV2 = (await constructContract(
     chainId,
     "OptimisticOracleV2"
   )) as OptimisticOracleV2Ethers;
@@ -55,7 +55,7 @@ async function constructOptimisticOraclesByChain(chainId: SupportedChainIds) {
   // Only mainnet has a SkinnyOptimisticOracle so only construct it here. All other chains of interest have OOv1 and V2.
   const skinnyOptimisticOracle =
     chainId == 1
-      ? ((await constructContractOnChain(
+      ? ((await constructContract(
           chainId,
           "SkinnyOptimisticOracle"
         )) as SkinnyOptimisticOracleEthers)
@@ -136,12 +136,12 @@ async function getRequestTxFromL1RequestInformation(
 }
 
 async function getAugmentingRequestInformation(l1Requests: PriceRequestT[]) {
-  const votingV1 = (await constructContractOnChain(
+  const votingV1 = (await constructContract(
     1,
     "Voting"
   )) as VotingEthers;
   // todo: add voting v2 when released.
-  // const votingV2 = await constructContractOnChain(1, "VotingV2");
+  // const votingV2 = await constructContract(1, "VotingV2");
   const l1RequestEvents = (
     await Promise.all([
       votingV1.queryFilter(votingV1.filters.PriceRequestAdded()),

--- a/pages/api/augment-request.ts
+++ b/pages/api/augment-request.ts
@@ -136,10 +136,7 @@ async function getRequestTxFromL1RequestInformation(
 }
 
 async function getAugmentingRequestInformation(l1Requests: PriceRequestT[]) {
-  const votingV1 = (await constructContract(
-    1,
-    "Voting"
-  )) as VotingEthers;
+  const votingV1 = (await constructContract(1, "Voting")) as VotingEthers;
   // todo: add voting v2 when released.
   // const votingV2 = await constructContract(1, "VotingV2");
   const l1RequestEvents = (

--- a/pages/api/decode-admin.ts
+++ b/pages/api/decode-admin.ts
@@ -9,7 +9,7 @@ import { getAbi, getContractNames } from "@uma/contracts-node";
 import { NextApiRequest, NextApiResponse } from "next";
 // @ts-expect-error - no types for this module
 import abiDecoder from "abi-decoder";
-import { constructContractOnChain } from "./_common";
+import { constructContract } from "./_common";
 
 type AbiDecoder = typeof abiDecoder;
 
@@ -168,10 +168,10 @@ const _generateTransactionDataRecursive = function (
 };
 
 async function generateReadableAdminTransactionData(identifiers: string[]) {
-  const governorV1 = await constructContractOnChain(1, "Governor");
+  const governorV1 = await constructContract(1, "Governor");
 
   // TODO: to enable decoding of v2 transactions we simply need to uncomment this.
-  // const governorV2 = constructContractOnChain(1, "GovernorV2");
+  // const governorV2 = constructContract(1, "GovernorV2");
 
   const events = (
     await Promise.all([

--- a/pages/api/past-rewards.ts
+++ b/pages/api/past-rewards.ts
@@ -1,7 +1,8 @@
 import { VotingEthers } from "@uma/contracts-frontend";
 import { NextApiRequest, NextApiResponse } from "next";
 import { SupportedChainIdsWithGoerli } from "types";
-import { constructContractOnChain } from "./_common";
+import { constructContract } from "./_common";
+import { ethers } from "ethers";
 
 type GroupedReveals = Record<
   string,
@@ -11,11 +12,8 @@ type GroupedReveals = Record<
 async function generatePastRewardTx(
   voterAddress: string,
   chainId: SupportedChainIdsWithGoerli
-) {
-  const votingV1 = (await constructContractOnChain(
-    chainId,
-    "Voting"
-  )) as VotingEthers;
+): Promise<{ multiCallPayload: string[]; totalRewards: string }> {
+  const votingV1 = (await constructContract(chainId, "Voting")) as VotingEthers;
 
   const [voteRevealEvents, rewardsRetrievedEvents] = await Promise.all([
     votingV1.queryFilter(votingV1.filters.VoteRevealed(voterAddress)),
@@ -49,17 +47,18 @@ async function generatePastRewardTx(
     else groupedReveals[roundId].push(voteProps);
   });
 
-  if (Object.keys(groupedReveals).length === 0) return [];
+  if (Object.keys(groupedReveals).length === 0)
+    return { multiCallPayload: [], totalRewards: "0" };
 
-  return await constructMultiCall(groupedReveals, voterAddress, chainId);
+  return constructMultiCall(groupedReveals, voterAddress, chainId);
 }
 
 async function constructMultiCall(
   unclaimedVotes: GroupedReveals,
   voterAddress: string,
   chainId: SupportedChainIdsWithGoerli
-) {
-  const votingV2 = await constructContractOnChain(chainId, "VotingV2");
+): Promise<{ multiCallPayload: string[]; totalRewards: string }> {
+  const votingV2 = await constructContract(chainId, "VotingV2");
   const retrieveFragment = votingV2.interface.getFunction(
     "retrieveRewardsOnMigratedVotingContract(address,uint256,(bytes32,uint256,bytes)[])"
   );
@@ -75,7 +74,16 @@ async function constructMultiCall(
       ])
     );
   });
-  return multiCallPayload;
+
+  try {
+    const totalRewards = (await votingV2.callStatic.multicall(multiCallPayload))
+      .map((reward: string) => ethers.BigNumber.from(reward))
+      .reduce((a: any, b: any) => a.add(b), ethers.BigNumber.from(0))
+      .toString();
+    return { multiCallPayload, totalRewards };
+  } catch (error) {
+    return { multiCallPayload: [], totalRewards: "0" };
+  }
 }
 
 export default async function handler(

--- a/pages/api/warm-cache.ts
+++ b/pages/api/warm-cache.ts
@@ -7,12 +7,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { constructContractOnChain } from "./_common";
+import { constructContract } from "./_common";
 
 async function warmAugmentedDataCache() {
-  const votingV1 = await constructContractOnChain(1, "Voting");
+  const votingV1 = await constructContract(1, "Voting");
   // todo: add voting v2 when released.
-  // const votingV2 = await constructContractOnChain(1, "VotingV2");
+  // const votingV2 = await constructContract(1, "VotingV2");
   const l1RequestEvents = (
     await Promise.all([
       votingV1.queryFilter(votingV1.filters.PriceRequestAdded()),


### PR DESCRIPTION
This PR adds the ability for the `past-rewards` serverless function to include the total amount of rewards fetched. It also includes a small formatting improvement.
