### PR TITLE
feat: wire up discord api to discusstion panel

### DIFF
--- a/components/Panel/VotePanel/Discussion.tsx
+++ b/components/Panel/VotePanel/Discussion.tsx
@@ -6,46 +6,15 @@ import NextImage from "next/image";
 import Message from "public/assets/icons/message.svg";
 import ReactMarkdown from "react-markdown";
 import styled, { css } from "styled-components";
-import { DiscordMessageT, DiscordThreadT, VoteT } from "types";
+import { VoteT } from "types";
 import { PanelSectionTitle } from "../styles";
+import { useDiscordThread } from "hooks";
 
 export function Discussion({ identifier, time }: VoteT) {
-  const dummyMessages: DiscordMessageT[] = [
-    {
-      message:
-        "[https://etherscan.io/tx/0x1837b4f9c97f29d3d1dce36jc18f3d4aaebe6686ef006ba9b5e3b8b85aec371b4](https://etherscan.io/tx/0x1837b4f9c97f29d3d1dce36jc18f3d4aaebe6686ef006ba9b5e3b8b85aec371b4)",
-      sender: "Ry | UMA",
-      senderPicture: "/assets/placeholder-sender-picture.jpeg",
-      time: Math.floor(Date.now() / 1000).toString(),
-    },
-    {
-      message: `Longer text afessional boxing match between undefeated WBA, IBF, WBO lightweight champion George Kambosos Jr., and undefeated WBC lightweight champion Devin Haney. The fight will take place on June 5, 2022 at Marvel Stadium in Melbourne, Australia. If George Kambosos Jr. wins this fight, this market will resolve to "Kambosos". 
-
-If Devin Haney wins this fight, this market will resolve to "Haney". If this fight ends in a tie, is not officially designated as a win for either George Kambosos Jr. or Devin Haney, or otherwise is not decided by June 12, 2022, 11:59:59 PM ET, this market will resolve to 50-50
-        
-Here's my rationale lorem ipsum so I vote 1.`,
-      sender: "David | UMA",
-      senderPicture: "/assets/placeholder-sender-picture.jpeg",
-      time: (Math.floor(Date.now() / 1000) + 1000).toString(),
-    },
-    {
-      message:
-        `I will be voting NO (0) because the pool rebalance root is incorrect` +
-        "`REQUEST_TIME=1656639124 ts-node ./src/scripts/validateRootBundle.ts --wallet mnemonic" +
-        '"expectedPoolRebalanceRoot": "0xe277695f3f39270aa2497edf46b5b32c1514c43e75c5b88d6c97921a83d8a87d"' +
-        '"pendingRoot": "0x0770225954b17994684695e74ebb5c8880ccb5d3dddc3ff90a5ec169baee3bd0"`',
-      sender: "SomeGuy",
-      senderPicture: "/assets/placeholder-sender-picture.jpeg",
-      time: (Math.floor(Date.now() / 1000) + 2000).toString(),
-    },
-  ];
-
-  const dummyThread: DiscordThreadT = {
+  const { data: thread = { thread: [] } } = useDiscordThread({
     identifier,
     time,
-    thread: dummyMessages,
-  };
-
+  });
   return (
     <Wrapper>
       <Disclaimer>
@@ -63,18 +32,18 @@ Here's my rationale lorem ipsum so I vote 1.`,
           Discussion
         </PanelSectionTitle>
       </TitleSectionWrapper>
-      {dummyThread.thread.map(({ message, sender, senderPicture, time }) => (
+      {thread.thread.map(({ message, sender, senderPicture, time }) => (
         <SectionWrapper key={time}>
           <MessageWrapper>
             <ImageWrapper>
-              {senderPicture && (
+              {senderPicture ? (
                 <Image
                   src={senderPicture}
                   alt="Discord user avatar"
                   width={20}
                   height={20}
                 />
-              )}
+              ) : null}
             </ImageWrapper>
             <MessageContentWrapper>
               <SenderWrapper>

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -66,3 +66,4 @@ export { useCommittedVotesByCaller } from "./queries/votes/useCommittedVotesByCa
 export { useCommittedVotesForDelegator } from "./queries/delegation/useCommittedVotesForDelegator";
 export { useSign } from "./helpers/useSign";
 export { useGlobals } from "./queries/rewards/useGlobals";
+export { useDiscordThread } from "./queries/discord/useDiscordThread";

--- a/hooks/queries/discord/useDiscordThread.ts
+++ b/hooks/queries/discord/useDiscordThread.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getDiscordThread } from "web3";
+import { L1Request } from "types";
+
+export function useDiscordThread(params: L1Request) {
+  return useQuery({
+    queryKey: ["discordThread", params.identifier, params.time],
+    queryFn: () => getDiscordThread(params),
+    onError: (err) => console.error(err),
+  });
+}

--- a/next.config.js
+++ b/next.config.js
@@ -27,6 +27,14 @@ const nextConfig = {
 
     return config;
   },
+  images:{
+    remotePatterns:[
+      {
+        protocol: 'https',
+        hostname: 'cdn.discordapp.com',
+      }
+    ]
+  }
 };
 
 module.exports = nextConfig;

--- a/pages/api/discord-thread.ts
+++ b/pages/api/discord-thread.ts
@@ -1,15 +1,24 @@
 import { discordToken, evidenceRationalDiscordChannelId } from "constant";
 import { NextApiRequest, NextApiResponse } from "next";
 import {
-  DiscordMessageT,
   DiscordThreadT,
-  PriceRequestT,
   RawDiscordThreadT,
+  DiscordMessageT,
+  RawDiscordMessageT,
+  L1Request,
 } from "types";
+
+import * as ss from "superstruct";
+
+export const DiscordThreadRequestBody = ss.object({ l1Request: L1Request });
+export type DiscordThreadRequestBody = ss.Infer<
+  typeof DiscordThreadRequestBody
+>;
+
+if (discordToken === "") throw Error("DISCORD_TOKEN env variable not set!");
 
 export async function discordRequest(endpoint: string) {
   const url = "https://discord.com/api/v10/" + endpoint;
-  if (discordToken === "") throw Error("DISCORD_TOKEN env variable not set!");
   const res = await fetch(url, {
     headers: {
       Authorization: `Bot ${discordToken}`,
@@ -27,8 +36,48 @@ export async function getDiscordMessages(threadId: string) {
 }
 
 function discordPhoto(userId: string, userAvatar: string) {
-  if (!userId || !userAvatar) return null;
+  if (!userId || !userAvatar) return undefined;
   return `https://cdn.discordapp.com/avatars/${userId}/${userAvatar}`;
+}
+// messages by default use userids when mentioning other users in the format <@id>. Fortunately
+// messages also have the list of mentions with ids and usernames. This function swaps ids for usernames.
+function replaceMentions(
+  message: string,
+  mentions: { id: string; username: string }[]
+) {
+  let result = message;
+  for (const entry of mentions) {
+    result = result.replace(`<@${entry.id}>`, `**@${entry.username}**`);
+  }
+  return result;
+}
+function replaceEmbeds(
+  message: string,
+  embeds: { url: string; title: string; type: string }[]
+) {
+  let result = message;
+  for (const embed of embeds) {
+    result = result.replace(`(${embed.url})`, `[${embed.title}](${embed.url})`);
+  }
+  return result;
+}
+function concatenateAttachments(
+  message: string,
+  attachments: {
+    id: string;
+    filename: string;
+    proxy_url: string;
+    url: string;
+  }[]
+) {
+  const concat: string[] = [];
+  attachments.forEach((attachment, index) => {
+    concat.push(
+      `[Link ${index + 1}](${attachment.proxy_url || attachment.url})`
+    );
+  });
+
+  return [message, concat.join(",  ")].join("\n");
 }
 
 function extractValidateTimestamp(msg: string) {
@@ -40,10 +89,11 @@ function extractValidateTimestamp(msg: string) {
   return isValid ? time : null;
 }
 
-async function fetchDiscordData(l1Requests: PriceRequestT[]) {
+async function fetchDiscordThread(
+  l1Request: L1Request
+): Promise<DiscordThreadT> {
   // First, fetch all messages in the evidence rational channel.
   const threadMsg = await getDiscordMessages(evidenceRationalDiscordChannelId);
-
   // Then, extract the timestamp from each message and for each timestamp relate
   // it to the associated threadId.
   const timeToThread: { [key: string]: string } = {};
@@ -51,50 +101,35 @@ async function fetchDiscordData(l1Requests: PriceRequestT[]) {
     const time = extractValidateTimestamp(message.content);
     if (time) timeToThread[time.toString()] = message.thread.id;
   });
-
   // Associate the threadId with each timestamp provided in the payload.
   const requestsToThread: { [key: string]: string } = {};
-  l1Requests.forEach((l1Request: PriceRequestT) => {
-    const time = l1Request.time.toString();
-    if (timeToThread[time]) requestsToThread[time] = timeToThread[time];
-    else requestsToThread[time] = "";
-  });
+  const time = l1Request.time.toString();
+  if (timeToThread[time]) requestsToThread[time] = timeToThread[time];
+  else requestsToThread[time] = "";
 
-  // For each request that has an associated thread construct a discord thread
-  // fetch to get that threads messages. Push these into an array of promises
-  // so that we can fetch them all in one go.
-  const promises = [];
-  for (const time in requestsToThread) {
-    if (requestsToThread[time] !== "")
-      promises.push(getDiscordMessages(requestsToThread[time]));
-    else promises.push(null);
-  }
-  const threadMessages = await Promise.all(promises);
+  let messages: RawDiscordThreadT = [];
+  if (requestsToThread[time] !== "")
+    messages = await getDiscordMessages(requestsToThread[time]);
 
-  // Finally, process the results by traversing each request and the associated
-  // thread to construct the final data structure with minimal data.
-  const processedResults: DiscordThreadT[] = [];
-  threadMessages.forEach((messages, index) => {
-    let processedMessages: DiscordMessageT[] = [];
-    if (messages)
-      processedMessages = messages
-        .filter((message) => message.content != "")
-        .map((msg) => {
-          return {
-            message: msg.content,
-            sender: msg.author.username,
-            senderPicture: discordPhoto(msg.author.id, msg.author.avatar),
-            time: msg.timestamp,
-          };
-        });
-    processedResults.push({
-      identifier: l1Requests[index].identifier,
-      time: l1Requests[index].time,
-      thread: processedMessages.reverse(),
+  const processedMessages: DiscordMessageT[] = messages
+    .filter((message) => message.content != "")
+    .map((msg: RawDiscordMessageT) => {
+      return {
+        message: concatenateAttachments(
+          replaceEmbeds(replaceMentions(msg.content, msg.mentions), msg.embeds),
+          msg.attachments
+        ),
+        sender: msg.author.username,
+        senderPicture: discordPhoto(msg.author.id, msg.author.avatar),
+        time: Math.floor(new Date(msg.timestamp).getTime() / 1000),
+      };
     });
-  });
 
-  return processedResults;
+  return {
+    identifier: l1Request.identifier,
+    time: l1Request.time,
+    thread: processedMessages.reverse(),
+  };
 }
 
 export default async function handler(
@@ -104,12 +139,10 @@ export default async function handler(
   response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000"); // Cache for 30 days and re-build cache if re-deployed.
 
   try {
-    const body = request.body as { l1Requests: PriceRequestT[] };
-    ["l1Requests"].forEach((requiredKey) => {
-      if (!Object.keys(body).includes(requiredKey))
-        throw "Missing key in req body! required: l1Requests";
-    });
-    const discordMessages = await fetchDiscordData(body.l1Requests);
+    const body = ss.create(request.body, DiscordThreadRequestBody);
+    const discordMessages: DiscordThreadT = await fetchDiscordThread(
+      body.l1Request
+    );
     response.status(200).send(discordMessages);
   } catch (e) {
     console.error(e);

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -2,6 +2,7 @@ import { VotingV2Ethers } from "@uma/contracts-frontend";
 import { supportedChains } from "constant";
 import { BigNumber } from "ethers";
 import { DropdownItemT, LinkT, UserVoteDataT } from "types";
+import * as ss from "superstruct";
 
 export type UniqueKeyT = string;
 
@@ -245,19 +246,52 @@ export type RawDiscordMessageT = {
   };
   timestamp: string;
   thread: { id: string };
+  attachments: {
+    id: string;
+    filename: string;
+    size: number;
+    url: string;
+    proxy_url: string;
+    width?: number;
+    height?: number;
+    content_type: string;
+  }[];
+  embeds: {
+    type: string;
+    url: string;
+    title: string;
+    description: string;
+  }[];
+  mentions: {
+    id: string;
+    username: string;
+    avatar: string;
+    discriminator: string;
+  }[];
 };
 
 export type RawDiscordThreadT = RawDiscordMessageT[];
 
-export type DiscordMessageT = {
-  message: string;
-  sender: string;
-  senderPicture: string | null;
-  time: string;
-};
+export const DiscordMessageT = ss.object({
+  message: ss.string(),
+  sender: ss.string(),
+  senderPicture: ss.optional(ss.string()),
+  time: ss.number(),
+});
+export type DiscordMessageT = ss.Infer<typeof DiscordMessageT>;
 
-export type DiscordThreadT = {
-  identifier: string;
-  time: number;
-  thread: DiscordMessageT[];
-};
+export const DiscordThreadT = ss.object({
+  identifier: ss.string(),
+  time: ss.number(),
+  thread: ss.array(DiscordMessageT),
+});
+export type DiscordThreadT = ss.Infer<typeof DiscordThreadT>;
+
+export const DiscordThreadsT = ss.array(DiscordThreadT);
+export type DiscordThreadsT = ss.Infer<typeof DiscordThreadsT>;
+
+export const L1Request = ss.object({
+  time: ss.number(),
+  identifier: ss.string(),
+});
+export type L1Request = ss.Infer<typeof L1Request>;

--- a/web3/index.ts
+++ b/web3/index.ts
@@ -35,3 +35,4 @@ export { getEncryptedVotes } from "./queries/votes/getEncryptedVotes";
 export { getRevealedVotes } from "./queries/votes/getRevealedVotes";
 export { getUpcomingVotes } from "./queries/votes/getUpcomingVotes";
 export { getCommittedVotesByCaller } from "./queries/votes/getCommittedVotesByCaller";
+export { getDiscordThread } from "./queries/discord/getDiscordThread";

--- a/web3/queries/discord/getDiscordThread.ts
+++ b/web3/queries/discord/getDiscordThread.ts
@@ -1,0 +1,19 @@
+import * as ss from "superstruct";
+import { DiscordThreadT, L1Request } from "types";
+
+export async function getDiscordThread(
+  l1Request: L1Request
+): Promise<DiscordThreadT> {
+  const response = await fetch("/api/discord-thread", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ l1Request }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Getting discord threads failed with unknown error");
+  }
+  return ss.create(await response.json(), DiscordThreadT);
+}


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

## Motivation
We had independently built a discussion panel for votes, and a discord serverless api.  We needed to wire these together to get discussions working correctly.

## Changes
This changes aspects of the serverless api. Previously the api requested an array of discord threads, but this design was not ideal for the way the frontend was designed to query. This was changed to query a single thread at a time, based on when the user opens the discussion panel ( rather than compiling a list of all possible discussions).  We also add superstruct to validate calls and results between the frontend and the serverless api. 

Several parsers were added to make mentions, links and attachments work somewhat more nicely. 

There is still a lot of refinements we can make on this.
1. mentions to other channels do not work correctly
2. images are not displayed, but rather are linked as attachments 
3. serverless function is not particularly efficient, it runs a big query to discord every time its hit
4. there is no loading icon on the discussion panel
5. discussion panel should show there has not been any discussion if no discussion exist
6. there should be a red dot or badge number showing how many messages are in the discussion tab ( before entering the tab)

![image](https://user-images.githubusercontent.com/4429761/208929048-eea1e42b-3ef4-48db-a63d-0c55921ac0c5.png)
