### PR TITLE
fix: fix crashing in chainicon

### DIFF
--- a/components/Panel/VotePanel/ChainIcon.tsx
+++ b/components/Panel/VotePanel/ChainIcon.tsx
@@ -19,6 +19,7 @@ export function ChainIcon({
 
   const icons = {
     1: EthereumIcon,
+    5: EthereumIcon,
     10: OptimismIcon,
     100: GnosisIcon,
     137: PolygonIcon,
@@ -27,8 +28,10 @@ export function ChainIcon({
     43114: AvalancheIcon,
     42161: ArbitrumIcon,
   };
+
   const chainName = supportedChains[chainId];
   const Icon = icons[chainId];
+  if (!Icon || !chainName) return null;
 
   return (
     <Wrapper>


### PR DESCRIPTION
This prevents crashing by explicitly checking that icon and chain name exists