### PR TITLE
fix: use time from contract in vote details panel

### DIFF
--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -28,6 +28,7 @@ export function Details({
   ancillaryData,
   decodedAncillaryData,
   options,
+  time,
   timeAsDate,
   discordLink,
   decodedAdminTransactions,
@@ -200,7 +201,7 @@ export function Details({
           <span>UTC</span> <span>{timeAsDate.toUTCString()}</span>
         </Timestamp>
         <Timestamp>
-          <span>UNIX</span> <span>{timeAsDate.getTime()}</span>
+          <span>UNIX</span> <span>{time}</span>
         </Timestamp>
       </SectionWrapper>
       {links.length > 0 ? (


### PR DESCRIPTION
We already have the correct value from the contract, so use that instead of getting a millisecond timestamp from the time as date.

<img width="525" alt="Screenshot 2022-11-30 at 10 36 31" src="https://user-images.githubusercontent.com/39741965/204747366-f68f71a9-5dd5-4ec4-8476-bae0c178bee5.png">
