### PR TITLE
improve: remove error handlers from non-critical data fetchers

### DIFF
--- a/hooks/queries/votes/useAugmentedVoteData.ts
+++ b/hooks/queries/votes/useAugmentedVoteData.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { augmentedVoteDataKey } from "constant";
-import { useHandleError } from "hooks/helpers/useHandleError";
 import { getAugmentedVoteData } from "web3";
 import { useActiveVotes } from "./useActiveVotes";
 import { usePastVotes } from "./usePastVotes";
@@ -14,7 +13,6 @@ export function useAugmentedVoteData() {
     data: { upcomingVotes },
   } = useUpcomingVotes();
   const { data: pastVotes } = usePastVotes();
-  const { onError, clearErrors } = useHandleError({ isDataFetching: true });
 
   const allVotes = { ...activeVotes, ...upcomingVotes, ...pastVotes };
 
@@ -22,8 +20,6 @@ export function useAugmentedVoteData() {
     queryKey: [augmentedVoteDataKey, activeVotes, upcomingVotes, pastVotes],
     queryFn: () => getAugmentedVoteData(allVotes),
     initialData: {},
-    onError,
-    onSuccess: clearErrors,
   });
 
   return queryResult;

--- a/hooks/queries/votes/useDecodedAdminTransactions.ts
+++ b/hooks/queries/votes/useDecodedAdminTransactions.ts
@@ -1,11 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { decodedAdminTransactionsKey } from "constant";
-import {
-  useActiveVotes,
-  useHandleError,
-  usePastVotes,
-  useUpcomingVotes,
-} from "hooks";
+import { useActiveVotes, usePastVotes, useUpcomingVotes } from "hooks";
 import { getDecodedAdminTransactions } from "web3";
 
 export function useDecodedAdminTransactions() {
@@ -16,7 +11,6 @@ export function useDecodedAdminTransactions() {
     data: { upcomingVotes },
   } = useUpcomingVotes();
   const { data: pastVotes } = usePastVotes();
-  const { onError, clearErrors } = useHandleError({ isDataFetching: true });
 
   const governanceVoteIdentifiers = Object.entries({
     ...activeVotes,
@@ -35,8 +29,6 @@ export function useDecodedAdminTransactions() {
     ],
     queryFn: () => getDecodedAdminTransactions(governanceVoteIdentifiers),
     initialData: {},
-    onError,
-    onSuccess: clearErrors,
   });
 
   return queryResult;


### PR DESCRIPTION
The app still works fine without decoded admin data and augmented vote data — they are enhancements. In the event that something goes wrong with them (in the serverless functions) we don't want to make the user think that the _whole_ app is broken by showing a "error fetching vote data" error.