### PR TITLE
fix: fix magic number crash and display

### DIFF
--- a/components/Panel/VotePanel/Result.tsx
+++ b/components/Panel/VotePanel/Result.tsx
@@ -34,11 +34,7 @@ export function Result({
     participation;
 
   const resultsWithLabels = results.map(({ vote, tokensVotedWith }) => {
-    const voteAsString = vote.toFixed();
-    const formatted = formatVoteStringWithPrecision(
-      voteAsString,
-      decodedIdentifier
-    );
+    const formatted = formatVoteStringWithPrecision(vote, decodedIdentifier);
     const label = findVoteInOptions(formatted)?.label ?? formatted;
     const value = tokensVotedWith;
 

--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -92,9 +92,19 @@ export function VotesListItem({
   }, [wrapperRef.current?.offsetWidth]);
 
   useEffect(() => {
+    // Function returns true if the input exist and has changed from our committed value, false otherwise
+    function isDirtyCheck(): boolean {
+      if (phase !== "commit") return false;
+      const existingVote = getDecryptedVoteAsFormattedString();
+      if (!existingVote) return false;
+      // this happens if you clear the vote inputs, selected vote normally
+      // would be "" if editing. dirty = false if we clear inputs.
+      if (selectedVote === undefined) return false;
+      return selectedVote !== existingVote;
+    }
     const dirty = isDirtyCheck();
     if (setDirty && dirty !== isDirty) setDirty(dirty);
-  }, [selectedVote, setDirty, isDirty, isDirtyCheck]);
+  }, [selectedVote, setDirty, isDirty]);
 
   function onSelectVote(option: DropdownItemT) {
     if (option.value === "custom") {
@@ -166,9 +176,8 @@ export function VotesListItem({
 
   function getCorrectVote() {
     if (correctVote === undefined) return;
-    const correctVoteAsString = correctVote.toFixed();
     const formatted = formatVoteStringWithPrecision(
-      correctVoteAsString,
+      correctVote,
       decodedIdentifier
     );
 
@@ -266,17 +275,6 @@ export function VotesListItem({
     ) : (
       getCommittedOrRevealed()
     );
-  }
-
-  // Function returns true if the input exist and has changed from our committed value, false otherwise
-  function isDirtyCheck(): boolean {
-    if (phase !== "commit") return false;
-    const existingVote = getDecryptedVoteAsFormattedString();
-    if (!existingVote) return false;
-    // this happens if you clear the vote inputs, selected vote normally
-    // would be "" if editing. dirty = false if we clear inputs.
-    if (selectedVote === undefined) return false;
-    return selectedVote !== existingVote;
   }
 
   const style = {

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -1,12 +1,7 @@
 import { config } from "helpers/config";
 import { BigNumber } from "ethers";
 import request, { gql } from "graphql-request";
-import {
-  formatBytes32String,
-  formatVoteStringWithPrecision,
-  makePriceRequestsByKey,
-  parseEtherSafe,
-} from "helpers";
+import { formatBytes32String, makePriceRequestsByKey } from "helpers";
 import { PastVotesQuery } from "types";
 
 const { graphEndpoint, graphEndpointV1 } = config;
@@ -54,9 +49,7 @@ export async function getPastVotesV1() {
       revealedVotes,
     }) => {
       const identifier = formatBytes32String(id);
-      const correctVote = Number(
-        formatVoteStringWithPrecision(parseEtherSafe(price), identifier)
-      );
+      const correctVote = price;
       const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
       const participation = {
         uniqueCommitAddresses: revealedVotes.length,
@@ -65,9 +58,7 @@ export async function getPastVotesV1() {
       };
 
       const results = latestRound.groups.map(({ price, totalVoteAmount }) => ({
-        vote: Number(
-          formatVoteStringWithPrecision(parseEtherSafe(price), identifier)
-        ),
+        vote: price,
         tokensVotedWith: Number(totalVoteAmount),
       }));
       return {
@@ -129,9 +120,7 @@ export async function getPastVotesV2() {
       revealedVotes,
     }) => {
       const identifier = formatBytes32String(id);
-      const correctVote = Number(
-        formatVoteStringWithPrecision(parseEtherSafe(price), identifier)
-      );
+      const correctVote = price;
       const priceRequestIndex = BigNumber.from(requestIndex);
       const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
       const participation = {
@@ -140,9 +129,7 @@ export async function getPastVotesV2() {
         totalTokensVotedWith,
       };
       const results = latestRound.groups.map(({ price, totalVoteAmount }) => ({
-        vote: Number(
-          formatVoteStringWithPrecision(parseEtherSafe(price), identifier)
-        ),
+        vote: price,
         tokensVotedWith: Number(totalVoteAmount),
       }));
       return {

--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -1,5 +1,11 @@
 import { decodeHexString, makeUniqueKeyForVote } from "helpers";
-import { PriceRequestByKeyT, PriceRequestT, RawPriceRequestDataT } from "types";
+import {
+  PriceRequestByKeyT,
+  PriceRequestT,
+  RawPriceRequestDataT,
+  VoteParticipationT,
+  VoteResultsT,
+} from "types";
 
 export function makePriceRequestsByKey(
   priceRequests: RawPriceRequestDataT[] | undefined
@@ -22,7 +28,9 @@ function formatPriceRequests(priceRequests: RawPriceRequestDataT[]) {
     .filter((priceRequest): priceRequest is PriceRequestT => !!priceRequest);
 }
 
-function formatPriceRequest(priceRequest: RawPriceRequestDataT) {
+function formatPriceRequest(
+  priceRequest: RawPriceRequestDataT
+): PriceRequestT & VoteParticipationT & VoteResultsT {
   const time = Number(priceRequest.time);
   const timeMilliseconds = time * 1000;
   const timeAsDate = new Date(timeMilliseconds);
@@ -42,14 +50,21 @@ function formatPriceRequest(priceRequest: RawPriceRequestDataT) {
     decodedAncillaryData = `The ancillary data for this request is malformed and could not be decoded. Raw ancillary data: ${ancillaryData}`;
   }
   const correctVote = priceRequest.correctVote;
-  const participation = priceRequest.participation;
+  const participation = {
+    uniqueCommitAddresses:
+      priceRequest?.participation?.uniqueCommitAddresses || 0,
+    uniqueRevealAddresses:
+      priceRequest?.participation?.uniqueRevealAddresses || 0,
+    totalTokensVotedWith:
+      priceRequest?.participation?.totalTokensVotedWith || 0,
+  };
   const results = priceRequest.results;
   const uniqueKey = makeUniqueKeyForVote(
     decodedIdentifier,
     time,
     ancillaryData
   );
-  const isV1 = priceRequest.isV1;
+  const isV1 = priceRequest.isV1 ? true : false;
 
   return {
     time,
@@ -65,5 +80,5 @@ function formatPriceRequest(priceRequest: RawPriceRequestDataT) {
     results,
     uniqueKey,
     isV1,
-  } as PriceRequestT;
+  };
 }

--- a/stories/BaseComponents/navigation/Panel.stories.tsx
+++ b/stories/BaseComponents/navigation/Panel.stories.tsx
@@ -267,19 +267,19 @@ VotePanelWithResults.args = {
     },
     results: [
       {
-        vote: 50000000000,
+        vote: "50000000000",
         tokensVotedWith: 1234,
       },
       {
-        vote: 20,
+        vote: "20",
         tokensVotedWith: 5678,
       },
       {
-        vote: 0.1,
+        vote: "10",
         tokensVotedWith: 500,
       },
       {
-        vote: 2,
+        vote: "2",
         tokensVotedWith: 199,
       },
     ],

--- a/stories/mocks/votes.ts
+++ b/stories/mocks/votes.ts
@@ -97,12 +97,12 @@ export const voteRevealed = {
 
 export const voteWithCorrectVoteWithoutUserVote = {
   ...voteWithoutUserVote,
-  correctVote: 0,
+  correctVote: "0",
 };
 
 export const voteWithCorrectVoteWithUserVote = {
   ...voteWithUserVote,
-  correctVote: 0,
+  correctVote: "0",
 };
 
 export function makeVoteWithHistory(

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -22,7 +22,7 @@ export type PriceRequestT = {
   identifier: string;
   ancillaryData: string;
   voteNumber: BigNumber | undefined;
-  correctVote?: number;
+  correctVote?: string;
   // computed values
   timeMilliseconds: number;
   timeAsDate: Date;
@@ -43,7 +43,7 @@ export type VoteParticipationT = {
 };
 
 export type ResultsT = {
-  vote: number;
+  vote: string;
   tokensVotedWith: number;
 }[];
 
@@ -56,7 +56,7 @@ export type RawPriceRequestDataT = {
   identifier: string;
   ancillaryData: string;
   priceRequestIndex: BigNumber | undefined;
-  correctVote?: number;
+  correctVote?: string;
   participation?: ParticipationT;
   results?: ResultsT;
   isV1?: boolean;


### PR DESCRIPTION
## motivation
There were a couple issues, when viewing the zelensky vote, the app would crash due to magic number breaking display formatting. once that was fixed, it would show 2 no values, because the magic number value on the vote was not matching the value on the option, this ended up showing 2 no values rather than yes, no, early vote.

## changes
the root cause of this problem was pulling the correct vote number from the subgraph and immediately converting it to a number, this ends up converting the magic number to something that cannot be converted back to the original number.  to fix this we stop tryign to convert votes into numbers and leave them as raw strings. when the number is finally displayed its converted to the correct decimals. 

## QA
go to page 2 of past votes, and see the zelensky time magazine vote. open the details panel and see the yes/no/early vote chart working correctly, app not crashing