### PR TITLE
fix: filter v1 votes from history panel

### DIFF
--- a/components/Panel/HistoryPanel.tsx
+++ b/components/Panel/HistoryPanel.tsx
@@ -19,7 +19,7 @@ import { PanelTitle } from "./PanelTitle";
 import { PanelSectionText, PanelSectionTitle, PanelWrapper } from "./styles";
 
 export function HistoryPanel() {
-  const { getPastVotes } = useVotesContext();
+  const { getPastVotesV2 } = useVotesContext();
   const {
     apr,
     cumulativeCalculatedSlash,
@@ -32,7 +32,7 @@ export function HistoryPanel() {
     },
   } = usePaginationContext();
 
-  const pastVotes = getPastVotes();
+  const pastVotes = getPastVotesV2();
   const numberOfPastVotes = pastVotes.length;
   const votesToShow = getEntriesForPage(pageNumber, resultsPerPage, pastVotes);
 

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -39,6 +39,7 @@ export interface VotesContextState {
   getActiveVotes: () => VoteT[];
   getUpcomingVotes: () => VoteT[];
   getPastVotes: () => VoteT[];
+  getPastVotesV2: () => VoteT[];
   getActivityStatus: () => ActivityStatusT;
   getUserDependentIsLoading: () => boolean;
   getUserIndependentIsLoading: () => boolean;
@@ -62,6 +63,7 @@ export const defaultVotesContextState: VotesContextState = {
   getActiveVotes: () => [],
   getUpcomingVotes: () => [],
   getPastVotes: () => [],
+  getPastVotesV2: () => [],
   getActivityStatus: () => "past",
   getUserDependentIsLoading: () => false,
   getUserIndependentIsLoading: () => false,
@@ -177,6 +179,10 @@ export function VotesProvider({ children }: { children: ReactNode }) {
     return getVotesWithData(pastVotes);
   }
 
+  function getPastVotesV2() {
+    return getVotesWithData(pastVotes).filter((vote) => !vote.isV1);
+  }
+
   function getActivityStatus() {
     if (hasActiveVotes) return "active";
     if (hasUpcomingVotes) return "upcoming";
@@ -230,6 +236,7 @@ export function VotesProvider({ children }: { children: ReactNode }) {
         getActiveVotes,
         getUpcomingVotes,
         getPastVotes,
+        getPastVotesV2,
         getActivityStatus,
         getUserDependentIsLoading,
         getUserIndependentIsLoading,


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This basically just filters out v1 votes from history panel. 

![image](https://user-images.githubusercontent.com/4429761/205085641-b0daf198-86c8-4513-9103-9802295bad0d.png)
