### PR TITLE
fix: add aspect ratio to vote result key dot

### DIFF
--- a/components/Panel/VotePanel/Result.tsx
+++ b/components/Panel/VotePanel/Result.tsx
@@ -177,6 +177,7 @@ const LegendItem = styled.li`
 const LegendItemDot = styled.div`
   width: 15px;
   height: 15px;
+  aspect-ratio: 1/1;
   margin-top: 6px;
   border-radius: 50%;
   background: var(--color);


### PR DESCRIPTION
Adding `aspect-ratio: 1/1` forces the element to always have the same width and height, which in turn makes sure that it's always circular in this case.

<img width="210" alt="Screenshot 2022-12-02 at 11 06 23" src="https://user-images.githubusercontent.com/39741965/205256711-9a8faec0-c9c0-49b3-99f1-06c7c27485ea.png">
