### PR TITLE
improve: allow augment request to configure fromblocks

### DIFF
--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -64,10 +64,12 @@ export function Details({
 
   const links = [
     umipOrUppLink,
-    makeTransactionHashLink(
-      "Ethereum DVM request",
-      augmentedData?.l1RequestTxHash
-    ),
+    augmentedData?.l1RequestTxHash !== "rolled"
+      ? makeTransactionHashLink(
+          "Ethereum DVM request",
+          augmentedData?.l1RequestTxHash
+        )
+      : undefined,
     // only show if the originating chain id is not ethereum
     augmentedData?.originatingChainId &&
     augmentedData?.originatingChainId !== 1 &&

--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -57,6 +57,10 @@ export function Details({
   }
 
   const optionLabels = options?.map(({ label }) => label);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const chainName: string | undefined = augmentedData?.originatingChainId
+    ? supportedChains[augmentedData.originatingChainId]
+    : undefined;
 
   const links = [
     umipOrUppLink,
@@ -65,9 +69,11 @@ export function Details({
       augmentedData?.l1RequestTxHash
     ),
     // only show if the originating chain id is not ethereum
-    augmentedData?.originatingChainId && augmentedData?.originatingChainId !== 1
+    augmentedData?.originatingChainId &&
+    augmentedData?.originatingChainId !== 1 &&
+    chainName
       ? makeTransactionHashLink(
-          `${supportedChains[augmentedData.originatingChainId]} DVM request`,
+          `${chainName} DVM request`,
           augmentedData.originatingChainTxHash
         )
       : false,

--- a/pages/api/_common.ts
+++ b/pages/api/_common.ts
@@ -36,8 +36,8 @@ export function isSupportedChainId(
   return chainId in supportedChains;
 }
 
-// add block start times here, can also convert this to envs somehow. this is used for augmented request evnets
-// and can be used in other places as well to optimize event calls.
+// add block start times here, perhaps we can allow this to be configured through environment variables eventually.
+// this is used for augmented request events and can be used in other places as well to optimize event calls.
 export const fromBlocks: Record<string, Record<number | string, number>> = {
   OptimisticOracle: {
     1: 0,

--- a/pages/api/_common.ts
+++ b/pages/api/_common.ts
@@ -1,12 +1,13 @@
 import { getAbi, getAddress } from "@uma/contracts-node";
 import { Contract, ethers } from "ethers";
 import { NodeUrls, SupportedChainIdsWithGoerli } from "types";
+import { supportedChains } from "constant";
 
 type GetAddressParams = Parameters<typeof getAddress>;
 
 type GetAbiParams = Parameters<typeof getAbi>;
 
-type ContractName = GetAddressParams[0] & GetAbiParams[0];
+export type ContractName = GetAddressParams[0] & GetAbiParams[0];
 
 export function getProviderByChainId(chainId: SupportedChainIdsWithGoerli) {
   return new ethers.providers.JsonRpcBatchProvider(getNodeUrls()[chainId]);
@@ -26,4 +27,44 @@ export async function constructContract(
     getAbi(contractName),
     getProviderByChainId(chainId)
   );
+}
+
+export function isSupportedChainId(
+  chainId: string | number | undefined
+): chainId is SupportedChainIdsWithGoerli {
+  if (chainId === undefined) return false;
+  return chainId in supportedChains;
+}
+
+// add block start times here, can also convert this to envs somehow. this is used for augmented request evnets
+// and can be used in other places as well to optimize event calls.
+export const fromBlocks: Record<string, Record<number | string, number>> = {
+  OptimisticOracle: {
+    1: 0,
+    5: 0,
+  },
+  OptimisticOracleV2: {
+    1: 0,
+    5: 0,
+  },
+  SkinnyOptimisticOracle: {
+    1: 0,
+    5: 0,
+  },
+  VotingV2: {
+    1: 0,
+    5: 0,
+  },
+  Voting: {
+    1: 0,
+    5: 0,
+  },
+};
+
+export function getFromBlock(
+  oracleType: string,
+  chainId: number,
+  fallbackFromBlock = 0
+): number {
+  return fromBlocks?.[oracleType]?.[chainId] || fallbackFromBlock;
 }

--- a/pages/api/augment-request.ts
+++ b/pages/api/augment-request.ts
@@ -1,18 +1,56 @@
-import {
-  OptimisticOracleEthers,
-  OptimisticOracleV2Ethers,
-  SkinnyOptimisticOracleEthers,
-  VotingEthers,
-} from "@uma/contracts-node";
+import assert from "assert";
 import { NextApiRequest, NextApiResponse } from "next";
-import { OracleTypeT, PriceRequestT, SupportedChainIds } from "types";
-import { constructContract, getNodeUrls } from "./_common";
+import { SupportedChainIdsWithGoerli } from "types";
+import {
+  constructContract,
+  getNodeUrls,
+  getFromBlock,
+  isSupportedChainId,
+  ContractName,
+} from "./_common";
+import * as ss from "superstruct";
 
-enum OracleType {
-  OptimisticOracle,
-  OptimisticOracleV2,
-  SkinnyOptimisticOracle,
-}
+const debug = !!process.env.DEBUG;
+
+type SupportedChainIds = SupportedChainIdsWithGoerli;
+type OracleType = Extract<
+  ContractName,
+  "OptimisticOracle" | "OptimisticOracleV2" | "SkinnyOptimisticOracle"
+>;
+type VotingType = Extract<ContractName, "Voting" | "VotingV2">;
+
+// TODO: enable voting v2 when its ready
+const EnabledVoting: VotingType[] = ["Voting"];
+const EnabledOracles: OracleType[] = [
+  "OptimisticOracle",
+  "OptimisticOracleV2",
+  "SkinnyOptimisticOracle",
+];
+
+const L1Request = ss.object({
+  uniqueKey: ss.string(),
+  time: ss.number(),
+  identifier: ss.string(),
+});
+type L1Request = ss.Infer<typeof L1Request>;
+
+const L1Requests = ss.array(L1Request);
+type L1Requests = ss.Infer<typeof L1Requests>;
+
+const RequestBody = ss.object({
+  l1Requests: L1Requests,
+  chainId: ss.defaulted(ss.number(), 1),
+});
+type RequestBody = ss.Infer<typeof RequestBody>;
+
+const CommonEventData = ss.object({
+  transactionHash: ss.string(),
+  identifier: ss.string(),
+  time: ss.number(),
+  contractType: ss.string(),
+  chainId: ss.number(),
+});
+type CommonEventData = ss.Infer<typeof CommonEventData>;
 
 function getOoChainIds() {
   return Object.keys(getNodeUrls()).map(Number) as SupportedChainIds[];
@@ -20,10 +58,11 @@ function getOoChainIds() {
 
 function constructOoUiLink(
   txHash: string | undefined,
-  chainId: SupportedChainIds | undefined,
-  oracleType: OracleTypeT | undefined
+  chainId: string | number | undefined,
+  oracleType: string | undefined
 ) {
   if (!txHash || !chainId || !oracleType) return;
+  if (!isSupportedChainId(chainId)) return;
   return `https://oracle.umaproject.org/request?transactionHash=${txHash}&chainId=${chainId}&oracleType=${castOracleNameForOOUi(
     oracleType
   )}`;
@@ -38,148 +77,156 @@ function castOracleNameForOOUi(oracleType: string): string {
     case "SkinnyOptimisticOracle":
       return "Skinny";
     default:
-      return "";
+      throw new Error("Unable to cast oracle name for OO UI: " + oracleType);
   }
 }
 
-async function constructOptimisticOraclesByChain(chainId: SupportedChainIds) {
-  const optimisticOracle = (await constructContract(
-    chainId,
-    "OptimisticOracle"
-  )) as OptimisticOracleEthers;
-  const optimisticOracleV2 = (await constructContract(
-    chainId,
-    "OptimisticOracleV2"
-  )) as OptimisticOracleV2Ethers;
-
-  // Only mainnet has a SkinnyOptimisticOracle so only construct it here. All other chains of interest have OOv1 and V2.
-  const skinnyOptimisticOracle =
-    chainId == 1
-      ? ((await constructContract(
-          chainId,
-          "SkinnyOptimisticOracle"
-        )) as SkinnyOptimisticOracleEthers)
-      : null;
-  return [optimisticOracle, optimisticOracleV2, skinnyOptimisticOracle];
+type LookupTable<E> = Record<string, Record<number, E>>;
+function createLookupTable<Event extends { time: number; identifier: string }>(
+  events: Event[],
+  table: LookupTable<Event> = {}
+): LookupTable<Event> {
+  return events.reduce((table, event) => {
+    const identifier = event.identifier.toLowerCase();
+    const time = event.time;
+    if (identifier && table[identifier] === undefined) table[identifier] = {};
+    if (time && table[identifier][time] === undefined)
+      table[identifier][time] = event;
+    return table;
+  }, table);
 }
 
-async function getOptimisticOraclePriceRequestEventsByChainId(
+async function getVotingPriceRequestAdded(
+  contractType: VotingType,
   chainId: SupportedChainIds
-) {
-  const chainOptimisticOracles = await constructOptimisticOraclesByChain(
-    chainId
+): Promise<CommonEventData[]> {
+  const contract = await constructContract(chainId, contractType);
+  const events = await contract.queryFilter(
+    contract.filters.PriceRequestAdded(),
+    getFromBlock(contractType as string, chainId as number)
   );
-
-  const requests = await Promise.all(
-    chainOptimisticOracles.map((optimisticOracle) =>
-      optimisticOracle
-        ? optimisticOracle.queryFilter(optimisticOracle.filters.RequestPrice())
-        : null
+  return events.map((event) =>
+    ss.create(
+      {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        transactionHash: event?.transactionHash || "rolled",
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        identifier: event?.args?.identifier,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        time: event?.args?.time?.toNumber(),
+        contractType,
+        chainId,
+      },
+      CommonEventData
     )
   );
+}
 
-  return requests
-    .map((oracleRequests, index) => {
-      return oracleRequests
-        ? oracleRequests.map((ooRequest) => {
-            return {
-              transactionHash: ooRequest.transactionHash,
-              identifier: ooRequest?.args?.identifier,
-              time: Number(ooRequest?.args?.timestamp),
-              oracleType: OracleType[index] as OracleTypeT,
-            };
-          })
-        : [];
+async function getManyVotingPriceRequestAdded(
+  contractTypes: VotingType[],
+  chainIds: SupportedChainIds[]
+): Promise<CommonEventData[]> {
+  const requests = contractTypes
+    .map((contractType) =>
+      chainIds.map((chainId) =>
+        getVotingPriceRequestAdded(contractType, chainId)
+      )
+    )
+    .flat();
+  return (await Promise.allSettled(requests))
+    .map((result) => {
+      if (result.status === "fulfilled") {
+        return result.value;
+      }
+      if (debug) console.warn(result.reason);
+      return [];
     })
     .flat();
 }
 
-type OoTransactionT = {
-  requestTransactionHash: string | undefined;
-  chainId: SupportedChainIds | undefined;
-  oracleType: OracleTypeT | undefined;
-};
-
-async function getRequestTxFromL1RequestInformation(
-  l1Requests: PriceRequestT[]
-) {
-  const ooChainIds = getOoChainIds();
-
-  const chainOoRequests = await Promise.all(
-    ooChainIds.map((chainId) =>
-      getOptimisticOraclePriceRequestEventsByChainId(chainId)
+async function getOracleRequestPrices(
+  contractType: OracleType,
+  chainId: SupportedChainIds
+): Promise<CommonEventData[]> {
+  const contract = await constructContract(chainId, contractType);
+  const events = await contract.queryFilter(
+    contract.filters.RequestPrice(),
+    getFromBlock(contractType, chainId)
+  );
+  return events.map((event) =>
+    ss.create(
+      {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        transactionHash: event?.transactionHash,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        identifier: event?.args?.identifier,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        time: event?.args?.timestamp,
+        contractType,
+        chainId,
+      },
+      CommonEventData
     )
   );
-  const ooRequestTxs: (OoTransactionT | undefined)[] = [];
-  l1Requests.forEach((l1Request) => {
-    const foundOoRequestTx: OoTransactionT = {
-      requestTransactionHash: undefined,
-      chainId: undefined,
-      oracleType: undefined,
-    };
-    chainOoRequests.forEach((_, ooChainId) => {
-      chainOoRequests[ooChainId].forEach((ooRequest) => {
-        if (
-          l1Request.identifier.toLowerCase() ==
-            ooRequest.identifier.toLowerCase() &&
-          l1Request.time == ooRequest.time
-        ) {
-          foundOoRequestTx.requestTransactionHash = ooRequest.transactionHash;
-          foundOoRequestTx.chainId = ooChainIds[ooChainId];
-          foundOoRequestTx.oracleType = ooRequest.oracleType;
-        }
-      });
-    });
-    ooRequestTxs.push(foundOoRequestTx);
-  });
-  return ooRequestTxs;
 }
 
-async function getAugmentingRequestInformation(l1Requests: PriceRequestT[]) {
-  const votingV1 = (await constructContract(1, "Voting")) as VotingEthers;
-  // todo: add voting v2 when released.
-  // const votingV2 = await constructContract(1, "VotingV2");
-  const l1RequestEvents = (
-    await Promise.all([
-      votingV1.queryFilter(votingV1.filters.PriceRequestAdded()),
-      // votingV2.queryFilter(votingV2.filters.PriceRequestAdded())
-    ])
-  ).flat();
+async function getManyOracleRequestsPrices(
+  oracleTypes: OracleType[],
+  chainIds: SupportedChainIds[]
+): Promise<CommonEventData[]> {
+  const requests = oracleTypes
+    .map((oracleType) =>
+      chainIds.map((chainId) => getOracleRequestPrices(oracleType, chainId))
+    )
+    .flat();
+  return (await Promise.allSettled(requests))
+    .map((result) => {
+      if (result.status === "fulfilled") {
+        return result.value;
+      }
+      if (debug) console.warn(result.reason);
+      return [];
+    })
+    .flat();
+}
 
-  const l1RequestTxHashes = l1Requests.map((l1Request) => {
-    const l1RequestTxHash =
-      l1RequestEvents.find((event) => {
-        if (
-          l1Request.identifier.toLowerCase() ==
-            event.args?.identifier?.toLowerCase() &&
-          event.args.time.eq(l1Request.time)
-        ) {
-          return true;
-        } else return false;
-      })?.transactionHash ?? "rolled";
-    return {
-      uniqueKey: l1Request.uniqueKey,
-      l1RequestTxHash,
-    };
-  });
-
-  const requestTransactions = await getRequestTxFromL1RequestInformation(
-    l1Requests
+async function augmentRequests({ l1Requests, chainId }: RequestBody) {
+  assert(isSupportedChainId(chainId), `Unsupported chainid: ${chainId}`);
+  const votingPriceRequestAddedEvents = await getManyVotingPriceRequestAdded(
+    EnabledVoting,
+    [chainId]
+  );
+  const votingPriceRequestTable = createLookupTable(
+    votingPriceRequestAddedEvents
   );
 
-  return l1RequestTxHashes.map(({ l1RequestTxHash, uniqueKey }, index) => {
+  const ooChains = getOoChainIds();
+  const requestPriceEvents = await getManyOracleRequestsPrices(
+    EnabledOracles,
+    ooChains
+  );
+  const requestPriceTable = createLookupTable(requestPriceEvents);
+
+  return l1Requests.map((l1Request) => {
+    const votingPriceRequestEvent =
+      votingPriceRequestTable?.[l1Request.identifier.toLowerCase()]?.[
+        l1Request.time
+      ] || {};
+    const oracleRequestPriceEvent =
+      requestPriceTable?.[l1Request.identifier.toLowerCase()]?.[
+        l1Request.time
+      ] || {};
     return {
-      l1RequestTxHash,
-      uniqueKey,
+      ...l1Request,
+      l1RequestTxHash: votingPriceRequestEvent.transactionHash,
       ooRequestUrl: constructOoUiLink(
-        requestTransactions[index]?.requestTransactionHash,
-        requestTransactions[index]?.chainId,
-        requestTransactions[index]?.oracleType
+        oracleRequestPriceEvent.transactionHash,
+        oracleRequestPriceEvent.chainId,
+        oracleRequestPriceEvent.contractType
       ),
-      originatingChainTxHash:
-        requestTransactions[index]?.requestTransactionHash,
-      originatingChainId: requestTransactions[index]?.chainId,
-      originatingOracleType: requestTransactions[index]?.oracleType,
+      originatingChainTxHash: oracleRequestPriceEvent.transactionHash,
+      originatingChainId: oracleRequestPriceEvent.chainId,
+      originatingOracleType: oracleRequestPriceEvent.contractType,
     };
   });
 }
@@ -191,17 +238,11 @@ export default async function handler(
   response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000"); // Cache for 30 days and re-build cache if re-deployed.
 
   try {
-    const body = request.body as { l1Requests: PriceRequestT[] };
-    ["l1Requests"].forEach((requiredKey) => {
-      if (!Object.keys(body).includes(requiredKey))
-        throw "Missing key in req body! required: l1Requests";
-    });
-    const readableTxData = await getAugmentingRequestInformation(
-      body.l1Requests
-    );
-    response.status(200).send(readableTxData);
+    const body: RequestBody = ss.create(request.body, RequestBody);
+    const result = await augmentRequests(body);
+    response.status(200).send(result);
   } catch (e) {
-    console.error(e);
+    debug && console.error(e);
     response.status(500).send({
       message: "Error in fetching augmented information",
       error: e instanceof Error ? e.message : e,

--- a/pages/api/augment-request.ts
+++ b/pages/api/augment-request.ts
@@ -9,6 +9,7 @@ import {
   ContractName,
 } from "./_common";
 import * as ss from "superstruct";
+import { BigNumber } from "ethers";
 
 const debug = !!process.env.DEBUG;
 
@@ -113,7 +114,10 @@ async function getVotingPriceRequestAdded(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         identifier: event?.args?.identifier,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        time: event?.args?.time?.toNumber(),
+        time:
+          event?.args?.time instanceof BigNumber
+            ? event?.args?.time?.toNumber()
+            : event?.args?.time,
         contractType,
         chainId,
       },
@@ -161,7 +165,10 @@ async function getOracleRequestPrices(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         identifier: event?.args?.identifier,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        time: event?.args?.timestamp,
+        time:
+          event?.args?.timestamp instanceof BigNumber
+            ? event?.args?.timestamp?.toNumber()
+            : event?.args?.timestamp,
         contractType,
         chainId,
       },

--- a/pages/api/augment-request.ts
+++ b/pages/api/augment-request.ts
@@ -110,7 +110,7 @@ async function getVotingPriceRequestAdded(
     ss.create(
       {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        transactionHash: event?.transactionHash || "rolled",
+        transactionHash: event?.transactionHash,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         identifier: event?.args?.identifier,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
@@ -225,7 +225,7 @@ async function augmentRequests({ l1Requests, chainId }: RequestBody) {
       ] || {};
     return {
       ...l1Request,
-      l1RequestTxHash: votingPriceRequestEvent.transactionHash,
+      l1RequestTxHash: votingPriceRequestEvent.transactionHash ?? "rolled",
       ooRequestUrl: constructOoUiLink(
         oracleRequestPriceEvent.transactionHash,
         oracleRequestPriceEvent.chainId,

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -220,6 +220,24 @@ export type OracleTypeT =
   | "OptimisticOracleV2"
   | "SkinnyOptimisticOracle";
 
+export const AugmentedVoteDataResponseT = ss.object({
+  uniqueKey: ss.string(),
+  time: ss.number(),
+  identifier: ss.string(),
+  l1RequestTxHash: ss.optional(ss.string()),
+  ooRequestUrl: ss.optional(ss.string()),
+  originatingChainTxHash: ss.optional(ss.string()),
+  originatingChainId: ss.optional(ss.number()),
+  originatingOracleType: ss.optional(ss.string()),
+});
+export type AugmentedVoteDataResponseT = ss.Infer<
+  typeof AugmentedVoteDataResponseT
+>;
+
+export type VoteAugmentedDataT = {
+  augmentedData: AugmentedVoteDataT | undefined;
+};
+
 export type AugmentedVoteDataT = {
   l1RequestTxHash: string;
   uniqueKey: UniqueKeyT;
@@ -227,10 +245,6 @@ export type AugmentedVoteDataT = {
   originatingChainTxHash: string | undefined;
   originatingChainId: SupportedChainIds | undefined;
   originatingOracleType: OracleTypeT | undefined;
-};
-
-export type VoteAugmentedDataT = {
-  augmentedData: AugmentedVoteDataT | undefined;
 };
 
 export type AugmentedVoteDataByKeyT = Record<UniqueKeyT, AugmentedVoteDataT>;

--- a/web3/queries/votes/getAugmentedVoteData.ts
+++ b/web3/queries/votes/getAugmentedVoteData.ts
@@ -1,29 +1,53 @@
+import * as ss from "superstruct";
 import {
   AugmentedVoteDataByKeyT,
-  AugmentedVoteDataT,
+  AugmentedVoteDataResponseT,
   PriceRequestByKeyT,
 } from "types";
 
-export async function getAugmentedVoteData(priceRequests: PriceRequestByKeyT) {
+const ErrorT = ss.object({
+  message: ss.string(),
+  error: ss.string(),
+});
+
+export async function getAugmentedVoteData(
+  priceRequests: PriceRequestByKeyT,
+  chainId = 1
+): Promise<AugmentedVoteDataByKeyT> {
   const response = await fetch("/api/augment-request", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ l1Requests: Object.values(priceRequests) }),
+    body: JSON.stringify({
+      l1Requests: Object.values(priceRequests).map((req) => ({
+        uniqueKey: req.uniqueKey,
+        time: req.time,
+        identifier: req.identifier,
+      })),
+      chainId,
+    }),
   });
 
   if (!response.ok) {
-    throw new Error("Error fetching augmented request data");
+    const { message, error } = ss.create(await response.json(), ErrorT);
+    throw new Error([message, error].join(": "));
   }
 
-  const result = (await response.json()) as AugmentedVoteDataT[];
+  const result: AugmentedVoteDataResponseT[] = ss.create(
+    await response.json(),
+    ss.array(AugmentedVoteDataResponseT)
+  );
 
-  const byKey: AugmentedVoteDataByKeyT = {};
-
-  result.forEach((augmentedData) => {
-    byKey[augmentedData.uniqueKey] = augmentedData;
-  });
-
-  return byKey;
+  return result.reduce((byKey, augmentedData: AugmentedVoteDataResponseT) => {
+    const key = augmentedData.uniqueKey;
+    byKey[key] = {
+      ...priceRequests[key],
+      ...augmentedData,
+    };
+    return byKey;
+    // this still needs to be casted because superstruct isnt validating the enumerated data such as
+    // chain id and oracle type which are stricter in typescript. this should prevent compile issues even though
+    // its not ideal
+  }, {} as Record<string, AugmentedVoteDataResponseT>) as AugmentedVoteDataByKeyT;
 }


### PR DESCRIPTION
## Motivitation
Consistently getting errors in the serverless function due to large event queries, this is preventing data from being returned from the augment request calls. 

## changes
The initial solution was to add a way to configure block start times for each event query, but the way the types and code was structured it was quite difficult to get typescript to approve.  used this as an opportunity to improve the code:
1. optional block start times per contract per chain are added, currently defaulting to 0
2. less casting, stronger type checks generally
3. data parameters sent to serverless function is now validated with superstruct before use
4. an optional parameter for chain id is now available to the caller, rather than hard coding this to 1 ( defaults to 1 if omitted)
5. data returned from serverless function is more strongly validated on the frontend with super struct, though it still gets cast in the end
6. structure of serverless code is updated to query data at the beginning of the call, rather than throughout the code to make it easier to understand and optimize calls if needed
7. event data returned from queries are treated as unknown, and put into a common event type, which gets validated with superstruct
8. efficiency is improved from n*m lookups to n+m where n is the number of requests to augment, and m is the number of events returned from queries
9. Promise.allSettled is used instead of Promise.all when making multiple event queries, to prevent a single failure from stopping calculations
10. optional debugging output with new env `DEBUG`
11. more obvious way to enable/disable querying of certain contracts at the top of the file

These changes had the effect of eliminating the initial problem without needing to change the startblock times ( all still 0). its possible perhaps an issue was causing the request to fail and keep requering, but not exactly sure why this fixed it. 

sample of logged data in frontend
![image](https://user-images.githubusercontent.com/4429761/210809236-297191c5-0f0b-4ae7-8959-d9baf6c243c1.png)
