### PR TITLE
fix: paginating one page also paginates the other pages

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,7 +4,18 @@ import React from "react";
 import "styles/fonts.css";
 import { GlobalStyle } from "../components/GlobalStyle";
 import { Panel } from "../components/Panel/Panel";
-import { ContractsProvider, DelegationProvider, ErrorProvider, PaginationProvider, PanelProvider, StakingProvider, UserProvider, VotesProvider, VoteTimingProvider, WalletProvider } from "../contexts";
+import {
+  ContractsProvider,
+  DelegationProvider,
+  ErrorProvider,
+  PaginationProvider,
+  PanelProvider,
+  StakingProvider,
+  UserProvider,
+  VotesProvider,
+  VoteTimingProvider,
+  WalletProvider,
+} from "../contexts";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -20,27 +31,28 @@ const queryClient = new QueryClient();
 
 addDecorator((Story) => (
   <ErrorProvider>
-      <VoteTimingProvider>
-        <WalletProvider>
-          <QueryClientProvider client={queryClient}>
-            <UserProvider>
-              <ContractsProvider>
-                <StakingProvider>
+    <VoteTimingProvider>
+      <WalletProvider>
+        <QueryClientProvider client={queryClient}>
+          <UserProvider>
+            <ContractsProvider>
+              <StakingProvider>
+                <PaginationProvider>
                   <DelegationProvider>
                     <VotesProvider>
-                    <PanelProvider>
-                      <PaginationProvider />
+                      <PanelProvider>
                         <GlobalStyle />
                         <Story />
                         <Panel />
                       </PanelProvider>
                     </VotesProvider>
                   </DelegationProvider>
-                </StakingProvider>
-              </ContractsProvider>
-            </UserProvider>
-          </QueryClientProvider>
-        </WalletProvider>
-      </VoteTimingProvider>
-    </ErrorProvider>
+                </PaginationProvider>
+              </StakingProvider>
+            </ContractsProvider>
+          </UserProvider>
+        </QueryClientProvider>
+      </WalletProvider>
+    </VoteTimingProvider>
+  </ErrorProvider>
 ));

--- a/contexts/PaginationContext.tsx
+++ b/contexts/PaginationContext.tsx
@@ -42,57 +42,73 @@ export const PaginationContext = createContext<PaginationContextState>(
 );
 
 export function PaginationProvider({ children }: { children: ReactNode }) {
-  const [pageStates, setPageStates] = useState<PageStatesT>(defaultPageStates);
+  const [activeVotesPage, setActiveVotesPage] = useState({
+    ...defaultPageState,
+  });
+  const [upcomingVotesPage, setUpcomingVotesPage] = useState({
+    ...defaultPageState,
+  });
+  const [pastVotesPage, setPastVotesPage] = useState({ ...defaultPageState });
+  const [voteHistoryPage, setVoteHistoryPage] = useState({
+    ...defaultPageState,
+  });
+  const pageStates = {
+    activeVotesPage,
+    upcomingVotesPage,
+    pastVotesPage,
+    voteHistoryPage,
+  };
+
+  const setterFunctions = {
+    activeVotesPage: setActiveVotesPage,
+    upcomingVotesPage: setUpcomingVotesPage,
+    pastVotesPage: setPastVotesPage,
+    voteHistoryPage: setVoteHistoryPage,
+  };
 
   function goToPage(paginateFor: PaginateForT, number: number) {
-    setPageStates((prev) => {
-      const newState = { ...prev };
-      newState[paginateFor].pageNumber = number;
-      return newState;
-    });
+    setterFunctions[paginateFor]((prevState) => ({
+      ...prevState,
+      pageNumber: number,
+    }));
   }
 
   function nextPage(paginateFor: PaginateForT) {
-    setPageStates((prev) => {
-      const newState = { ...prev };
-      newState[paginateFor].pageNumber += 1;
-      return newState;
-    });
+    setterFunctions[paginateFor]((prevState) => ({
+      ...prevState,
+      pageNumber: prevState.pageNumber + 1,
+    }));
   }
 
   function previousPage(paginateFor: PaginateForT) {
-    setPageStates((prev) => {
-      const newState = { ...prev };
-      newState[paginateFor].pageNumber -= 1;
-      return newState;
-    });
+    setterFunctions[paginateFor]((prevState) => ({
+      ...prevState,
+      pageNumber: prevState.pageNumber - 1,
+    }));
   }
 
   function setResultsPerPage(
     paginateFor: PaginateForT,
     resultsPerPage: number
   ) {
-    setPageStates((prev) => {
-      const newState = { ...prev };
-      newState[paginateFor].resultsPerPage = resultsPerPage;
-      return newState;
-    });
+    setterFunctions[paginateFor]((prevState) => ({
+      ...prevState,
+      resultsPerPage,
+    }));
   }
 
   function firstPage(paginateFor: PaginateForT) {
-    setPageStates((prev) => {
-      const newState = { ...prev };
-      newState[paginateFor].pageNumber = 1;
-      return newState;
-    });
+    setterFunctions[paginateFor]((prevState) => ({
+      ...prevState,
+      pageNumber: 1,
+    }));
   }
 
   function lastPage(paginateFor: PaginateForT, lastPageNumber: number) {
-    setPageStates((prev) => {
-      const newState = { ...prev };
-      newState[paginateFor].pageNumber = lastPageNumber;
-      return newState;
-    });
+    setterFunctions[paginateFor]((prevState) => ({
+      ...prevState,
+      pageNumber: lastPageNumber,
+    }));
   }
 
   return (


### PR DESCRIPTION
[Updating nested objects in react state](https://beta.reactjs.org/learn/updating-objects-in-state) is ugly. Trying to maintain an object of objects for the various pagination states was a mistake — it didn't work properly to begin with, and to make it work, we'd have to use multiple layers of object spreads all over the place.

Much easier and cleaner to just use separate state for each object.