### PR TITLE
feat: add network switch button

### DIFF
--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -26,6 +26,7 @@ import {
 import { useState } from "react";
 import styled from "styled-components";
 import { SelectedVotesByKeyT, VoteT } from "types";
+import { config } from "helpers/config";
 
 export function Votes() {
   const {
@@ -37,8 +38,15 @@ export function Votes() {
   } = useVotesContext();
   const [{ connecting: isConnectingWallet }, connect] = useConnectWallet();
   const { phase, roundId } = useVoteTimingContext();
-  const { address, hasSigningKey } = useUserContext();
-  const { signer, signingKeys, sign, isSigning } = useWalletContext();
+  const { address, hasSigningKey, correctChainConnected } = useUserContext();
+  const {
+    signer,
+    signingKeys,
+    sign,
+    isSigning,
+    setCorrectChain,
+    isSettingChain,
+  } = useWalletContext();
   const { voting } = useContractsContext();
   const { stakedBalance, delegatorStakedBalance } = useStakingContext();
   const { getDelegationStatus } = useDelegationContext();
@@ -94,6 +102,17 @@ export function Votes() {
       actionConfig.onClick = () => connect();
 
       if (isConnectingWallet) {
+        actionConfig.disabled = true;
+      }
+      return actionConfig;
+    }
+    if (!correctChainConnected) {
+      actionConfig.hidden = false;
+      actionConfig.disabled = false;
+      actionConfig.label = `Switch To ${config.properName}`;
+      actionConfig.onClick = () => setCorrectChain();
+
+      if (isSettingChain) {
         actionConfig.disabled = true;
       }
       return actionConfig;

--- a/components/Wallet/Wallet.tsx
+++ b/components/Wallet/Wallet.tsx
@@ -15,10 +15,11 @@ import {
   createVotingTokenContractInstance,
 } from "web3";
 import { WalletIcon } from "./WalletIcon";
+import { config } from "helpers/config";
 
 export function Wallet() {
   const [{ wallet, connecting }, connect] = useConnectWallet();
-  const [{ connectedChain }, setChain] = useSetChain();
+  const [{ connectedChain }] = useSetChain();
   const connectedWallets = useWallets();
   const { setProvider, setSigner } = useWalletContext();
   const { setVoting, setVotingToken } = useContractsContext();
@@ -28,17 +29,13 @@ export function Wallet() {
 
   useEffect(() => {
     if (!connectedChain) return;
-
-    void (async () => {
-      if (connectedChain.id !== "0x5") {
-        addErrorMessage(wrongChainMessage);
-        await setChain({ chainId: "0x5" });
-      } else {
-        removeErrorMessage(wrongChainMessage);
-      }
-    })();
+    if (connectedChain.id !== config.onboardConfig.id) {
+      addErrorMessage(wrongChainMessage);
+    } else {
+      removeErrorMessage(wrongChainMessage);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectedChain?.id, setChain]);
+  }, [connectedChain?.id]);
 
   useEffect(() => {
     if (!connectedWallets.length) return;

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -8,6 +8,7 @@ import {
 } from "hooks";
 import { createContext, ReactNode } from "react";
 import { VoteHistoryByKeyT, SigningKey } from "types";
+import { config } from "helpers/config";
 
 export interface UserContextState {
   connectedWallet: WalletState | undefined;
@@ -27,6 +28,7 @@ export interface UserContextState {
   userDataFetching: boolean;
   signingKey: SigningKey | undefined;
   hasSigningKey: boolean;
+  correctChainConnected: boolean;
 }
 
 export const defaultUserContextState: UserContextState = {
@@ -47,6 +49,7 @@ export const defaultUserContextState: UserContextState = {
   userDataFetching: false,
   signingKey: undefined,
   hasSigningKey: false,
+  correctChainConnected: true,
 };
 
 export const UserContext = createContext<UserContextState>(
@@ -56,7 +59,7 @@ export const UserContext = createContext<UserContextState>(
 export function UserProvider({ children }: { children: ReactNode }) {
   const { connectedWallet, account, address, truncatedAddress } =
     useAccountDetails();
-  const { signingKeys } = useWalletContext();
+  const { signingKeys, connectedChainId } = useWalletContext();
 
   const {
     data: {
@@ -75,6 +78,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
 
   const walletIcon = connectedWallet?.icon;
   const signingKey = signingKeys[address];
+  const correctChainConnected = connectedChainId === config.chainId;
 
   return (
     <UserContext.Provider
@@ -96,6 +100,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         userDataFetching,
         signingKey,
         hasSigningKey: !!signingKey,
+        correctChainConnected,
       }}
     >
       {children}


### PR DESCRIPTION
## Motivation
Commit/reveal button was not being disabled when user was on wrong chain. 

## change
This changes the commit/reveal button behavior to allow the user to switch to the correct chain. 
![image](https://user-images.githubusercontent.com/4429761/208161500-0b92d830-3cc7-472d-91a4-f43d1523cd74.png)
This also removes the automatic behavior of immediately requesting metamask to switch chain, instead preferring the user explicitly click the button.

This is a slight issue becuase this button is hidden unlesss there is an active vote. will talk to jesper to see how we can resolve.