### PR TITLE
fix: ensure we clear contracts with signers when it changes

### DIFF
--- a/components/Wallet/Wallet.tsx
+++ b/components/Wallet/Wallet.tsx
@@ -78,6 +78,9 @@ export function Wallet() {
   useEffect(() => {
     if (!wallet?.provider) {
       setProvider(null);
+      setSigner(null);
+      setVoting(createVotingContractInstance());
+      setVotingToken(createVotingTokenContractInstance());
     } else {
       // After this is set you can use the provider to sign or transact
       const provider = new ethers.providers.Web3Provider(wallet.provider);


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

This will clear any contracts which have a previous signer in it. this may help prevent the problem where we can possibly submit a transaction based on another wallet account. 