### PR TITLE
improve: rearrange words in unclaimed rewards

### DIFF
--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -123,7 +123,7 @@ export function HowItWorks() {
           }
           content={
             <>
-              You have{" "}
+              Your unclaimed UMA rewards:{" "}
               <Strong>
                 {isLoading() ? (
                   <LoadingSkeleton width={50} />
@@ -131,7 +131,6 @@ export function HowItWorks() {
                   formatNumberForDisplay(outstandingRewards, { decimals: 3 })
                 )}
               </Strong>{" "}
-              in unclaimed rewards
             </>
           }
           actionLabel="Claim"


### PR DESCRIPTION
Changing the phrasing of this sentence fixes the issue of jumpy looking text in the rewards counter. I think that this phrasing would look better anyway regardless of the bug. It's visually pleasing to have the emphasis at the end of the text.

<img width="342" alt="Screenshot 2022-12-01 at 09 41 12" src="https://user-images.githubusercontent.com/39741965/204994473-7513a048-f1b2-4117-9b7d-c370d5bfcba3.png">
