### PR TITLE
fix: prevent clearing stake input if not maxing approval

### DIFF
--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -18,6 +18,7 @@ interface Props {
   unstakeCoolDown: BigNumber | undefined;
   isDelegate: boolean;
   approve: (approveAmount: string) => void;
+  isApproving: boolean;
   stake: (stakeAmount: string, resetStakeAmount: () => void) => void;
 }
 export function Stake({
@@ -27,6 +28,7 @@ export function Stake({
   stake,
   unstakeCoolDown,
   isDelegate,
+  isApproving,
 }: Props) {
   const [inputAmount, setInputAmount] = useState("");
   const [disclaimerChecked, setDisclaimerChecked] = useState(false);
@@ -43,6 +45,7 @@ export function Stake({
   }
 
   function isButtonDisabled() {
+    if (isApproving) return true;
     if (inputAmount === maximumApprovalAmountString && disclaimerChecked)
       return false;
     return (
@@ -56,7 +59,7 @@ export function Stake({
 
   function onApprove() {
     approve(inputAmount);
-    setInputAmount("");
+    if (inputAmount === maximumApprovalAmountString) setInputAmount("");
   }
 
   function onStake() {

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -32,7 +32,7 @@ export function StakeUnstakePanel() {
     unstakeCoolDown,
   } = useStakingContext();
   const { getDelegationStatus } = useDelegationContext();
-  const { approveMutation } = useApprove("stake");
+  const { approveMutation, isApproving } = useApprove("stake");
   const { stakeMutation, isStaking } = useStake("stake");
   const { requestUnstakeMutation, isRequestingUnstake } =
     useRequestUnstake("unstake");
@@ -94,6 +94,7 @@ export function StakeUnstakePanel() {
           tokenAllowance={tokenAllowance}
           unstakedBalance={unstakedBalance}
           approve={approve}
+          isApproving={isApproving}
           stake={stake}
           unstakeCoolDown={unstakeCoolDown}
           isDelegate={isDelegate}


### PR DESCRIPTION
## motivation
for staking, when approving an amount less than unlimited, the input box would be cleared. this seemed counter intuitive since that amount should  be the amount you want to stake in the next step.

## changes
this only clears input box if you have set "unlimited approval" since that will cause the app to crash if not cleared out. this also disables the approval button while approval is in progress. 