### PR TITLE
fix: filter past commit value from showing in a rolled vote

### DIFF
--- a/hooks/queries/votes/useDecryptedVotes.ts
+++ b/hooks/queries/votes/useDecryptedVotes.ts
@@ -8,9 +8,9 @@ import {
   EncryptedVotesByKeyT,
 } from "types";
 
-export function useDecryptedVotes() {
+export function useDecryptedVotes(roundId?: number) {
   const { address, signingKey } = useUserContext();
-  const { data: encryptedVotes } = useEncryptedVotes();
+  const { data: encryptedVotes } = useEncryptedVotes(roundId);
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(

--- a/hooks/queries/votes/useEncryptedVotes.ts
+++ b/hooks/queries/votes/useEncryptedVotes.ts
@@ -1,22 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { encryptedVotesKey } from "constant";
-import {
-  useAccountDetails,
-  useContractsContext,
-  useHandleError,
-  useVoteTimingContext,
-} from "hooks";
+import { useAccountDetails, useContractsContext, useHandleError } from "hooks";
 import { getEncryptedVotes } from "web3";
 
-export function useEncryptedVotes() {
+export function useEncryptedVotes(roundId?: number) {
   const { voting, votingV1 } = useContractsContext();
   const { address } = useAccountDetails();
-  const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [encryptedVotesKey, address, roundId],
-    () => getEncryptedVotes(voting, votingV1, address),
+    () => getEncryptedVotes(voting, votingV1, address, roundId),
     {
       enabled: !!address,
       initialData: {},

--- a/web3/queries/votes/getEncryptedVotes.ts
+++ b/web3/queries/votes/getEncryptedVotes.ts
@@ -5,7 +5,8 @@ import { EncryptedVotesByKeyT } from "types";
 export async function getEncryptedVotes(
   votingContract: VotingV2Ethers,
   votingV1Contract: VotingEthers,
-  address: string
+  address: string,
+  findRoundId?: number
 ) {
   const v1Filter = votingV1Contract.filters.EncryptedVote(address);
   const v1Result = await votingV1Contract.queryFilter(v1Filter);
@@ -14,7 +15,9 @@ export async function getEncryptedVotes(
   const v2Result = await votingContract.queryFilter(v2Filter);
 
   const v1EventData = v1Result?.map(({ args }) => args);
-  const v2EventData = v2Result?.map(({ args }) => args);
+  const v2EventData = v2Result
+    ?.map(({ args }) => args)
+    .filter(({ roundId }) => (findRoundId ? roundId.eq(findRoundId) : true));
 
   const encryptedVotes: EncryptedVotesByKeyT = {};
 


### PR DESCRIPTION
## motivation
When committing a vote, letting it roll to next round, the previous commit value keeps showing up as the default in the commit input box. The previous commit is not related to the next round when a vote is rolled, so it should be blank.

## changes
This was caused by not filtering decrypted votes by round id when doing a lookup for the committed value, this was treating past votes the same as votes in the current round. we slightly change queries to allow for a round id. this affected past votes, since they  were sharing the same data structure, so a new query is made for all past votes.