### PR TITLE
fix: change connect button to primary colors

### DIFF
--- a/components/Wallet/Wallet.tsx
+++ b/components/Wallet/Wallet.tsx
@@ -129,9 +129,12 @@ const Wrapper = styled.div`
   justify-content: center;
   padding-inline: 15px;
   font: var(--text-md);
-  color: var(--black);
-  background-color: var(--grey-50);
+  color: var(--white);
+  background-color: var(--red-500);
   border-radius: 5px;
+  &:hover {
+    background-color: var(--red-600);
+  }
 `;
 
 const WalletButtonWrapper = styled.div``;


### PR DESCRIPTION
Changes connect button to use primary colors ( previously gray) 

![image](https://user-images.githubusercontent.com/4429761/208482043-9c3509a3-98a6-4cd3-80d6-fd1f61142972.png)
