### PR TITLE
feat: rank active votes by spam deletion and vote number

### DIFF
--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -30,7 +30,7 @@ import { config } from "helpers/config";
 
 export function Votes() {
   const {
-    getActiveVotes,
+    getActiveVotesPrioritized,
     getUpcomingVotes,
     getPastVotes,
     getActivityStatus,
@@ -221,7 +221,7 @@ export function Votes() {
     if (!actionStatus.canCommit) return;
 
     const formattedVotes = await formatVotesToCommit({
-      votes: getActiveVotes(),
+      votes: getActiveVotesPrioritized(),
       selectedVotes,
       roundId,
       address,
@@ -251,7 +251,7 @@ export function Votes() {
   }
 
   function getVotesToReveal() {
-    return getActiveVotes().filter(
+    return getActiveVotesPrioritized().filter(
       (vote) =>
         vote.isCommitted &&
         !!vote.decryptedVote &&
@@ -272,7 +272,7 @@ export function Votes() {
     const status = getActivityStatus();
     switch (status) {
       case "active":
-        return getActiveVotes();
+        return getActiveVotesPrioritized();
       case "upcoming":
         return getUpcomingVotes();
       case "past":

--- a/components/pages/PastVotes.tsx
+++ b/components/pages/PastVotes.tsx
@@ -37,6 +37,7 @@ export function PastVotes() {
   const pastVotes = getPastVotes();
   const numberOfPastVotes = pastVotes.length;
   const votesToShow = getEntriesForPage(pageNumber, resultsPerPage, pastVotes);
+  console.log(pastVotes);
 
   return (
     <Layout title="UMA | Past Votes">


### PR DESCRIPTION
## motivation
we want spam deletion proposal votes during an active vote to be prioritized at the top of the list.

## changes
this will order spam deletion proposals to the top of the active votes list. it also sortes by vote number and timestamp ascending which changes the old behavior

## qa
this cant be tested currently until we have some spam deletion proposals. will wait until we have some to merge