### PR TITLE
fix: fix delegate queries to use delegator address

### DIFF
--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -50,7 +50,7 @@ export function Stake({
       !disclaimerChecked ||
       inputAmount === "" ||
       parseEtherSafe(inputAmount).eq(0) ||
-      parseEtherSafe(inputAmount).gt(unstakedBalance)
+      (unstakedBalance ? parseEtherSafe(inputAmount).gt(unstakedBalance) : true)
     );
   }
 

--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -48,7 +48,7 @@ export function Votes() {
     isSettingChain,
   } = useWalletContext();
   const { voting } = useContractsContext();
-  const { stakedBalance, delegatorStakedBalance } = useStakingContext();
+  const { stakedBalance } = useStakingContext();
   const { getDelegationStatus } = useDelegationContext();
   const { commitVotesMutation, isCommittingVotes } = useCommitVotes();
   const { revealVotesMutation, isRevealingVotes } = useRevealVotes();
@@ -89,7 +89,6 @@ export function Votes() {
     const isCommit = phase === "commit";
     const isReveal = phase === "reveal";
     const hasStaked = stakedBalance?.gt(0) ?? false;
-    const hasDelegatorStaked = delegatorStakedBalance?.gt(0) ?? false;
     const isDelegate = getDelegationStatus() === "delegate";
     const hasSigner = !!signer;
     const hasVotesToCommit = Object.keys(selectedVotes).length > 0;
@@ -126,7 +125,7 @@ export function Votes() {
         return actionConfig;
       }
       if (isDelegate) {
-        if (!hasDelegatorStaked) {
+        if (!hasStaked) {
           actionConfig.disabled = true;
           actionConfig.tooltip =
             "You cannot commit because your delegator has no UMA Staked.";

--- a/contexts/DelegationContext.tsx
+++ b/contexts/DelegationContext.tsx
@@ -350,7 +350,6 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
       },
     });
   }
