### PR TITLE
fix: fixed blocked commits, and delegate/delegator statuses

### DIFF
--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -96,8 +96,9 @@ export function Votes() {
     const isDelegate = getDelegationStatus() === "delegate";
     const hasSigner = !!signer;
     const votesToShow = determineVotesToShow();
-    const hasPreviouslyCommitted =
-      votesToShow.filter((vote) => vote.decryptedVote).length > 0;
+    const hasPreviouslyCommittedAll =
+      votesToShow.filter((vote) => vote.decryptedVote).length ===
+      votesToShow.length;
     // counting how many votes we have edited with commitable values ( non empty )
     const selectedVotesCount = Object.values(selectedVotes).filter(
       (x) => x
@@ -105,7 +106,7 @@ export function Votes() {
     // check if we have votes to commit by seeing there are more than 1 and its dirty
     const hasVotesToCommit =
       selectedVotesCount > 0
-        ? hasPreviouslyCommitted
+        ? hasPreviouslyCommittedAll
           ? isDirty()
           : true
         : false;
@@ -303,6 +304,7 @@ export function Votes() {
               activityStatus={getActivityStatus()}
               moreDetailsAction={() => openVotePanel(vote)}
               key={vote.uniqueKey}
+              delegationStatus={getDelegationStatus()}
               isDirty={dirtyInputs[index]}
               setDirty={(dirty: boolean) => {
                 setDirtyInput((inputs) => {

--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -31,6 +31,7 @@ export interface Props {
   activityStatus: ActivityStatusT;
   moreDetailsAction: () => void;
   isFetching: boolean;
+  delegationStatus?: string;
   setDirty?: (dirty: boolean) => void;
   isDirty?: boolean;
 }
@@ -44,6 +45,7 @@ export function VotesListItem({
   isFetching,
   setDirty,
   isDirty = false,
+  delegationStatus,
 }: Props) {
   const { signer } = useWalletContext();
   const { width } = useWindowSize();
@@ -164,6 +166,9 @@ export function VotesListItem({
   }
 
   function getYourVote() {
+    if (!decryptedVote && isCommitted) {
+      return "Unknown";
+    }
     if (!decryptedVote) return "Did not vote";
     return (
       findVoteInOptions(getDecryptedVoteAsFormattedString())?.label ??
@@ -192,10 +197,27 @@ export function VotesListItem({
 
   function getCommittedOrRevealed() {
     if (phase === "commit") {
+      if (isCommitted && !decryptedVote) {
+        if (delegationStatus === "delegator") {
+          return "Committed by Delegate";
+        } else if (delegationStatus === "delegate") {
+          return "Committed by Delegator";
+        } else {
+          return "Decrypt Error";
+        }
+      }
       return isCommitted ? "Committed" : "Not committed";
     } else {
       if (!isCommitted) return "Not committed";
-      if (!decryptedVote || !canReveal) return "Unable to reveal";
+      if (!decryptedVote || !canReveal) {
+        if (delegationStatus === "delegator") {
+          return "Delegate Must Reveal";
+        } else if (delegationStatus === "delegate") {
+          return "Delegator Must Reveal";
+        } else {
+          return "Unable to reveal";
+        }
+      }
       return isRevealed ? "Revealed" : "Not revealed";
     }
   }


### PR DESCRIPTION
## motivation
turns out when you have a delegate/delegator relationship, and both commit 1 vote, you can no longer commit again for any votes you have not already committed. 

## changes
This fixes the logic disabling the commit button incorrectly, the logic is a bit tricky, but it seems to work now. also used this as an opportunity to clarify labels when votes are committed from delegate/delegator account. probably should have put this in a new PR but we can see the changes here:
commit cycle where delegator committed viewing from delegate:
![1](https://user-images.githubusercontent.com/4429761/211062145-f2da4c76-fcb2-4752-8eb0-5312583fee9b.PNG)

reveal cycle from various viewpoints, and a reveal
![2](https://user-images.githubusercontent.com/4429761/211062149-fd9023d9-878b-4d78-90d6-0976e28391a8.PNG)
![3](https://user-images.githubusercontent.com/4429761/211062158-48fa44d9-ff29-4e88-a5d1-9dd08f2d9551.PNG)
![4](https://user-images.githubusercontent.com/4429761/211062170-1b029532-de36-4d4b-9469-9b48bcdcca37.PNG)
