### PR TITLE
improve: remove references to goerli as a supported chain, include it natively

### DIFF
--- a/constant/web3/supportedChains.ts
+++ b/constant/web3/supportedChains.ts
@@ -1,5 +1,6 @@
 export const supportedChains = {
   1: "Ethereum",
+  5: "Görli",
   10: "Optimism",
   100: "Gnosis",
   137: "Polygon",

--- a/pages/api/_common.ts
+++ b/pages/api/_common.ts
@@ -1,6 +1,6 @@
 import { getAbi, getAddress } from "@uma/contracts-node";
 import { Contract, ethers } from "ethers";
-import { NodeUrls, SupportedChainIdsWithGoerli } from "types";
+import { NodeUrls, SupportedChainIds } from "types";
 import { supportedChains } from "constant";
 
 type GetAddressParams = Parameters<typeof getAddress>;
@@ -9,7 +9,7 @@ type GetAbiParams = Parameters<typeof getAbi>;
 
 export type ContractName = GetAddressParams[0] & GetAbiParams[0];
 
-export function getProviderByChainId(chainId: SupportedChainIdsWithGoerli) {
+export function getProviderByChainId(chainId: SupportedChainIds) {
   return new ethers.providers.JsonRpcBatchProvider(getNodeUrls()[chainId]);
 }
 
@@ -19,7 +19,7 @@ export function getNodeUrls() {
 }
 
 export async function constructContract(
-  chainId: SupportedChainIdsWithGoerli,
+  chainId: SupportedChainIds,
   contractName: ContractName
 ) {
   return new Contract(
@@ -31,7 +31,7 @@ export async function constructContract(
 
 export function isSupportedChainId(
   chainId: string | number | undefined
-): chainId is SupportedChainIdsWithGoerli {
+): chainId is SupportedChainIds {
   if (chainId === undefined) return false;
   return chainId in supportedChains;
 }

--- a/pages/api/augment-request.ts
+++ b/pages/api/augment-request.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { NextApiRequest, NextApiResponse } from "next";
-import { SupportedChainIdsWithGoerli } from "types";
+import { SupportedChainIds } from "types";
 import {
   constructContract,
   getNodeUrls,
@@ -13,7 +13,6 @@ import { BigNumber } from "ethers";
 
 const debug = !!process.env.DEBUG;
 
-type SupportedChainIds = SupportedChainIdsWithGoerli;
 type OracleType = Extract<
   ContractName,
   "OptimisticOracle" | "OptimisticOracleV2" | "SkinnyOptimisticOracle"

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -202,13 +202,11 @@ export type VoteDecodedAdminTransactionsT = {
 
 export type SupportedChainIds = keyof typeof supportedChains;
 
-export type SupportedChainIdsWithGoerli = SupportedChainIds | 5;
-
 export type MainnetOrGoerli = 1 | 5;
 
 export type NodeUrl = string;
 
-export type NodeUrls = Record<SupportedChainIdsWithGoerli, NodeUrl>;
+export type NodeUrls = Record<SupportedChainIds, NodeUrl>;
 
 export type IdentifierAndTimeStampT = {
   identifier: string;


### PR DESCRIPTION
## motivation
We dont want to special case the testnet if we dont have to, doing this has also caused typescript issues when trying to find names for supported chains when using goerli, as that object did not have a goerli id.  

## changes
this simply adds goerli into supported chain object and supported chain type, and removes references to the type with goerli.

**do not merge until #153 goes in, the base needs to be set to master**