### PR TITLE
improve: add explicit signing button

### DIFF
--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -7,10 +7,10 @@ import {
   VotesTableHeadings,
   VoteTimeline,
 } from "components";
+import { useConnectWallet } from "@web3-onboard/react";
 import { defaultResultsPerPage } from "constant";
 import { formatVotesToCommit, getEntriesForPage } from "helpers";
 import {
-  useAccountDetails,
   useCommitVotes,
   useContractsContext,
   useDelegationContext,
@@ -21,6 +21,7 @@ import {
   useVotesContext,
   useVoteTimingContext,
   useWalletContext,
+  useUserContext,
 } from "hooks";
 import { useState } from "react";
 import styled from "styled-components";
@@ -34,9 +35,10 @@ export function Votes() {
     getActivityStatus,
     getUserDependentIsFetching,
   } = useVotesContext();
+  const [{ connecting: isConnectingWallet }, connect] = useConnectWallet();
   const { phase, roundId } = useVoteTimingContext();
-  const { address } = useAccountDetails();
-  const { signer, signingKeys } = useWalletContext();
+  const { address, hasSigningKey } = useUserContext();
+  const { signer, signingKeys, sign, isSigning } = useWalletContext();
   const { voting } = useContractsContext();
   const { stakedBalance, delegatorStakedBalance } = useStakingContext();
   const { getDelegationStatus } = useDelegationContext();
@@ -50,26 +52,136 @@ export function Votes() {
   } = usePaginationContext();
   const [selectedVotes, setSelectedVotes] = useState<SelectedVotesByKeyT>({});
 
-  const isCommit = phase === "commit";
-  const isReveal = phase === "reveal";
-  const hasStaked = stakedBalance?.gt(0) ?? false;
-  const hasDelegatorStaked = delegatorStakedBalance?.gt(0) ?? false;
-  const hasSigner = !!signer;
-  const hasVotesToCommit = Object.keys(selectedVotes).length > 0;
-  const hasVotesToReveal = getVotesToReveal().length > 0;
-  const isButtonDisabled =
-    (isCommit && !canCommit()) || (isReveal && !canReveal());
-  const disabledButtonExplanation = getDisabledButtonExplanation();
-  const buttonLabel = isCommit ? "Commit Votes" : "Reveal Votes";
-  const buttonOnClick = isCommit ? commitVotes : revealVotes;
   const votesToShow = getEntriesForPage(
     pageNumber,
     resultsPerPage,
     determineVotesToShow()
   );
+  const actionStatus = calculateActionStatus();
+  type ActionStatus = {
+    tooltip?: string;
+    label: string;
+    onClick: () => any;
+    disabled?: boolean;
+    hidden?: boolean;
+    canCommit: boolean;
+    canReveal: boolean;
+  };
+  function calculateActionStatus(): ActionStatus {
+    const actionConfig: ActionStatus = {
+      hidden: true,
+      tooltip: "",
+      label: "",
+      onClick: () => undefined,
+      disabled: true,
+      canCommit: false,
+      canReveal: false,
+    };
 
+    const isCommit = phase === "commit";
+    const isReveal = phase === "reveal";
+    const hasStaked = stakedBalance?.gt(0) ?? false;
+    const hasDelegatorStaked = delegatorStakedBalance?.gt(0) ?? false;
+    const isDelegate = getDelegationStatus() === "delegate";
+    const hasSigner = !!signer;
+    const hasVotesToCommit = Object.keys(selectedVotes).length > 0;
+    const hasVotesToReveal = getVotesToReveal().length > 0;
+
+    if (!hasSigner || !address) {
+      actionConfig.hidden = false;
+      actionConfig.disabled = false;
+      actionConfig.label = "Connect Wallet";
+      actionConfig.tooltip = "Connect your wallet to commit or reveal votes.";
+      actionConfig.onClick = () => connect();
+
+      if (isConnectingWallet) {
+        actionConfig.disabled = true;
+      }
+      return actionConfig;
+    }
+    if (isCommit) {
+      actionConfig.label = "Commit";
+      actionConfig.hidden = false;
+      if (isCommittingVotes) {
+        actionConfig.disabled = true;
+        actionConfig.tooltip = "Committing votes in progress...";
+        return actionConfig;
+      }
+      if (isDelegate) {
+        if (!hasDelegatorStaked) {
+          actionConfig.disabled = true;
+          actionConfig.tooltip =
+            "You cannot commit because your delegator has no UMA Staked.";
+          return actionConfig;
+        }
+      } else {
+        if (!hasStaked) {
+          actionConfig.disabled = true;
+          actionConfig.tooltip =
+            "You cannot commit because you have no UMA Staked.";
+          return actionConfig;
+        }
+      }
+      if (!hasSigningKey) {
+        actionConfig.label = "Sign";
+        actionConfig.tooltip = "You must first sign before you can commit.";
+        actionConfig.onClick = () => sign();
+        actionConfig.disabled = false;
+
+        if (isSigning) {
+          actionConfig.disabled = true;
+          actionConfig.tooltip =
+            "Confirm the request for a signature in your wallet software.";
+          return actionConfig;
+        }
+        return actionConfig;
+      }
+      if (!hasVotesToCommit) {
+        actionConfig.disabled = true;
+        actionConfig.tooltip =
+          "You must enter your votes before you can continue.";
+        return actionConfig;
+      }
+      actionConfig.canCommit = true;
+      actionConfig.disabled = false;
+      actionConfig.onClick = () => commitVotes();
+      return actionConfig;
+    }
+    if (isReveal) {
+      actionConfig.hidden = false;
+      actionConfig.label = "Reveal";
+      if (!hasSigningKey) {
+        actionConfig.label = "Sign";
+        actionConfig.tooltip = "You must first sign before you can reveal.";
+        actionConfig.onClick = () => sign();
+        actionConfig.disabled = false;
+        if (isSigning) {
+          actionConfig.disabled = true;
+          actionConfig.tooltip =
+            "Confirm the request for a signature in your wallet software.";
+          return actionConfig;
+        }
+        return actionConfig;
+      }
+      if (isRevealingVotes) {
+        actionConfig.disabled = true;
+        actionConfig.tooltip = "Revealing votes in progress...";
+        return actionConfig;
+      }
+      if (!hasVotesToReveal) {
+        actionConfig.disabled = true;
+        actionConfig.tooltip = "You have no votes to reveal.";
+        return actionConfig;
+      }
+      actionConfig.canReveal = true;
+      actionConfig.disabled = false;
+      actionConfig.onClick = () => revealVotes();
+      return actionConfig;
+    }
+    return actionConfig;
+  }
   async function commitVotes() {
-    if (!address || !canCommit()) return;
+    if (!actionStatus.canCommit) return;
 
     const formattedVotes = await formatVotesToCommit({
       votes: getActiveVotes(),
@@ -93,13 +205,14 @@ export function Votes() {
   }
 
   function revealVotes() {
-    if (!address || !canReveal()) return;
+    if (!actionStatus.canReveal) return;
 
     revealVotesMutation({
       voting,
       votesToReveal: getVotesToReveal(),
     });
   }
+
   function getVotesToReveal() {
     return getActiveVotes().filter(
       (vote) =>
@@ -130,32 +243,6 @@ export function Votes() {
     }
   }
 
-  function canCommit() {
-    if (getDelegationStatus() === "delegate") {
-      return canCommitAsDelegate();
-    }
-    return (
-      isCommit &&
-      hasVotesToCommit &&
-      hasStaked &&
-      hasSigner &&
-      !isCommittingVotes
-    );
-  }
-  function canCommitAsDelegate() {
-    return (
-      isCommit &&
-      hasVotesToCommit &&
-      hasSigner &&
-      !isCommittingVotes &&
-      hasDelegatorStaked
-    );
-  }
-
-  function canReveal() {
-    return isReveal && hasVotesToReveal && !isRevealingVotes;
-  }
-
   function determineTitle() {
     const status = getActivityStatus();
     switch (status) {
@@ -166,45 +253,6 @@ export function Votes() {
       default:
         return "Past votes:";
     }
-  }
-
-  function getDisabledButtonExplanation() {
-    const connectWalletToCommitVotesMessage =
-      "Connect your wallet to commit or reveal votes.";
-    const selectVotesToCommitMessage =
-      "Add your answers to some votes to commit.";
-    const didNotCommitSoCannotRevealMessage =
-      "You cannot reveal votes this round because you did not commit any votes.";
-    const hasStakedMessage = "You must stake UMA to commit or reveal votes.";
-    const busyCommittingVotesMessage = "Committing votes...";
-    const busyRevealingVotesMessage = "Revealing votes...";
-
-    if (!hasSigner) {
-      return connectWalletToCommitVotesMessage;
-    }
-    if (!hasStaked) {
-      return hasStakedMessage;
-    }
-
-    if (isCommit) {
-      if (!hasVotesToCommit) {
-        return selectVotesToCommitMessage;
-      }
-      if (isCommittingVotes) {
-        return busyCommittingVotesMessage;
-      }
-    }
-
-    if (isReveal) {
-      if (!hasVotesToReveal) {
-        return didNotCommitSoCannotRevealMessage;
-      }
-      if (isRevealingVotes) {
-        return busyRevealingVotesMessage;
-      }
-    }
-
-    return "";
   }
 
   return (
@@ -235,24 +283,27 @@ export function Votes() {
       </VotesTableWrapper>
       {getActivityStatus() === "active" ? (
         <CommitVotesButtonWrapper>
-          {isButtonDisabled ? (
-            <Tooltip label={disabledButtonExplanation}>
-              <div>
-                <Button
-                  variant="primary"
-                  label={buttonLabel}
-                  onClick={buttonOnClick}
-                  disabled
-                />
-              </div>
-            </Tooltip>
-          ) : (
-            <Button
-              variant="primary"
-              label={buttonLabel}
-              onClick={buttonOnClick}
-            />
-          )}
+          {!actionStatus.hidden ? (
+            actionStatus.tooltip ? (
+              <Tooltip label={actionStatus.tooltip}>
+                <div>
+                  <Button
+                    variant="primary"
+                    label={actionStatus.label}
+                    onClick={actionStatus.onClick}
+                    disabled={actionStatus.disabled}
+                  />
+                </div>
+              </Tooltip>
+            ) : (
+              <Button
+                variant="primary"
+                label={actionStatus.label}
+                onClick={actionStatus.onClick}
+                disabled={actionStatus.disabled}
+              />
+            )
+          ) : null}
         </CommitVotesButtonWrapper>
       ) : null}
       {determineVotesToShow().length > defaultResultsPerPage && (

--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -70,7 +70,7 @@ export function Votes() {
   function calculateActionStatus(): ActionStatus {
     const actionConfig: ActionStatus = {
       hidden: true,
-      tooltip: "",
+      tooltip: undefined,
       label: "",
       onClick: () => undefined,
       disabled: true,
@@ -91,7 +91,6 @@ export function Votes() {
       actionConfig.hidden = false;
       actionConfig.disabled = false;
       actionConfig.label = "Connect Wallet";
-      actionConfig.tooltip = "Connect your wallet to commit or reveal votes.";
       actionConfig.onClick = () => connect();
 
       if (isConnectingWallet) {
@@ -124,7 +123,6 @@ export function Votes() {
       }
       if (!hasSigningKey) {
         actionConfig.label = "Sign";
-        actionConfig.tooltip = "You must first sign before you can commit.";
         actionConfig.onClick = () => sign();
         actionConfig.disabled = false;
 
@@ -152,7 +150,6 @@ export function Votes() {
       actionConfig.label = "Reveal";
       if (!hasSigningKey) {
         actionConfig.label = "Sign";
-        actionConfig.tooltip = "You must first sign before you can reveal.";
         actionConfig.onClick = () => sign();
         actionConfig.disabled = false;
         if (isSigning) {

--- a/components/Wallet/Wallet.tsx
+++ b/components/Wallet/Wallet.tsx
@@ -1,7 +1,6 @@
 import { useConnectWallet, useSetChain, useWallets } from "@web3-onboard/react";
-import { signingMessage, wrongChainMessage } from "constant";
+import { wrongChainMessage } from "constant";
 import { ethers } from "ethers";
-import { derivePrivateKey, recoverPublicKey } from "helpers";
 import {
   useContractsContext,
   useErrorContext,
@@ -11,7 +10,6 @@ import {
 } from "hooks";
 import { useEffect } from "react";
 import styled from "styled-components";
-import { SigningKey, SigningKeys } from "types";
 import {
   createVotingContractInstance,
   createVotingTokenContractInstance,
@@ -22,10 +20,10 @@ export function Wallet() {
   const [{ wallet, connecting }, connect] = useConnectWallet();
   const [{ connectedChain }, setChain] = useSetChain();
   const connectedWallets = useWallets();
-  const { setProvider, setSigner, setSigningKeys } = useWalletContext();
+  const { setProvider, setSigner } = useWalletContext();
   const { setVoting, setVotingToken } = useContractsContext();
   const { openPanel } = usePanelContext();
-  const { address, truncatedAddress } = useUserContext();
+  const { truncatedAddress } = useUserContext();
   const { addErrorMessage, removeErrorMessage } = useErrorContext();
 
   useEffect(() => {
@@ -84,51 +82,16 @@ export function Wallet() {
     } else {
       // After this is set you can use the provider to sign or transact
       const provider = new ethers.providers.Web3Provider(wallet.provider);
-      setProvider(provider);
       const signer = provider.getSigner();
+
+      setProvider(provider);
       setSigner(signer);
       // if a signer exists, we can change the voting contract instance to use it instead of the default `VoidSigner`
       setVoting(createVotingContractInstance(signer));
       setVotingToken(createVotingTokenContractInstance(signer));
-      void (async () => {
-        const savedSigningKeys = getSavedSigningKeys();
-        if (savedSigningKeys[address]) {
-          setSigningKeys(savedSigningKeys);
-        } else {
-          const newSigningKey = await makeSigningKey(signer, signingMessage);
-          const newSigningKeys = {
-            ...savedSigningKeys,
-            [address]: newSigningKey,
-          };
-          setSigningKeys(newSigningKeys);
-          saveSigningKeys(newSigningKeys);
-        }
-      })();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wallet]);
-
-  async function makeSigningKey(signer: ethers.Signer, message: string) {
-    const signedMessage = await signer.signMessage(message);
-    const privateKey = derivePrivateKey(signedMessage);
-    const publicKey = recoverPublicKey(privateKey);
-    return {
-      privateKey,
-      publicKey,
-      signedMessage,
-    } as SigningKey;
-  }
-
-  function saveSigningKeys(newSigningKeys: SigningKeys) {
-    localStorage.setItem("signingKeys", JSON.stringify(newSigningKeys));
-  }
-
-  function getSavedSigningKeys() {
-    const savedSigningKeys = localStorage.getItem("signingKeys");
-    return savedSigningKeys
-      ? (JSON.parse(savedSigningKeys) as SigningKeys)
-      : {};
-  }
 
   function openMenuPanel() {
     openPanel("menu");

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -1,9 +1,13 @@
 import { WalletState } from "@web3-onboard/core";
 import { Account } from "@web3-onboard/core/dist/types";
 import { BigNumber } from "ethers";
-import { useAccountDetails, useUserVotingAndStakingDetails } from "hooks";
+import {
+  useAccountDetails,
+  useUserVotingAndStakingDetails,
+  useWalletContext,
+} from "hooks";
 import { createContext, ReactNode } from "react";
-import { VoteHistoryByKeyT } from "types";
+import { VoteHistoryByKeyT, SigningKey } from "types";
 
 export interface UserContextState {
   connectedWallet: WalletState | undefined;
@@ -21,6 +25,8 @@ export interface UserContextState {
   voteHistoryByKey: VoteHistoryByKeyT | undefined;
   userDataLoading: boolean;
   userDataFetching: boolean;
+  signingKey: SigningKey | undefined;
+  hasSigningKey: boolean;
 }
 
 export const defaultUserContextState: UserContextState = {
@@ -39,6 +45,8 @@ export const defaultUserContextState: UserContextState = {
   voteHistoryByKey: {},
   userDataLoading: false,
   userDataFetching: false,
+  signingKey: undefined,
+  hasSigningKey: false,
 };
 
 export const UserContext = createContext<UserContextState>(
@@ -48,6 +56,8 @@ export const UserContext = createContext<UserContextState>(
 export function UserProvider({ children }: { children: ReactNode }) {
   const { connectedWallet, account, address, truncatedAddress } =
     useAccountDetails();
+  const { signingKeys } = useWalletContext();
+
   const {
     data: {
       apr,
@@ -64,6 +74,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
   } = useUserVotingAndStakingDetails();
 
   const walletIcon = connectedWallet?.icon;
+  const signingKey = signingKeys[address];
 
   return (
     <UserContext.Provider
@@ -83,6 +94,8 @@ export function UserProvider({ children }: { children: ReactNode }) {
         voteHistoryByKey,
         userDataLoading,
         userDataFetching,
+        signingKey,
+        hasSigningKey: !!signingKey,
       }}
     >
       {children}

--- a/contexts/WalletContext.tsx
+++ b/contexts/WalletContext.tsx
@@ -1,8 +1,9 @@
 import { OnboardAPI } from "@web3-onboard/core";
 import { ethers } from "ethers";
-import { initOnboard } from "helpers";
+import { initOnboard, getSavedSigningKeys } from "helpers";
 import { createContext, ReactNode, useState } from "react";
 import { SigningKeys } from "types";
+import { useSign } from "hooks";
 
 export interface WalletContextState {
   onboard: OnboardAPI | null;
@@ -13,6 +14,8 @@ export interface WalletContextState {
   setSigner: (signer: ethers.Signer | null) => void;
   signingKeys: SigningKeys;
   setSigningKeys: (signingKeys: SigningKeys) => void;
+  sign: () => void;
+  isSigning: boolean;
 }
 
 export const defaultWalletContextState = {
@@ -24,6 +27,8 @@ export const defaultWalletContextState = {
   setSigner: () => null,
   signingKeys: {},
   setSigningKeys: () => null,
+  sign: () => null,
+  isSigning: false,
 };
 
 export const WalletContext = createContext<WalletContextState>(
@@ -35,7 +40,14 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const [provider, setProvider] =
     useState<ethers.providers.Web3Provider | null>(null);
   const [signer, setSigner] = useState<ethers.Signer | null>(null);
-  const [signingKeys, setSigningKeys] = useState<SigningKeys>({});
+  const [signingKeys, setSigningKeys] = useState<SigningKeys>(
+    getSavedSigningKeys()
+  );
+
+  const { mutate: sign, isLoading: isSigning } = useSign(
+    signer,
+    setSigningKeys
+  );
 
   return (
     <WalletContext.Provider
@@ -48,6 +60,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         setSigner,
         signingKeys,
         setSigningKeys,
+        sign,
+        isSigning,
       }}
     >
       {children}

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -22,3 +22,4 @@ export * from "./web3/events";
 export { initOnboard } from "./web3/initOnboard";
 export { truncateEthAddress } from "./web3/truncateEthAddress";
 export * from "./web3/wallet";
+export * from "./web3/signing";

--- a/helpers/voting/formatVotes.ts
+++ b/helpers/voting/formatVotes.ts
@@ -57,6 +57,7 @@ export async function formatVotesToCommit({
         selectedVote,
         decodedIdentifier
       );
+
       // the hash must be created with exactly these values in exactly this order
       const hash = makeVoteHash(
         price,

--- a/helpers/web3/signing.ts
+++ b/helpers/web3/signing.ts
@@ -1,0 +1,46 @@
+import { ethers } from "ethers";
+import { SigningKeys, SigningKey } from "types";
+import { signingMessage } from "constant";
+import { derivePrivateKey, recoverPublicKey } from "helpers";
+
+type Signer = ethers.Signer;
+
+export async function sign(signer: Signer): Promise<SigningKeys> {
+  const address = await signer.getAddress();
+  const savedSigningKeys = getSavedSigningKeys();
+  const signingKey = savedSigningKeys[address];
+  if (signingKey) {
+    return savedSigningKeys;
+  }
+  const newSigningKey = await makeSigningKey(signer, signingMessage);
+  const newSigningKeys = {
+    ...savedSigningKeys,
+    [address]: newSigningKey,
+  };
+  saveSigningKeys(newSigningKeys);
+  return newSigningKeys;
+}
+export async function makeSigningKey(
+  signer: ethers.Signer,
+  message: string
+): Promise<SigningKey> {
+  const signedMessage = await signer.signMessage(message);
+  const privateKey = derivePrivateKey(signedMessage);
+  const publicKey = recoverPublicKey(privateKey);
+  return {
+    privateKey,
+    publicKey,
+    signedMessage,
+  };
+}
+
+export function saveSigningKeys(newSigningKeys: SigningKeys): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem("signingKeys", JSON.stringify(newSigningKeys));
+}
+
+export function getSavedSigningKeys(): SigningKeys {
+  if (typeof window === "undefined") return {};
+  const savedSigningKeys = window.localStorage.getItem("signingKeys");
+  return savedSigningKeys ? (JSON.parse(savedSigningKeys) as SigningKeys) : {};
+}

--- a/hooks/helpers/useSign.ts
+++ b/hooks/helpers/useSign.ts
@@ -1,0 +1,14 @@
+import { useMutation } from "@tanstack/react-query";
+import { SigningKeys } from "types";
+import { sign } from "helpers";
+import { ethers } from "ethers";
+
+export function useSign(
+  signer: ethers.Signer | null | undefined,
+  setSigningKeys: (signingKeys: SigningKeys) => void
+) {
+  return useMutation(async () => (signer ? sign(signer) : {}), {
+    onError: (error) => console.error("Error signing:", error),
+    onSuccess: setSigningKeys,
+  });
+}

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -64,3 +64,4 @@ export { useDelegatorStakedBalance } from "./queries/staking/useDelegatorStakedB
 export { useCommittedVotes } from "./queries/votes/useCommittedVotes";
 export { useCommittedVotesByCaller } from "./queries/votes/useCommittedVotesByCaller";
 export { useCommittedVotesForDelegator } from "./queries/delegation/useCommittedVotesForDelegator";
+export { useSign } from "./helpers/useSign";

--- a/hooks/queries/votes/useDecryptedVotes.ts
+++ b/hooks/queries/votes/useDecryptedVotes.ts
@@ -1,12 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { decryptedVotesKey } from "constant";
 import { decryptMessage } from "helpers";
-import {
-  useAccountDetails,
-  useEncryptedVotes,
-  useHandleError,
-  useWalletContext,
-} from "hooks";
+import { useEncryptedVotes, useHandleError, useUserContext } from "hooks";
 import {
   DecryptedVotesByKeyT,
   DecryptedVoteT,
@@ -14,14 +9,13 @@ import {
 } from "types";
 
 export function useDecryptedVotes() {
-  const { address } = useAccountDetails();
-  const { signingKeys } = useWalletContext();
+  const { address, signingKey } = useUserContext();
   const { data: encryptedVotes } = useEncryptedVotes();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [decryptedVotesKey, encryptedVotes, address],
-    () => decryptVotes(signingKeys[address]?.privateKey, encryptedVotes),
+    () => decryptVotes(signingKey?.privateKey, encryptedVotes),
     {
       enabled: !!address,
       initialData: {},

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -24,8 +24,8 @@ function MyApp({ Component, pageProps }: AppProps) {
     <ErrorProvider>
       <NotificationsProvider>
         <VoteTimingProvider>
-          <WalletProvider>
-            <QueryClientProvider client={queryClient}>
+          <QueryClientProvider client={queryClient}>
+            <WalletProvider>
               <UserProvider>
                 <ContractsProvider>
                   <PaginationProvider>
@@ -45,8 +45,8 @@ function MyApp({ Component, pageProps }: AppProps) {
                 </ContractsProvider>
                 <ReactQueryDevtools />
               </UserProvider>
-            </QueryClientProvider>
-          </WalletProvider>
+            </WalletProvider>
+          </QueryClientProvider>
         </VoteTimingProvider>
       </NotificationsProvider>
     </ErrorProvider>


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

## motiviation
When first opening the page metamask immediately asks us to sign a message. If this message is cancelled by the user, theres no clear way to re-sign without reloading the page. Would notice that multiple signature requests would be sent to users metamask. Additionally commit/reveal were not disabled if the user had not signed.

## fix
This gives you an explicit button to "sign"  with a tooltip before you can commit or reveal. We also refactor our button display logic to help make this more managable. 

![image](https://user-images.githubusercontent.com/4429761/207670324-db464551-e403-4250-a3ce-ffac47ad0b3d.png)
![image](https://user-images.githubusercontent.com/4429761/207670390-bd4007a7-bcaa-43bb-a015-7728c23f7179.png)
![image](https://user-images.githubusercontent.com/4429761/207670459-a5294300-aad8-4794-8c0f-8fa9beb2576f.png)

## testing
to test this new flow, you must clear your application cache.
![image](https://user-images.githubusercontent.com/4429761/207670859-4d38b275-92af-4c40-9605-5399fcd676f0.png)
