### PR TITLE
fix: check user unstaked balance before staking

### DIFF
--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -45,12 +45,12 @@ export function Stake({
   function isButtonDisabled() {
     if (inputAmount === maximumApprovalAmountString && disclaimerChecked)
       return false;
-
     return (
       unstakedBalance?.eq(0) ||
       !disclaimerChecked ||
       inputAmount === "" ||
-      parseEtherSafe(inputAmount).eq(0)
+      parseEtherSafe(inputAmount).eq(0) ||
+      parseEtherSafe(inputAmount).gt(unstakedBalance)
     );
   }
 

--- a/helpers/web3/ethers.ts
+++ b/helpers/web3/ethers.ts
@@ -8,7 +8,9 @@ export const parseEther = ethers.utils.parseEther;
 // This catches any potential errors form parsing an unknown string value, returns 0 if error happens.
 export function parseEtherSafe(value: string, decimals = 18): ethers.BigNumber {
   try {
-    return ethers.utils.parseUnits(Number(value).toFixed(decimals), decimals);
+    // previously we were casting this to number, and using tofixed. this does not work because casting to
+    // number may change the value. this was affecting the "max" button when decimals of user was very long.
+    return ethers.utils.parseUnits(value, decimals);
   } catch (err) {
     return ethers.BigNumber.from(0);
   }


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

## Motivation
we were allowing people to try to stake more than they had unstaked, causing revert

## changes
we check the unstaked balance, we also had to change how we were parsing eth because the number cast caused a mismatch in the compared result.