### PR TITLE
fix: past votes shows me that i did not vote

### DIFF
--- a/constant/web3/addresses.ts
+++ b/constant/web3/addresses.ts
@@ -1,2 +1,6 @@
-export const votingContractAddress = process.env.NEXT_PUBLIC_VOTING_CONTRACT_ADDRESS_GOERLI ?? "";
-export const votingTokenContractAddress = process.env.NEXT_PUBLIC_VOTING_TOKEN_CONTRACT_ADDRESS_GOERLI ?? "";
+export const votingContractAddress =
+  process.env.NEXT_PUBLIC_VOTING_CONTRACT_ADDRESS_GOERLI ?? "";
+export const votingTokenContractAddress =
+  process.env.NEXT_PUBLIC_VOTING_TOKEN_CONTRACT_ADDRESS_GOERLI ?? "";
+export const votingV1ContractAddress =
+  process.env.NEXT_PUBLIC_VOTING_V1_CONTRACT_ADDRESS_GOERLI ?? "";

--- a/contexts/ContractsContext.tsx
+++ b/contexts/ContractsContext.tsx
@@ -1,8 +1,13 @@
-import { VotingTokenEthers, VotingV2Ethers } from "@uma/contracts-frontend";
+import {
+  VotingEthers,
+  VotingTokenEthers,
+  VotingV2Ethers,
+} from "@uma/contracts-frontend";
 import { createContext, ReactNode, useState } from "react";
 import {
   createVotingContractInstance,
   createVotingTokenContractInstance,
+  createVotingV1ContractInstance,
 } from "web3";
 
 export interface ContractsContextState {
@@ -10,16 +15,21 @@ export interface ContractsContextState {
   setVoting: (voting: VotingV2Ethers) => void;
   votingToken: VotingTokenEthers;
   setVotingToken: (votingToken: VotingTokenEthers) => void;
+  votingV1: VotingEthers;
+  setVotingV1: (votingV1: VotingEthers) => void;
 }
 
 const defaultVoting = createVotingContractInstance();
 const defaultVotingToken = createVotingTokenContractInstance();
+const defaultVotingV1 = createVotingV1ContractInstance();
 
 export const defaultContractContextState = {
   voting: defaultVoting,
   setVoting: () => null,
   votingToken: defaultVotingToken,
   setVotingToken: () => null,
+  votingV1: defaultVotingV1,
+  setVotingV1: () => null,
 };
 
 export const ContractsContext = createContext<ContractsContextState>(
@@ -29,10 +39,18 @@ export const ContractsContext = createContext<ContractsContextState>(
 export function ContractsProvider({ children }: { children: ReactNode }) {
   const [voting, setVoting] = useState(defaultVoting);
   const [votingToken, setVotingToken] = useState(defaultVotingToken);
+  const [votingV1, setVotingV1] = useState(defaultVotingV1);
 
   return (
     <ContractsContext.Provider
-      value={{ voting, setVoting, votingToken, setVotingToken }}
+      value={{
+        voting,
+        setVoting,
+        votingToken,
+        setVotingToken,
+        votingV1,
+        setVotingV1,
+      }}
     >
       {children}
     </ContractsContext.Provider>

--- a/helpers/web3/wallet.ts
+++ b/helpers/web3/wallet.ts
@@ -1,6 +1,6 @@
 import { DisconnectOptions, WalletState } from "@web3-onboard/core";
 import { ethers } from "ethers";
-import { truncateEthAddress } from "helpers";
+import { getAddress, truncateEthAddress } from "helpers";
 
 export function handleDisconnectWallet(
   wallet: WalletState | null,
@@ -18,7 +18,7 @@ export function handleDisconnectWallet(
 export function getAccountDetails(connectedWallets?: WalletState[]) {
   const connectedWallet = connectedWallets?.[0];
   const account = connectedWallet?.accounts[0];
-  const address = account?.address ?? "";
+  const address = account?.address ? getAddress(account.address) : "";
   const truncatedAddress = address ? truncateEthAddress(address) : undefined;
 
   return {

--- a/hooks/queries/votes/useEncryptedVotes.ts
+++ b/hooks/queries/votes/useEncryptedVotes.ts
@@ -9,14 +9,14 @@ import {
 import { getEncryptedVotes } from "web3";
 
 export function useEncryptedVotes() {
-  const { voting } = useContractsContext();
+  const { voting, votingV1 } = useContractsContext();
   const { address } = useAccountDetails();
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [encryptedVotesKey, address, roundId],
-    () => getEncryptedVotes(voting, address, roundId),
+    () => getEncryptedVotes(voting, votingV1, address),
     {
       enabled: !!address,
       initialData: {},

--- a/web3/contracts/createVotingV1ContractInstance.ts
+++ b/web3/contracts/createVotingV1ContractInstance.ts
@@ -1,0 +1,14 @@
+import { VotingEthers__factory } from "@uma/contracts-frontend";
+import { votingV1ContractAddress } from "constant";
+import { ethers } from "ethers";
+
+export function createVotingV1ContractInstance(signer?: ethers.Signer) {
+  if (!signer) {
+    const provider = new ethers.providers.InfuraProvider(
+      "goerli",
+      process.env.NEXT_PUBLIC_INFURA_ID
+    );
+    signer = new ethers.VoidSigner(votingV1ContractAddress, provider);
+  }
+  return VotingEthers__factory.connect(votingV1ContractAddress, signer);
+}

--- a/web3/index.ts
+++ b/web3/index.ts
@@ -1,4 +1,5 @@
 export { createVotingContractInstance } from "./contracts/createVotingContractInstance";
+export { createVotingV1ContractInstance } from "./contracts/createVotingV1ContractInstance";
 export { createVotingTokenContractInstance } from "./contracts/createVotingTokenContractInstance";
 export { removeDelegate } from "./mutations/delegation/removeDelegate";
 export { removeDelegator } from "./mutations/delegation/removeDelegator";


### PR DESCRIPTION
### Summary

There were some logical issues with how we fetched encrypted votes from the chain. Firstly, we were not using a checksum address, which caused ethers to think the address was incorrect (I could swear this worked before though so this is quite strange). Secondly, we were only fetching encrypted votes for the current round, which meant that we would not have encrypted votes for past votes. I fixed these problems, and also added another event query to fetch the encrypted votes from v1 as well — now you will see your vote in the past votes from v1 too.

* use checksum address in user context to prevent missed event queries
* get encrypted votes for all rounds to show in past votes
* get encrypted votes from v1 in the same query