### PR TITLE
fix: set default tab for stake/unstake panel

### DIFF
--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -153,7 +153,7 @@ export function StakeUnstakePanel() {
             </CooldownTimerWrapper>
           )}
         </BalancesWrapper>
-        <Tabs tabs={tabs} />
+        <Tabs tabs={tabs} defaultValue={"Stake"} />
       </SectionsWrapper>
       <PanelFooter />
     </PanelWrapper>

--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -56,7 +56,11 @@ export function VotePanel({ content }: Props) {
         isGovernance={isGovernance}
         voteNumber={voteNumber?.toString()}
       />
-      {hasResults ? <Tabs tabs={tabs} /> : <Details {...content} />}
+      {hasResults ? (
+        <Tabs tabs={tabs} defaultValue="Result" />
+      ) : (
+        <Details {...content} />
+      )}
       <PanelFooter />
     </PanelWrapper>
   );

--- a/components/Tabs/Tabs.tsx
+++ b/components/Tabs/Tabs.tsx
@@ -7,9 +7,15 @@ type Tab = {
   content: ReactNode;
 };
 
-export function Tabs({ tabs }: { tabs: Tab[] }) {
+export function Tabs({
+  tabs,
+  defaultValue,
+}: {
+  tabs: Tab[];
+  defaultValue: string;
+}) {
   return (
-    <TabsRoot>
+    <TabsRoot defaultValue={defaultValue}>
       <TabsList>
         {tabs.map(({ title }) => (
           <TabsTrigger key={title} value={title}>


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

## motivation
there seems to be an intermittent issue where panel tabs do not show sometimes. 

## changes
not sure if this fixes it, but we can set an optional default tab when the panel is opened. this is using a react tab library and the component is currently uncontrolled, so perhaps setting a default when opened fixes this. 