### PR TITLE
fix: ensure claim balance goes to 0 after claiming

### DIFF
--- a/contexts/StakingContext.tsx
+++ b/contexts/StakingContext.tsx
@@ -26,7 +26,6 @@ export interface StakingContextState {
   canUnstakeTime: Date | undefined;
   unstakeCoolDown: BigNumber | undefined;
   v1Rewards: V1RewardsT | undefined;
-  resetOutstandingRewards: () => void;
   getStakingDataLoading: () => boolean;
   getStakingDataFetching: () => boolean;
   setAddressOverride: (address?: string) => void;
@@ -42,7 +41,6 @@ export const defaultStakingContextState: StakingContextState = {
   unstakeRequestTime: undefined,
   canUnstakeTime: undefined,
   unstakeCoolDown: undefined,
-  resetOutstandingRewards: () => null,
   v1Rewards: undefined,
   getStakingDataLoading: () => false,
   getStakingDataFetching: () => false,
@@ -123,10 +121,6 @@ export function StakingProvider({ children }: { children: ReactNode }) {
     setOutstandingRewards(calculatedOutstandingRewards);
   }
 
-  function resetOutstandingRewards() {
-    setOutstandingRewards(BigNumber.from(0));
-  }
-
   function getStakingDataLoading() {
     if (!address) return false;
 
@@ -167,7 +161,6 @@ export function StakingProvider({ children }: { children: ReactNode }) {
         tokenAllowance,
         unstakeRequestTime,
         canUnstakeTime,
-        resetOutstandingRewards,
         v1Rewards,
         getStakingDataLoading,
         getStakingDataFetching,

--- a/hooks/mutations/rewards/useWithdrawAndRestake.ts
+++ b/hooks/mutations/rewards/useWithdrawAndRestake.ts
@@ -1,8 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { stakedBalanceKey, outstandingRewardsKey } from "constant";
+import {
+  stakedBalanceKey,
+  outstandingRewardsKey,
+  rewardsCalculationInputsKey,
+} from "constant";
 import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError, useStakingContext } from "hooks";
-import { ErrorOriginT } from "types";
+import { ErrorOriginT, RewardCalculationT } from "types";
 import { withdrawAndRestake } from "web3";
 
 export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
@@ -19,6 +23,27 @@ export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
       queryClient.setQueryData<BigNumber>(
         [stakedBalanceKey, address],
         (oldStakedBalance) => {
+          // change outstanding rewards from contract to 0
+          queryClient.setQueryData<BigNumber>(
+            [outstandingRewardsKey, address],
+            () => {
+              return BigNumber.from(0);
+            }
+          );
+
+          queryClient.setQueryData<RewardCalculationT>(
+            [rewardsCalculationInputsKey, address],
+            (previous) => {
+              return {
+                emissionRate: BigNumber.from(0),
+                rewardPerTokenStored: BigNumber.from(0),
+                cumulativeStake: BigNumber.from(0),
+                ...previous,
+                updateTime: BigNumber.from(Date.now()),
+              };
+            }
+          );
+
           if (
             outstandingRewards === undefined ||
             oldStakedBalance === undefined
@@ -27,17 +52,12 @@ export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
 
           const newStakedBalance = oldStakedBalance.add(outstandingRewards);
 
-          // change outstnading rewards from contract to 0
-          queryClient.setQueryData<BigNumber>(
-            [outstandingRewardsKey, address],
-            () => BigNumber.from(0)
-          );
-
           return newStakedBalance;
         }
       );
     },
   });
+
   return {
     withdrawAndRestakeMutation: mutate,
     isWithdrawingAndRestaking: isLoading,

--- a/hooks/mutations/rewards/useWithdrawAndRestake.ts
+++ b/hooks/mutations/rewards/useWithdrawAndRestake.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { stakedBalanceKey } from "constant";
+import { stakedBalanceKey, outstandingRewardsKey } from "constant";
 import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError, useStakingContext } from "hooks";
 import { ErrorOriginT } from "types";
@@ -8,7 +8,7 @@ import { withdrawAndRestake } from "web3";
 export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
   const queryClient = useQueryClient();
   const { address } = useAccountDetails();
-  const { outstandingRewards, resetOutstandingRewards } = useStakingContext();
+  const { outstandingRewards } = useStakingContext();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 
   const { mutate, isLoading } = useMutation(withdrawAndRestake, {
@@ -27,11 +27,15 @@ export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
 
           const newStakedBalance = oldStakedBalance.add(outstandingRewards);
 
+          // change outstnading rewards from contract to 0
+          queryClient.setQueryData<BigNumber>(
+            [outstandingRewardsKey, address],
+            () => BigNumber.from(0)
+          );
+
           return newStakedBalance;
         }
       );
-
-      resetOutstandingRewards();
     },
   });
   return {

--- a/hooks/mutations/rewards/useWithdrawRewards.ts
+++ b/hooks/mutations/rewards/useWithdrawRewards.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { unstakedBalanceKey } from "constant";
+import { unstakedBalanceKey, outstandingRewardsKey } from "constant";
 import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError, useStakingContext } from "hooks";
 import { ErrorOriginT } from "types";
