### PR TITLE
feat: add commit reset and dirty flag on input

### DIFF
--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -59,7 +59,11 @@ export function Votes() {
     },
   } = usePaginationContext();
   const [selectedVotes, setSelectedVotes] = useState<SelectedVotesByKeyT>({});
+  const [dirtyInputs, setDirtyInput] = useState<boolean[]>([]);
 
+  function isDirty(): boolean {
+    return dirtyInputs.some((x) => x);
+  }
   const votesToShow = getEntriesForPage(
     pageNumber,
     resultsPerPage,
@@ -92,7 +96,20 @@ export function Votes() {
     const hasDelegatorStaked = delegatorStakedBalance?.gt(0) ?? false;
     const isDelegate = getDelegationStatus() === "delegate";
     const hasSigner = !!signer;
-    const hasVotesToCommit = Object.keys(selectedVotes).length > 0;
+    const votesToShow = determineVotesToShow();
+    const hasPreviouslyCommitted =
+      votesToShow.filter((vote) => vote.decryptedVote).length > 0;
+    // counting how many votes we have edited with commitable values ( non empty )
+    const selectedVotesCount = Object.values(selectedVotes).filter(
+      (x) => x
+    ).length;
+    // check if we have votes to commit by seeing there are more than 1 and its dirty
+    const hasVotesToCommit =
+      selectedVotesCount > 0
+        ? hasPreviouslyCommitted
+          ? isDirty()
+          : true
+        : false;
     const hasVotesToReveal = getVotesToReveal().length > 0;
 
     if (!hasSigner || !address) {
@@ -270,7 +287,6 @@ export function Votes() {
         return "Past votes:";
     }
   }
-
   return (
     <>
       <Title>{determineTitle()}</Title>
@@ -279,7 +295,7 @@ export function Votes() {
       <VotesTableWrapper>
         <VotesList
           headings={<VotesTableHeadings activityStatus={getActivityStatus()} />}
-          rows={votesToShow.map((vote) => (
+          rows={votesToShow.map((vote, index) => (
             <VotesListItem
               vote={vote}
               phase={phase}
@@ -288,6 +304,13 @@ export function Votes() {
               activityStatus={getActivityStatus()}
               moreDetailsAction={() => openVotePanel(vote)}
               key={vote.uniqueKey}
+              isDirty={dirtyInputs[index]}
+              setDirty={(dirty: boolean) => {
+                setDirtyInput((inputs) => {
+                  inputs[index] = dirty;
+                  return [...inputs];
+                });
+              }}
               isFetching={
                 getUserDependentIsFetching() ||
                 isCommittingVotes ||
@@ -299,6 +322,16 @@ export function Votes() {
       </VotesTableWrapper>
       {getActivityStatus() === "active" ? (
         <CommitVotesButtonWrapper>
+          {isDirty() ? (
+            <>
+              <Button
+                variant="secondary"
+                label="Reset Changes"
+                onClick={() => setSelectedVotes({})}
+              />
+              <ButtonSpacer />
+            </>
+          ) : undefined}
           {!actionStatus.hidden ? (
             actionStatus.tooltip ? (
               <Tooltip label={actionStatus.tooltip}>
@@ -356,4 +389,8 @@ const CommitVotesButtonWrapper = styled.div`
 
 const PaginationWrapper = styled.div`
   margin-block: 30px;
+`;
+
+const ButtonSpacer = styled.div`
+  width: 10px;
 `;

--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -31,6 +31,8 @@ export interface Props {
   activityStatus: ActivityStatusT;
   moreDetailsAction: () => void;
   isFetching: boolean;
+  setDirty?: (dirty: boolean) => void;
+  isDirty?: boolean;
 }
 export function VotesListItem({
   vote,
@@ -40,6 +42,8 @@ export function VotesListItem({
   activityStatus,
   moreDetailsAction,
   isFetching,
+  setDirty,
+  isDirty = false,
 }: Props) {
   const { signer } = useWalletContext();
   const { width } = useWindowSize();
@@ -86,6 +90,11 @@ export function VotesListItem({
       setWrapperWidth(wrapperRef.current.offsetWidth);
     }
   }, [wrapperRef.current?.offsetWidth]);
+
+  useEffect(() => {
+    const dirty = isDirtyCheck();
+    if (setDirty && dirty !== isDirty) setDirty(dirty);
+  }, [selectedVote, setDirty, isDirty, isDirtyCheck]);
 
   function onSelectVote(option: DropdownItemT) {
     if (option.value === "custom") {
@@ -259,6 +268,17 @@ export function VotesListItem({
     );
   }
 
+  // Function returns true if the input exist and has changed from our committed value, false otherwise
+  function isDirtyCheck(): boolean {
+    if (phase !== "commit") return false;
+    const existingVote = getDecryptedVoteAsFormattedString();
+    if (!existingVote) return false;
+    // this happens if you clear the vote inputs, selected vote normally
+    // would be "" if editing. dirty = false if we clear inputs.
+    if (selectedVote === undefined) return false;
+    return selectedVote !== existingVote;
+  }
+
   const style = {
     "--border-color": getBorderColor(),
     "--dot-color": getDotColor(),
@@ -355,6 +375,7 @@ export function VotesListItem({
                   }
                 />{" "}
                 {getRelevantTransactionLink()}
+                {isDirty ? "*" : ""}
               </>
             )}
           </VoteStatus>

--- a/web3/queries/votes/getEncryptedVotes.ts
+++ b/web3/queries/votes/getEncryptedVotes.ts
@@ -24,7 +24,6 @@ export async function getEncryptedVotes(
       makeUniqueKeyForVote(decodedIdentifier, time, ancillaryData)
     ] = encryptedVote;
   });
-
   v2EventData?.forEach(({ encryptedVote, identifier, time, ancillaryData }) => {
     const decodedIdentifier = decodeHexString(identifier);
     encryptedVotes[


### PR DESCRIPTION
## motivation
Previously when values were committed, it wasnt clear if we were changing them to be committed again.

## changes
This adds a button to reset inputs back to a previously committed vote, and lets you know if you are changing a previously committed value. Otherwise it does not change functionality
![image](https://user-images.githubusercontent.com/4429761/209380481-e5f4cdf2-3b3f-4895-afbc-4fb43fb9e093.png)
