### PR TITLE
improve: remove references to goerli, allow path to add chains

### DIFF
--- a/components/Notifications/Notification.tsx
+++ b/components/Notifications/Notification.tsx
@@ -5,6 +5,7 @@ import Close from "public/assets/icons/close.svg";
 import Warning from "public/assets/icons/warning.svg";
 import styled from "styled-components";
 import { NotificationT, UniqueIdT } from "types";
+import { config } from "helpers/config";
 
 export function Notification({
   message,
@@ -38,7 +39,7 @@ export function Notification({
         <Message>{message}</Message>
         {transactionHash && (
           <Link
-            href={`https://goerli.etherscan.io/tx/${transactionHash}`}
+            href={config.makeTransactionHashLink(transactionHash)}
             target="_blank"
           >
             View on Etherscan

--- a/components/Panel/DelegationPanel.tsx
+++ b/components/Panel/DelegationPanel.tsx
@@ -22,6 +22,7 @@ import styled, { css } from "styled-components";
 import { PanelFooter } from "./PanelFooter";
 import { PanelTitle } from "./PanelTitle";
 import { PanelSectionText, PanelSectionTitle, PanelWrapper } from "./styles";
+import { config } from "helpers/config";
 
 export function DelegationPanel() {
   const { closePanel } = usePanelContext();
@@ -161,7 +162,7 @@ export function DelegationPanel() {
                       </PendingRequestText>
                       <PendingRequestText>
                         <Link
-                          href={`https://goerli.etherscan.io/tx/${transactionHash}`}
+                          href={config.makeTransactionHashLink(transactionHash)}
                           target="_blank"
                         >
                           View Transaction

--- a/components/Panel/MenuPanel/MenuPanel.tsx
+++ b/components/Panel/MenuPanel/MenuPanel.tsx
@@ -9,6 +9,7 @@ import Time from "public/assets/icons/time-with-inner-circle.svg";
 import styled from "styled-components";
 import { PanelFooter } from "../PanelFooter";
 import { PanelWrapper } from "../styles";
+import { config } from "helpers/config";
 
 export function MenuPanel() {
   const [_wallets, connect, disconnect] = useConnectWallet();
@@ -161,10 +162,9 @@ export function MenuPanel() {
                         </Link>{" "}
                         to be delegate {toOrFrom} address{" "}
                         <Link
-                          href={`https://goerli.etherscan.io/address/${getPendingRequestAddress(
-                            delegator,
-                            delegate
-                          )}`}
+                          href={config.makeTransactionHashLink(
+                            getPendingRequestAddress(delegator, delegate)
+                          )}
                           target="_blank"
                         >
                           {truncateEthAddress(

--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -62,15 +62,13 @@ export function Details({
     umipOrUppLink,
     makeTransactionHashLink(
       "Ethereum DVM request",
-      augmentedData?.l1RequestTxHash,
-      false
+      augmentedData?.l1RequestTxHash
     ),
     // only show if the originating chain id is not ethereum
     augmentedData?.originatingChainId && augmentedData?.originatingChainId !== 1
       ? makeTransactionHashLink(
           `${supportedChains[augmentedData.originatingChainId]} DVM request`,
-          augmentedData.originatingChainTxHash,
-          false
+          augmentedData.originatingChainTxHash
         )
       : false,
     makeOoRequestLink(),

--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -22,6 +22,7 @@ import UMA from "public/assets/icons/uma.svg";
 import { CSSProperties, ReactNode, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { ActivityStatusT, DropdownItemT, VotePhaseT, VoteT } from "types";
+import { config } from "helpers/config";
 export interface Props {
   vote: VoteT;
   phase: VotePhaseT;
@@ -242,10 +243,7 @@ export function VotesListItem({
   function getRelevantTransactionLink(): ReactNode | string {
     if (phase === "commit") {
       return commitHash ? (
-        <Link
-          href={`https://goerli.etherscan.io/tx/${commitHash}`}
-          target="_blank"
-        >
+        <Link href={config.makeTransactionHashLink(commitHash)} target="_blank">
           {getCommittedOrRevealed()}
         </Link>
       ) : (
@@ -253,10 +251,7 @@ export function VotesListItem({
       );
     }
     return revealHash ? (
-      <Link
-        href={`https://goerli.etherscan.io/tx/${revealHash}`}
-        target="_blank"
-      >
+      <Link href={config.makeTransactionHashLink(revealHash)} target="_blank">
         {getCommittedOrRevealed()}
       </Link>
     ) : (

--- a/components/Wallet/Wallet.tsx
+++ b/components/Wallet/Wallet.tsx
@@ -17,7 +17,7 @@ import {
   createVotingTokenContractInstance,
 } from "web3";
 import { WalletIcon } from "./WalletIcon";
-import { appConfig } from "helpers/config";
+import { config } from "helpers/config";
 
 export function Wallet() {
   const [{ wallet, connecting }, connect] = useConnectWallet();
@@ -98,7 +98,7 @@ export function Wallet() {
         } else {
           const newSigningKey = await makeSigningKey(
             signer,
-            appConfig.signingMessage
+            config.signingMessage
           );
           const newSigningKeys = {
             ...savedSigningKeys,

--- a/components/pages/WalletSettings/PendingRequests.tsx
+++ b/components/pages/WalletSettings/PendingRequests.tsx
@@ -12,6 +12,7 @@ import {
   Header,
   Text,
 } from "./styles";
+import { config } from "helpers/config";
 
 export function PendingRequests({
   requestType,
@@ -105,7 +106,7 @@ export function PendingRequests({
             <Text>
               Waiting for approval |{" "}
               <NextLink
-                href={`https://goerli.etherscan.io/tx/${transactionHash}`}
+                href={config.makeTransactionHashLink(transactionHash)}
                 passHref
               >
                 <A target="_blank">View Transaction</A>

--- a/constant/misc/errorMessages.ts
+++ b/constant/misc/errorMessages.ts
@@ -1,4 +1,6 @@
+import {config} from 'helpers/config';
+
 export const errorFetchingVoteDataMessage =
   "Something went wrong while fetching vote data. Please refresh the page and try again.";
-export const wrongChainMessage =
-  "Your wallet is connected to the wrong chain. Please switch to goerli and try again.";
+
+export const wrongChainMessage = `Your wallet is connected to the wrong chain. Please switch to ${config.properName} and try again.`;

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -1,4 +1,4 @@
-import { appConfig } from "helpers/config";
+import { config } from "helpers/config";
 import { BigNumber } from "ethers";
 import request, { gql } from "graphql-request";
 import {
@@ -9,7 +9,7 @@ import {
 } from "helpers";
 import { PastVotesQuery } from "types";
 
-const { graphEndpoint, graphEndpointV1 } = appConfig;
+const { graphEndpoint, graphEndpointV1 } = config;
 
 export async function getPastVotesV1() {
   const endpoint = graphEndpointV1;

--- a/graph/queries/getUserVotingAndStakingDetails.ts
+++ b/graph/queries/getUserVotingAndStakingDetails.ts
@@ -6,8 +6,8 @@ import {
   VoteHistoryByKeyT,
   VoteHistoryT,
 } from "types";
-import { appConfig } from "helpers/config";
-const { graphEndpoint } = appConfig;
+import { config } from "helpers/config";
+const { graphEndpoint } = config;
 
 export async function getUserVotingAndStakingDetails(
   address: string | undefined

--- a/helpers/util/misc.ts
+++ b/helpers/util/misc.ts
@@ -1,4 +1,5 @@
 export const isExternalLink = (href: string) => !href.startsWith("/");
+import { config } from "helpers/config";
 
 export function capitalizeFirstLetter(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
@@ -6,14 +7,11 @@ export function capitalizeFirstLetter(str: string) {
 
 export function makeTransactionHashLink(
   label: string,
-  transactionHash: string | undefined,
-  isGoerli = true
+  transactionHash: string | undefined
 ) {
   if (!transactionHash) return;
   return {
     label,
-    href: `https://${
-      isGoerli ? "goerli." : ""
-    }etherscan.io/tx/${transactionHash}`,
+    href: config.makeTransactionHashLink(transactionHash),
   };
 }

--- a/helpers/web3/initOnboard.ts
+++ b/helpers/web3/initOnboard.ts
@@ -3,7 +3,7 @@ import injectedModule from "@web3-onboard/injected-wallets";
 import { init } from "@web3-onboard/react";
 import walletConnectModule from "@web3-onboard/walletconnect";
 import { logo } from "public/assets/logo";
-import { appConfig } from "helpers/config";
+import { config } from "helpers/config";
 
 const injected = injectedModule();
 const walletConnect = walletConnectModule();
@@ -11,20 +11,7 @@ const gnosis = gnosisModule();
 
 export const initOnboard = init({
   wallets: [injected, walletConnect, gnosis],
-  chains: [
-    {
-      id: "0x1",
-      token: "ETH",
-      label: "Ethereum",
-      rpcUrl: `https://mainnet.infura.io/v3/${appConfig.infuraId}`,
-    },
-    {
-      id: "0x5",
-      token: "GOR",
-      label: "Görli",
-      rpcUrl: `https://goerli.infura.io/v3/${appConfig.infuraId}`,
-    },
-  ],
+  chains: [config.onboardConfig],
   appMetadata: {
     name: "UMA 2.0",
     icon: logo,
@@ -34,7 +21,7 @@ export const initOnboard = init({
       { name: "MetaMask", url: "https://metamask.io" },
     ],
   },
-  apiKey: appConfig.blocknativeDappId,
+  apiKey: config.blocknativeDappId,
   notify: {
     enabled: false,
   },

--- a/web3/contracts/createVotingContractInstance.ts
+++ b/web3/contracts/createVotingContractInstance.ts
@@ -1,17 +1,14 @@
 import { VotingV2Ethers__factory } from "@uma/contracts-frontend";
 import { ethers } from "ethers";
-import { appConfig } from "helpers/config";
+import { config } from "helpers/config";
 
 export function createVotingContractInstance(signer?: ethers.Signer) {
   if (!signer) {
     const provider = new ethers.providers.InfuraProvider(
-      "goerli",
-      appConfig.infuraId
+      config.infuraName,
+      config.infuraId
     );
-    signer = new ethers.VoidSigner(appConfig.votingContractAddress, provider);
+    signer = new ethers.VoidSigner(config.votingContractAddress, provider);
   }
-  return VotingV2Ethers__factory.connect(
-    appConfig.votingContractAddress,
-    signer
-  );
+  return VotingV2Ethers__factory.connect(config.votingContractAddress, signer);
 }

--- a/web3/contracts/createVotingTokenContractInstance.ts
+++ b/web3/contracts/createVotingTokenContractInstance.ts
@@ -1,13 +1,13 @@
 import { VotingTokenEthers__factory } from "@uma/contracts-frontend";
 import { ethers } from "ethers";
-import { appConfig } from "helpers/config";
+import { config } from "helpers/config";
 
 export function createVotingTokenContractInstance(signer?: ethers.Signer) {
-  const address = appConfig.votingTokenContractAddress;
+  const address = config.votingTokenContractAddress;
   if (!signer) {
     const provider = new ethers.providers.InfuraProvider(
-      "goerli",
-      process.env.NEXT_PUBLIC_INFURA_ID
+      config.infuraName,
+      config.infuraId
     );
     signer = new ethers.VoidSigner(address, provider);
   }

--- a/web3/contracts/createVotingV1ContractInstance.ts
+++ b/web3/contracts/createVotingV1ContractInstance.ts
@@ -1,17 +1,14 @@
 import { VotingEthers__factory } from "@uma/contracts-frontend";
 import { ethers } from "ethers";
-import { appConfig } from "helpers/config";
+import { config } from "helpers/config";
 
 export function createVotingV1ContractInstance(signer?: ethers.Signer) {
   if (!signer) {
     const provider = new ethers.providers.InfuraProvider(
-      "goerli",
-      appConfig.infuraId
+      config.infuraName,
+      config.infuraId
     );
-    signer = new ethers.VoidSigner(appConfig.votingV1ContractAddress, provider);
+    signer = new ethers.VoidSigner(config.votingV1ContractAddress, provider);
   }
-  return VotingEthers__factory.connect(
-    appConfig.votingV1ContractAddress,
-    signer
-  );
+  return VotingEthers__factory.connect(config.votingV1ContractAddress, signer);
 }

--- a/web3/mutations/staking/approve.ts
+++ b/web3/mutations/staking/approve.ts
@@ -5,8 +5,8 @@ import {
   handleNotifications,
   maximumApprovalAmount,
 } from "helpers";
-import { appConfig } from "helpers/config";
-const { votingContractAddress } = appConfig;
+import { config } from "helpers/config";
+const { votingContractAddress } = config;
 
 export async function approve({
   votingToken,

--- a/web3/queries/staking/getTokenAllowance.ts
+++ b/web3/queries/staking/getTokenAllowance.ts
@@ -1,7 +1,7 @@
 import { VotingTokenEthers } from "@uma/contracts-frontend";
 
-import { appConfig } from "helpers/config";
-const { votingContractAddress } = appConfig;
+import { config } from "helpers/config";
+const { votingContractAddress } = config;
 
 export async function getTokenAllowance(
   votingTokenContract: VotingTokenEthers,

--- a/web3/queries/votes/getUpcomingVotes.ts
+++ b/web3/queries/votes/getUpcomingVotes.ts
@@ -1,15 +1,15 @@
 import { VotingV2Ethers } from "@uma/contracts-frontend";
 import { makePriceRequestsByKey } from "helpers";
 
-import { appConfig } from "helpers/config";
-const { goerliDeployBlock } = appConfig;
+import { config } from "helpers/config";
+const { deployBlock } = config;
 
 export async function getUpcomingVotes(
   voting: VotingV2Ethers,
   roundId: number
 ) {
   const filter = voting.filters.PriceRequestAdded(null, null, null);
-  const result = await voting.queryFilter(filter, goerliDeployBlock);
+  const result = await voting.queryFilter(filter, deployBlock);
   const eventData = result?.map(({ args }) => args);
   const onlyUpcoming = eventData?.filter(
     (event) => event.roundId.toNumber() > roundId


### PR DESCRIPTION
## motivation
we need to remove references to goerli from the app in order to prepare it to run on mainnet. 

## changes
this generalizes the app configuration, combines constants we need for each chain and selects it based on chain id specified in env.  i've tried to identify places in the app that were hard coded to goerli and replaced them with the generalized configuration. 

## important
This requires changes to vercels envs before this will run by removing references to goerli.  It also requires a new var that specifies the chain id the app is on. 