@@ -8,7 +8,7 @@ import { withdrawRewards } from "web3";
 export function useWithdrawRewards(errorOrigin?: ErrorOriginT) {
   const queryClient = useQueryClient();
   const { address } = useAccountDetails();
-  const { outstandingRewards, resetOutstandingRewards } = useStakingContext();
+  const { outstandingRewards } = useStakingContext();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 
   const { mutate, isLoading } = useMutation(withdrawRewards, {
@@ -27,11 +27,14 @@ export function useWithdrawRewards(errorOrigin?: ErrorOriginT) {
 
           const newUnstakedBalance = oldUnstakedBalance.add(outstandingRewards);
 
+          // change outstnading rewards from contract to 0
+          queryClient.setQueryData<BigNumber>(
+            [outstandingRewardsKey, address],
+            () => BigNumber.from(0)
+          );
           return newUnstakedBalance;
         }
       );
-
-      resetOutstandingRewards();
     },
   });
 

--- a/hooks/queries/rewards/useRewardsCalculationInputs.ts
+++ b/hooks/queries/rewards/useRewardsCalculationInputs.ts
@@ -1,31 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { oneMinute, rewardsCalculationInputsKey } from "constant";
 import { BigNumber } from "ethers";
-import {
-  useContractsContext,
-  useHandleError,
-  useStakingContext,
-  useUserContext,
-} from "hooks";
+import { useContractsContext, useHandleError, useUserContext } from "hooks";
 import { getRewardsCalculationInputs } from "web3";
 
 export function useRewardsCalculationInputs(addressOverride?: string) {
   const { voting } = useContractsContext();
   const { address: defaultAddress } = useUserContext();
-  const { stakedBalance, unstakedBalance, pendingUnstake, updateTime } =
-    useStakingContext();
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
 
   const queryResult = useQuery(
-    [
-      rewardsCalculationInputsKey,
-      address,
-      stakedBalance,
-      unstakedBalance,
-      pendingUnstake,
-      updateTime,
-    ],
+    [rewardsCalculationInputsKey, address],
     () => getRewardsCalculationInputs(voting),
     {
       refetchInterval: oneMinute,
@@ -34,7 +20,7 @@ export function useRewardsCalculationInputs(addressOverride?: string) {
         emissionRate: BigNumber.from(0),
         rewardPerTokenStored: BigNumber.from(0),
         cumulativeStake: BigNumber.from(0),
-        updateTime: BigNumber.from(0),
+        updateTime: BigNumber.from(Date.now()),
       },
       onError,
     }

--- a/types/staking.ts
+++ b/types/staking.ts
@@ -12,6 +12,13 @@ export type V1RewardsT = {
   totalRewards: BigNumber;
 };
 
+export type RewardCalculationT = {
+  emissionRate: BigNumber;
+  rewardPerTokenStored: BigNumber;
+  cumulativeStake: BigNumber;
+  updateTime: BigNumber;
+};
+
 export type SubgraphGlobals = {
   global: {
     annualPercentageReturn: number;

--- a/web3/queries/rewards/getRewardsCalculationInputs.ts
+++ b/web3/queries/rewards/getRewardsCalculationInputs.ts
@@ -2,10 +2,13 @@ import { VotingV2Ethers } from "@uma/contracts-frontend";
 import { BigNumber } from "ethers";
 
 export async function getRewardsCalculationInputs(voting: VotingV2Ethers) {
-  const emissionRate = await voting.emissionRate();
-  const rewardPerTokenStored = await voting.rewardPerTokenStored();
-  const cumulativeStake = await voting.cumulativeStake();
-  const updateTime = BigNumber.from(Date.now());
+  const [emissionRate, rewardPerTokenStored, cumulativeStake, updateTime] =
+    await Promise.all([
+      voting.emissionRate(),
+      voting.rewardPerTokenStored(),
+      voting.cumulativeStake(),
+      BigNumber.from(Date.now()),
+    ]);
 
   return {
     emissionRate,


### PR DESCRIPTION
## motivation
The amount to claim does not go to 0 after claiming rewards, seems to require a reload or takes a long time to reflect new value after tx is mined.

## changes
this was caused by a race condition, where claims are being regenerated on a timer based on contract information. resetting this calculated value to 0 would be quickly reset by the timer since the contract value has not been updated yet.  rather than resetting the final value to 0 when the claim tx succeeds, we change the cached value of the outstanding rewards from the contract call to 0, which is the key value in calculating our claim amount and wont immediately be overridden by the timer. 
