### PR TITLE
fix: corrected dvm links in details

### DIFF
--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -1,5 +1,5 @@
 import { Button, PanelErrorBanner } from "components";
-import { mobileAndUnder, supportedChains } from "constant";
+import { mobileAndUnder, supportedChains, getOracleProperName } from "constant";
 import {
   formatNumberForDisplay,
   makeTransactionHashLink,
@@ -17,7 +17,7 @@ import Time from "public/assets/icons/time-with-inner-circle.svg";
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import styled from "styled-components";
-import { LinkT, VoteT, SupportedChainIds } from "types";
+import { LinkT, VoteT } from "types";
 import { PanelSectionTitle } from "../styles";
 import { ChainIcon } from "./ChainIcon";
 import { OoTypeIcon } from "./OoTypeIcon";
@@ -58,17 +58,27 @@ export function Details({
   }
 
   const optionLabels = options?.map(({ label }) => label);
-  const chainId: SupportedChainIds =
-    augmentedData?.originatingChainId ?? config.chainId;
-  const chainName = supportedChains[chainId];
-
   const links = [
     umipOrUppLink,
+    augmentedData?.l1RequestTxHash &&
     augmentedData?.l1RequestTxHash !== "rolled"
       ? makeTransactionHashLink(
-          `${chainName} DVM request`,
-          augmentedData?.originatingChainTxHash,
-          chainId
+          `${config.properName} DVM request`,
+          augmentedData?.l1RequestTxHash,
+          config.chainId
+        )
+      : undefined,
+    augmentedData?.originatingChainTxHash &&
+    augmentedData.originatingChainId &&
+    augmentedData.originatingOracleType
+      ? makeTransactionHashLink(
+          `${
+            supportedChains[augmentedData.originatingChainId]
+          } ${getOracleProperName(
+            augmentedData.originatingOracleType
+          )} Request`,
+          augmentedData.originatingChainTxHash,
+          augmentedData.originatingChainId
         )
       : undefined,
     makeOoRequestLink(),

--- a/constant/web3/supportedChains.ts
+++ b/constant/web3/supportedChains.ts
@@ -9,3 +9,16 @@ export const supportedChains = {
   43114: "Avalanche",
   42161: "Arbitrum",
 };
+
+export function getOracleProperName(oracleType:string):string{
+  switch (oracleType) {
+    case "OptimisticOracle":
+      return "Optimistic Oracle";
+    case "OptimisticOracleV2":
+      return "Optimistic Oracle V2";
+    case "SkinnyOptimisticOracle":
+      return "Skinny Optimistic Oracle";
+    default:
+      return oracleType;
+  }
+}


### PR DESCRIPTION
## motivation
we are labeling links as "DVM requests" but then linking to the OO transaction, this seems incorrect. There should probably be 2 links, 1 for the dvm and 1 for the OO ( if its available).

## changes
This fixes the link to dvm so it correctly is based on the dvm price request event transaction. Then adds an optional second link which is based on the OO request event, which may or may not exist for a request.

before:
![image](https://user-images.githubusercontent.com/4429761/211350543-17611d53-363b-44da-ba01-194e7064ea3f.png)
![image](https://user-images.githubusercontent.com/4429761/211350679-aa2042d8-2300-4af8-be8e-ad5afb6b6b80.png)

after:
![image](https://user-images.githubusercontent.com/4429761/211350793-9b348037-111c-4170-b0eb-f153ec10f502.png)
![image](https://user-images.githubusercontent.com/4429761/211350904-3e0fa1f9-1a09-433f-b515-fed2a2cc0ff5.png)
