### PR TITLE
feat: add recent past votes to vote page

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -292,7 +292,7 @@ const NotificationIconWrapper = styled.div`
   }
 `;
 
-const Dot = styled.div`
+const Dot = styled.span`
   height: 8px;
   width: 8px;
   background-color: ${green};

--- a/components/IconWrapper/IconWrapper.tsx
+++ b/components/IconWrapper/IconWrapper.tsx
@@ -1,13 +1,16 @@
 import { ReactNode } from "react";
+import { CSSProperties } from "styled-components";
 
 export function IconWrapper({
   width = 15,
   height = 15,
+  display = "block",
   children,
 }: {
   width?: number;
   height?: number;
+  display?: CSSProperties["display"];
   children: ReactNode;
 }) {
-  return <span style={{ width, height }}>{children}</span>;
+  return <span style={{ width, height, display }}>{children}</span>;
 }

--- a/components/IconWrapper/IconWrapper.tsx
+++ b/components/IconWrapper/IconWrapper.tsx
@@ -9,5 +9,5 @@ export function IconWrapper({
   height?: number;
   children: ReactNode;
 }) {
-  return <div style={{ width, height }}>{children}</div>;
+  return <span style={{ width, height }}>{children}</span>;
 }

--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -336,7 +336,7 @@ export function Votes() {
         />
       </VotesTableWrapper>
       {getActivityStatus() === "active" ? (
-        <CommitVotesButtonWrapper>
+        <ButtonWrapper>
           {isDirty() ? (
             <>
               <Button
@@ -378,7 +378,7 @@ export function Votes() {
               </InfoText>
             </Tooltip>
           ) : null}
-        </CommitVotesButtonWrapper>
+        </ButtonWrapper>
       ) : null}
       {determineVotesToShow().length > defaultResultsPerPage && (
         <PaginationWrapper>
@@ -387,6 +387,34 @@ export function Votes() {
             numberOfEntries={determineVotesToShow().length}
           />
         </PaginationWrapper>
+      )}
+      {getPastVotes().length > 0 && getActivityStatus() !== "past" && (
+        <>
+          <Divider />
+          <Title>Recent past votes:</Title>
+          <VotesTableWrapper>
+            <VotesList
+              headings={<VotesTableHeadings activityStatus="past" />}
+              rows={getPastVotes()
+                .slice(0, 3)
+                .map((vote) => (
+                  <VotesListItem
+                    vote={vote}
+                    phase={phase}
+                    selectedVote={undefined}
+                    selectVote={() => null}
+                    activityStatus="past"
+                    moreDetailsAction={() => openPanel("vote", vote)}
+                    key={vote.uniqueKey}
+                    isFetching={getUserDependentIsFetching()}
+                  />
+                ))}
+            />
+          </VotesTableWrapper>
+          <ButtonWrapper>
+            <Button label="See all" href="/past-votes" variant="primary" />
+          </ButtonWrapper>
+        </>
       )}
     </>
   );
@@ -401,7 +429,7 @@ const Title = styled.h1`
   margin-bottom: 20px;
 `;
 
-const CommitVotesButtonWrapper = styled.div`
+const ButtonWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: end;
@@ -433,4 +461,11 @@ const PaginationWrapper = styled.div`
 
 const ButtonSpacer = styled.div`
   width: 10px;
+`;
+
+const Divider = styled.div`
+  height: 1px;
+  margin-top: 45px;
+  margin-bottom: 45px;
+  background: var(--black-opacity-25);
 `;


### PR DESCRIPTION
Adds a "recent past votes" section to the bottom of the vote page, with a link to see them all at `/past-votes`.

<img width="1014" alt="Screenshot 2023-01-13 at 15 05 07" src="https://user-images.githubusercontent.com/39741965/212326813-fcf0b6d0-b68f-48ab-9954-cc3b43675649.png">
