### PR TITLE
improve: truncate past votes numbers to 2 decimals

### DIFF
--- a/components/Panel/VotePanel/Result.tsx
+++ b/components/Panel/VotePanel/Result.tsx
@@ -6,7 +6,7 @@ import {
   Tooltip,
 } from "components";
 import { mobileAndUnder } from "constant";
-import { formatVoteStringWithPrecision } from "helpers";
+import { formatVoteStringWithPrecision, truncateDecimals } from "helpers";
 import { usePanelWidth } from "hooks";
 import Portion from "public/assets/icons/portion.svg";
 import Voting from "public/assets/icons/voting.svg";
@@ -79,7 +79,8 @@ export function Result({
                 <LegendItemDot style={{ "--color": color } as CSSProperties} />
                 <LegendItemData>
                   <LegendItemLabel label={label} />
-                  <Strong>{(percent * 100).toFixed(2)}%</Strong> ({value})
+                  <Strong>{(percent * 100).toFixed(2)}%</Strong> (
+                  {value ? truncateDecimals(value, 2) : 0})
                 </LegendItemData>
               </LegendItem>
             ))}
@@ -103,7 +104,11 @@ export function Result({
         </ParticipationItem>
         <ParticipationItem>
           <span>Total tokens voted with</span>
-          <Strong>{totalTokensVotedWith}</Strong>
+          <Strong>
+            {totalTokensVotedWith
+              ? truncateDecimals(totalTokensVotedWith, 2)
+              : 0}
+          </Strong>
         </ParticipationItem>
       </SectionWrapper>
       <PanelErrorBanner errorOrigin="vote" />

--- a/helpers/util/formatNumber.ts
+++ b/helpers/util/formatNumber.ts
@@ -11,9 +11,9 @@ export function formatNumberForDisplay(
   return truncateDecimals(commify(_number), decimals);
 }
 
-export function truncateDecimals(number: string, decimals: number) {
-  const [whole, decimal] = number.split(".");
-  if (!decimal) return number;
+export function truncateDecimals(number: string | number, decimals: number) {
+  const [whole, decimal] = number.toString().split(".");
+  if (!decimal) return number.toString();
   if (decimals === 0) return whole.toString();
   return `${whole}.${decimal.slice(0, decimals)}`;
 }


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

Decimals used to go on forever, now all are set to 2:
![image](https://user-images.githubusercontent.com/4429761/204605367-2056d5e2-06d5-4027-86a4-38ba74c818d0.png)
