### PR TITLE
fix: allow app to work without graph or contentful

### DIFF
--- a/graph/queries/getGlobals.ts
+++ b/graph/queries/getGlobals.ts
@@ -4,6 +4,8 @@ import { SubgraphGlobals } from "types";
 const { graphEndpoint } = config;
 
 export async function getGlobals() {
+  if (!graphEndpoint) throw new Error("V2 subgraph is disabled");
+
   const query = gql`
     {
       global(id: "global") {

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -13,6 +13,8 @@ const { graphEndpoint, graphEndpointV1 } = config;
 
 export async function getPastVotesV1() {
   const endpoint = graphEndpointV1;
+  if (!endpoint) throw new Error("V1 subgraph is disabled");
+
   const pastVotesQuery = gql`
     {
       priceRequests(
@@ -86,6 +88,7 @@ export async function getPastVotesV1() {
 
 export async function getPastVotesV2() {
   const endpoint = graphEndpoint;
+  if (!endpoint) throw new Error("V2 subgraph is disabled");
   const pastVotesQuery = gql`
     {
       priceRequests(

--- a/graph/queries/getUserVotingAndStakingDetails.ts
+++ b/graph/queries/getUserVotingAndStakingDetails.ts
@@ -12,6 +12,8 @@ const { graphEndpoint } = config;
 export async function getUserVotingAndStakingDetails(
   address: string | undefined
 ) {
+  if (!graphEndpoint) throw new Error("V2 subgraph is disabled");
+
   const userDataQuery = gql`
     {
       users(where: { address: "${address}" }) {

--- a/helpers/config.ts
+++ b/helpers/config.ts
@@ -5,18 +5,18 @@ import * as ss from "superstruct";
 // This would also be a great place to document what each env does and how to find it.
 const Env = ss.object({
   NEXT_PUBLIC_VOTING_V1_CONTRACT_ADDRESS: ss.string(),
-  NEXT_PUBLIC_GRAPH_ENDPOINT_V1: ss.string(),
-  NEXT_PUBLIC_GRAPH_ENDPOINT: ss.string(),
   NEXT_PUBLIC_VOTING_TOKEN_CONTRACT_ADDRESS: ss.string(),
   NEXT_PUBLIC_VOTING_CONTRACT_ADDRESS: ss.string(),
   NEXT_PUBLIC_BLOCKNATIVE_DAPP_ID: ss.string(),
-  NEXT_PUBLIC_THE_GRAPH_API_KEY: ss.string(),
   NEXT_PUBLIC_INFURA_ID: ss.string(),
   NEXT_PUBLIC_ONBOARD_API_KEY: ss.string(),
   NEXT_PUBLIC_CURRENT_ENV: ss.string(),
-  NEXT_PUBLIC_CONTENTFUL_SPACE_ID: ss.string(),
-  NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN: ss.string(),
   // optional envs
+  NEXT_PUBLIC_CONTENTFUL_SPACE_ID: ss.optional(ss.string()),
+  NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN: ss.optional(ss.string()),
+  NEXT_PUBLIC_THE_GRAPH_API_KEY: ss.optional(ss.string()),
+  NEXT_PUBLIC_GRAPH_ENDPOINT_V1: ss.optional(ss.string()),
+  NEXT_PUBLIC_GRAPH_ENDPOINT: ss.optional(ss.string()),
   NEXT_PUBLIC_DEPLOY_BLOCK: ss.optional(ss.string()),
   NEXT_PUBLIC_SIGNING_MESSAGE: ss.optional(ss.string()),
   NEXT_PUBLIC_CHAIN_ID: ss.optional(ss.string()),
@@ -58,14 +58,17 @@ const AppConfig = ss.object({
   votingContractAddress: ss.string(),
   votingTokenContractAddress: ss.string(),
   votingV1ContractAddress: ss.string(),
-  space: ss.string(),
-  accessToken: ss.string(),
   blocknativeDappId: ss.string(),
-  graphEndpointV1: ss.string(),
-  graphEndpoint: ss.string(),
   signingMessage: ss.string(),
   deployBlock: ss.number(),
   chainId: ss.number(),
+  graphEndpointV1: ss.optional(ss.string()),
+  graphEndpoint: ss.optional(ss.string()),
+  contentfulSpace: ss.optional(ss.string()),
+  contentfulAccessToken: ss.optional(ss.string()),
+  graphV1Enabled: ss.defaulted(ss.boolean(), false),
+  graphV2Enabled: ss.defaulted(ss.boolean(), false),
+  contentfulEnabled: ss.defaulted(ss.boolean(), false),
 });
 export type AppConfig = ss.Infer<typeof AppConfig>;
 
@@ -80,14 +83,19 @@ export const appConfig = ss.create(
     votingContractAddress: env.NEXT_PUBLIC_VOTING_CONTRACT_ADDRESS,
     votingTokenContractAddress: env.NEXT_PUBLIC_VOTING_TOKEN_CONTRACT_ADDRESS,
     votingV1ContractAddress: env.NEXT_PUBLIC_VOTING_V1_CONTRACT_ADDRESS,
-    space: env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
-    accessToken: env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN,
+    contentfulSpace: env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
+    contentfulAccessToken: env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN,
     graphEndpointV1: env.NEXT_PUBLIC_GRAPH_ENDPOINT_V1,
     graphEndpoint: env.NEXT_PUBLIC_GRAPH_ENDPOINT,
     signingMessage:
       env.NEXT_PUBLIC_SIGNING_MESSAGE ?? "Login to UMA Voter dApp",
     deployBlock: Number(env.NEXT_PUBLIC_DEPLOY_BLOCK ?? "0"),
     chainId: Number(env.NEXT_PUBLIC_CHAIN_ID ?? "1"),
+    graphV1Enabled: !!env.NEXT_PUBLIC_GRAPH_ENDPOINT_V1,
+    graphV2Enabled: !!env.NEXT_PUBLIC_GRAPH_ENDPOINT,
+    contentfulEnabled:
+      !!env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN &&
+      !!env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
   },
   AppConfig
 );

--- a/hooks/queries/rewards/useGlobals.ts
+++ b/hooks/queries/rewards/useGlobals.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { oneMinute } from "constant";
 import { getGlobals } from "graph";
+import { config } from "helpers/config";
 
 export function useGlobals() {
   return useQuery(["globals"], getGlobals, {
@@ -8,6 +9,7 @@ export function useGlobals() {
     initialData: {
       annualPercentageReturn: 0,
     },
+    enabled: config.graphV2Enabled,
     onError: (error) =>
       console.error("Error Fetching global data from subgraph:", error),
   });

--- a/hooks/queries/user/useUserVotingAndStakingDetails.ts
+++ b/hooks/queries/user/useUserVotingAndStakingDetails.ts
@@ -3,6 +3,7 @@ import { oneMinute, userDataKey } from "constant";
 import { BigNumber } from "ethers";
 import { getUserData } from "graph";
 import { useAccountDetails, useHandleError } from "hooks";
+import { config } from "helpers/config";
 
 export function useUserVotingAndStakingDetails(addressOverride?: string) {
   const { address: defaultAddress } = useAccountDetails();
@@ -13,7 +14,7 @@ export function useUserVotingAndStakingDetails(addressOverride?: string) {
     [userDataKey, address],
     () => getUserData(address),
     {
-      enabled: !!address,
+      enabled: !!address && config.graphV2Enabled,
       refetchInterval: oneMinute,
       initialData: {
         apr: BigNumber.from(0),

--- a/hooks/queries/votes/useContentfulData.ts
+++ b/hooks/queries/votes/useContentfulData.ts
@@ -8,18 +8,23 @@ import {
   useUpcomingVotes,
 } from "hooks";
 import { ContentfulDataByKeyT, ContentfulDataT, UniqueKeyT } from "types";
+import { config } from "helpers/config";
 
-const space = process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID ?? "";
-const accessToken = process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN ?? "";
+const { contentfulSpace, contentfulAccessToken } = config;
 
-const contentfulClient = contentful.createClient({
-  space,
-  accessToken,
-});
+const contentfulClient =
+  contentfulSpace && contentfulAccessToken
+    ? contentful.createClient({
+        space: contentfulSpace,
+        accessToken: contentfulAccessToken,
+      })
+    : undefined;
 
 async function getContentfulData(
   adminProposalNumbersByKey: Record<UniqueKeyT, number>
 ) {
+  if (!contentfulClient) throw new Error("Contentful API not available");
+
   const adminProposalNumbers = Object.values(adminProposalNumbersByKey);
   if (adminProposalNumbers.length === 0) return {};
 
@@ -73,6 +78,7 @@ export function useContentfulData() {
     () => getContentfulData(adminProposalNumbersByKey),
     {
       refetchInterval: oneMinute,
+      enabled: !!contentfulClient,
       initialData: {},
       onError,
     }

--- a/hooks/queries/votes/usePastVotes.ts
+++ b/hooks/queries/votes/usePastVotes.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { oneMinute, pastVotesKey } from "constant";
 import { getPastVotesAllVersions } from "graph";
 import { useHandleError, useVoteTimingContext } from "hooks";
+import { config } from "helpers/config";
 
 export function usePastVotes() {
   const { roundId } = useVoteTimingContext();
@@ -11,6 +12,7 @@ export function usePastVotes() {
     [pastVotesKey, roundId],
     () => getPastVotesAllVersions(),
     {
+      enabled: config.graphV1Enabled && config.graphV2Enabled,
       refetchInterval: oneMinute,
       initialData: {},
       onError,


### PR DESCRIPTION
## Motivation
We want to be able to run the app in the absense of contentful or the graph. The app should fail gracefully if either app is configured to not include these, or these endpoints fail to return data. 

## Changes
The app can now be explicitly configured to not include these services by making their environment variable configurations optional.  By disabling these we no longer have access to certain features such as apy calculations, or past vote history, but the app stays stable.  If these endpoints error or timeout the app will report the errors to the user but still work.