-
   return (
     <DelegationContext.Provider
       value={{

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -6,7 +6,7 @@ import {
   useUserVotingAndStakingDetails,
   useWalletContext,
 } from "hooks";
-import { createContext, ReactNode } from "react";
+import { createContext, ReactNode, useState } from "react";
 import { VoteHistoryByKeyT, SigningKey } from "types";
 import { config } from "helpers/config";
 
@@ -29,6 +29,7 @@ export interface UserContextState {
   signingKey: SigningKey | undefined;
   hasSigningKey: boolean;
   correctChainConnected: boolean;
+  setAddressOverride: (address?: string) => void;
 }
 
 export const defaultUserContextState: UserContextState = {
@@ -50,6 +51,7 @@ export const defaultUserContextState: UserContextState = {
   signingKey: undefined,
   hasSigningKey: false,
   correctChainConnected: true,
+  setAddressOverride: () => undefined,
 };
 
 export const UserContext = createContext<UserContextState>(
@@ -59,6 +61,9 @@ export const UserContext = createContext<UserContextState>(
 export function UserProvider({ children }: { children: ReactNode }) {
   const { connectedWallet, account, address, truncatedAddress } =
     useAccountDetails();
+  const [addressOverride, setAddressOverride] = useState<string | undefined>(
+    undefined
+  );
   const { signingKeys, connectedChainId } = useWalletContext();
 
   const {
@@ -74,7 +79,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
     },
     isLoading: userDataLoading,
     isFetching: userDataFetching,
-  } = useUserVotingAndStakingDetails();
+  } = useUserVotingAndStakingDetails(addressOverride);
 
   const walletIcon = connectedWallet?.icon;
   const signingKey = signingKeys[address];
@@ -101,6 +106,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
         signingKey,
         hasSigningKey: !!signingKey,
         correctChainConnected,
+        setAddressOverride,
       }}
     >
       {children}

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -16,7 +16,7 @@ import {
   useUserVotingAndStakingDetails,
   useCommittedVotesForDelegator,
 } from "hooks";
-import { createContext, ReactNode } from "react";
+import { createContext, ReactNode, useState } from "react";
 import {
   ActivityStatusT,
   ContentfulDataByKeyT,
@@ -49,6 +49,7 @@ export interface VotesContextState {
   getUserDependentIsFetching: () => boolean;
   getUserIndependentIsFetching: () => boolean;
   getIsFetching: () => boolean;
+  setAddressOverride: (address?: string) => void;
 }
 
 export const defaultVotesContextState: VotesContextState = {
@@ -73,6 +74,7 @@ export const defaultVotesContextState: VotesContextState = {
   getUserDependentIsFetching: () => false,
   getUserIndependentIsFetching: () => false,
   getIsFetching: () => false,
+  setAddressOverride: () => undefined,
 };
 
 export const VotesContext = createContext<VotesContextState>(
@@ -80,6 +82,9 @@ export const VotesContext = createContext<VotesContextState>(
 );
 
 export function VotesProvider({ children }: { children: ReactNode }) {
+  const [addressOverride, setAddressOverride] = useState<string | undefined>(
+    undefined
+  );
   const {
     data: { activeVotes, hasActiveVotes },
     isLoading: activeVotesIsLoading,
@@ -133,7 +138,7 @@ export function VotesProvider({ children }: { children: ReactNode }) {
   const { address } = useAccountDetails();
   const {
     data: { voteHistoryByKey },
-  } = useUserVotingAndStakingDetails();
+  } = useUserVotingAndStakingDetails(addressOverride);
   const { data: decodedAdminTransactions } = useDecodedAdminTransactions();
   const { data: augmentedData } = useAugmentedVoteData();
 
@@ -285,6 +290,7 @@ export function VotesProvider({ children }: { children: ReactNode }) {
         getUserDependentIsFetching,
         getUserIndependentIsFetching,
         getIsFetching,
+        setAddressOverride,
       }}
     >
       {children}

--- a/hooks/queries/rewards/useOutstandingRewards.ts
+++ b/hooks/queries/rewards/useOutstandingRewards.ts
@@ -1,13 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { outstandingRewardsKey } from "constant";
 import { BigNumber } from "ethers";
-import { useAccountDetails, useContractsContext, useHandleError } from "hooks";
+import { useContractsContext, useHandleError, useUserContext } from "hooks";
 import { getOutstandingRewards } from "web3";
 
-export function useOutstandingRewards() {
+export function useOutstandingRewards(addressOverride?: string) {
   const { voting } = useContractsContext();
-  const { address } = useAccountDetails();
+  const { address: defaultAddress } = useUserContext();
   const { onError } = useHandleError({ isDataFetching: true });
+  const address = addressOverride || defaultAddress;
 
   const queryResult = useQuery(
     [outstandingRewardsKey, address],

--- a/hooks/queries/rewards/useRewardsCalculationInputs.ts
+++ b/hooks/queries/rewards/useRewardsCalculationInputs.ts
@@ -9,12 +9,13 @@ import {
 } from "hooks";
 import { getRewardsCalculationInputs } from "web3";
 
-export function useRewardsCalculationInputs() {
+export function useRewardsCalculationInputs(addressOverride?: string) {
   const { voting } = useContractsContext();
-  const { address } = useUserContext();
+  const { address: defaultAddress } = useUserContext();
   const { stakedBalance, unstakedBalance, pendingUnstake, updateTime } =
     useStakingContext();
   const { onError } = useHandleError({ isDataFetching: true });
+  const address = addressOverride || defaultAddress;
 
   const queryResult = useQuery(
     [

--- a/hooks/queries/staking/useStakedBalance.ts
+++ b/hooks/queries/staking/useStakedBalance.ts
@@ -6,16 +6,19 @@ import { useHandleError } from "hooks/helpers/useHandleError";
 import { getStakedBalance } from "web3";
 import { useAccountDetails } from "../user/useAccountDetails";
 
-export function useStakedBalance() {
+const initialData = BigNumber.from(0);
+
+export function useStakedBalance(addressOverride?: string) {
   const { voting } = useContractsContext();
-  const { address } = useAccountDetails();
+  const { address: defaultAddress } = useAccountDetails();
   const { onError, clearErrors } = useHandleError({ isDataFetching: true });
+  const address = addressOverride || defaultAddress;
 
   const queryResult = useQuery({
     queryKey: [stakedBalanceKey, address],
-    queryFn: () => getStakedBalance(voting, address),
+    queryFn: () => (address ? getStakedBalance(voting, address) : initialData),
     enabled: !!address,
-    initialData: BigNumber.from(0),
+    initialData,
     onError,
     onSuccess: clearErrors,
   });

--- a/hooks/queries/staking/useStakerDetails.ts
+++ b/hooks/queries/staking/useStakerDetails.ts
@@ -2,41 +2,29 @@ import { useQuery } from "@tanstack/react-query";
 import { stakerDetailsKey } from "constant";
 import { BigNumber } from "ethers";
 import { zeroAddress } from "helpers";
-import {
-  useAccountDetails,
-  useContractsContext,
-  useDelegationContext,
-  useHandleError,
-} from "hooks";
+import { useAccountDetails, useContractsContext, useHandleError } from "hooks";
 import { getStakerDetails } from "web3";
 
-export function useStakerDetails() {
+const initialData = {
+  pendingUnstake: BigNumber.from(0),
+  unstakeRequestTime: new Date(0),
+  canUnstakeTime: new Date(0),
+  delegate: zeroAddress,
+  rewardsPaidPerToken: BigNumber.from(0),
+};
+
+export function useStakerDetails(addressOverride?: string) {
   const { voting } = useContractsContext();
-  const { address } = useAccountDetails();
-  const { getDelegationStatus, getDelegatorAddress } = useDelegationContext();
+  const { address: defaultAddress } = useAccountDetails();
   const { onError } = useHandleError({ isDataFetching: true });
-
-  const status = getDelegationStatus();
-  const delegatorAddress = getDelegatorAddress();
-
-  const addressToQuery =
-    status === "delegate" && delegatorAddress ? delegatorAddress : address;
-
-  const queryResult = useQuery(
+  const address = addressOverride || defaultAddress;
+  return useQuery(
     [stakerDetailsKey, address],
-    () => getStakerDetails(voting, addressToQuery),
+    () => (address ? getStakerDetails(voting, address) : initialData),
     {
       enabled: !!address,
-      initialData: {
-        pendingUnstake: BigNumber.from(0),
-        unstakeRequestTime: new Date(0),
-        canUnstakeTime: new Date(0),
-        delegate: zeroAddress,
-        rewardsPaidPerToken: BigNumber.from(0),
-      },
+      initialData,
       onError,
     }
   );
-
-  return queryResult;
 }

--- a/hooks/queries/staking/useUnstakedBalance.ts
+++ b/hooks/queries/staking/useUnstakedBalance.ts
@@ -2,18 +2,23 @@ import { useQuery } from "@tanstack/react-query";
 import { unstakedBalanceKey } from "constant";
 import { useAccountDetails, useContractsContext, useHandleError } from "hooks";
 import { getUnstakedBalance } from "web3";
+import { BigNumber } from "ethers";
 
-export function useUnstakedBalance() {
+const initialData = BigNumber.from(0);
+
+export function useUnstakedBalance(addressOverride?: string) {
   const { votingToken } = useContractsContext();
-  const { address } = useAccountDetails();
+  const { address: defaultAddress } = useAccountDetails();
   const { onError } = useHandleError({ isDataFetching: true });
+  const address = addressOverride || defaultAddress;
 
   const queryResult = useQuery(
     [unstakedBalanceKey, address],
-    () => getUnstakedBalance(votingToken, address),
+    () => (address ? getUnstakedBalance(votingToken, address) : initialData),
     {
       enabled: !!address,
       onError,
+      initialData,
     }
   );
 

--- a/hooks/queries/user/useUserVotingAndStakingDetails.ts
+++ b/hooks/queries/user/useUserVotingAndStakingDetails.ts
@@ -4,9 +4,10 @@ import { BigNumber } from "ethers";
 import { getUserData } from "graph";
 import { useAccountDetails, useHandleError } from "hooks";
 
-export function useUserVotingAndStakingDetails() {
-  const { address } = useAccountDetails();
+export function useUserVotingAndStakingDetails(addressOverride?: string) {
+  const { address: defaultAddress } = useAccountDetails();
   const { onError } = useHandleError({ isDataFetching: true });
+  const address = addressOverride || defaultAddress;
 
   const queryResult = useQuery(
     [userDataKey, address],


### PR DESCRIPTION
# motivation
The current version does not work correctly when logged in as a delegate. Much of the data should originate from the delegator:
1. stake/unstake balances 
2. vote history
3. claimable tokens

# changes
This allows many contexts to set an override user address, in this case we can override to the "delegator" address. This happens automatically at the top level ( in header component) when its detected that you are a delegate. Many hooks have now an optional field to override the address, and contexts selectively do this when you set an override address. This fixes the issue without major changes to the code, and keeps it backwards compatible to lower risk of regressions. 

![image](https://user-images.githubusercontent.com/4429761/209852263-e3c848c6-55f4-40f3-89c0-2a165516bac7.png)
![image](https://user-images.githubusercontent.com/4429761/209852303-d5eb7fc2-a435-4ca5-92f0-23596f487a47.png)
