### PR TITLE
fix: no multicall on single vote

### DIFF
--- a/web3/mutations/votes/commitVotes.ts
+++ b/web3/mutations/votes/commitVotes.ts
@@ -4,6 +4,28 @@ import { CommitVotes } from "types";
 export async function commitVotes({ voting, formattedVotes }: CommitVotes) {
   if (!formattedVotes.length) return;
 
+  if (formattedVotes.length === 1) {
+    const vote = formattedVotes[0];
+
+    if (!vote) return;
+
+    const { identifier, time, ancillaryData, hash, encryptedVote } = vote;
+
+    const tx = await voting.functions.commitAndEmitEncryptedVote(
+      identifier,
+      time,
+      ancillaryData,
+      hash,
+      encryptedVote
+    );
+
+    return handleNotifications(tx, {
+      pending: `Committing 1 vote...`,
+      success: `Committed 1 vote`,
+      error: `Failed to commit 1 vote`,
+    });
+  }
+
   const commitVoteFunctionFragment = voting.interface.getFunction(
     "commitAndEmitEncryptedVote(bytes32,uint256,bytes,bytes32,bytes)"
   );
@@ -22,16 +44,9 @@ export async function commitVotes({ voting, formattedVotes }: CommitVotes) {
   });
 
   const tx = await voting.functions.multicall(calldata);
-  const shouldPluralize = formattedVotes.length > 1;
   return handleNotifications(tx, {
-    pending: `Committing ${formattedVotes.length} vote${
-      shouldPluralize ? "s" : ""
-    }...`,
-    success: `Committed ${formattedVotes.length} vote${
-      shouldPluralize ? "s" : ""
-    }`,
-    error: `Failed to commit ${formattedVotes.length} vote${
-      shouldPluralize ? "s" : ""
-    }`,
+    pending: `Committing ${formattedVotes.length} votes...`,
+    success: `Committed ${formattedVotes.length} votes`,
+    error: `Failed to commit ${formattedVotes.length} votes`,
   });
 }

--- a/web3/mutations/votes/commitVotes.ts
+++ b/web3/mutations/votes/commitVotes.ts
@@ -44,6 +44,7 @@ export async function commitVotes({ voting, formattedVotes }: CommitVotes) {
   });
 
   const tx = await voting.functions.multicall(calldata);
+
   return handleNotifications(tx, {
     pending: `Committing ${formattedVotes.length} votes...`,
     success: `Committed ${formattedVotes.length} votes`,

--- a/web3/mutations/votes/revealVotes.ts
+++ b/web3/mutations/votes/revealVotes.ts
@@ -3,7 +3,30 @@ import { RevealVotes } from "types";
 
 export async function revealVotes({ votesToReveal, voting }: RevealVotes) {
   const formattedVotes = formatVotesToReveal(votesToReveal);
+
   if (!formattedVotes.length) return;
+
+  if (formattedVotes.length === 1) {
+    const vote = formattedVotes[0];
+
+    if (!vote) return;
+
+    const { identifier, time, price, ancillaryData, salt } = vote;
+
+    const tx = await voting.functions.revealVote(
+      identifier,
+      time,
+      price,
+      ancillaryData,
+      salt
+    );
+
+    return handleNotifications(tx, {
+      pending: `Revealing 1 vote...`,
+      success: `Revealed 1 vote`,
+      error: `Failed to reveal 1 vote`,
+    });
+  }
 
   const revealVoteFunctionFragment = voting.interface.getFunction(
     "revealVote(bytes32,uint256,int256,bytes,int256)"
@@ -25,16 +48,10 @@ export async function revealVotes({ votesToReveal, voting }: RevealVotes) {
   });
 
   const tx = await voting.functions.multicall(calldata);
-  const shouldPluralize = formattedVotes.length > 1;
+
   return handleNotifications(tx, {
-    pending: `Revealing ${formattedVotes.length} vote${
-      shouldPluralize ? "s" : ""
-    }...`,
-    success: `Revealed ${formattedVotes.length} vote${
-      shouldPluralize ? "s" : ""
-    }`,
-    error: `Failed to reveal ${formattedVotes.length} vote${
-      shouldPluralize ? "s" : ""
-    }`,
+    pending: `Revealing ${formattedVotes.length} votes...`,
+    success: `Revealed ${formattedVotes.length} votes`,
+    error: `Failed to reveal ${formattedVotes.length} votes`,
   });
 }


### PR DESCRIPTION
### Summary

When we are only committing or revealing one vote, we should rather call the commit or reveal contract methods directly instead of using multicall.