### PR TITLE
improve: move roll logic out of severless

### DIFF
--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -66,16 +66,15 @@ export function VotesListItem({
     isV1,
     isGovernance,
     timeAsDate,
-    augmentedData,
     canReveal,
+    rollCount,
   } = vote;
   const maxDecimals = getPrecisionForIdentifier(decodedIdentifier);
   const Icon = getVoteIcon();
   const isTabletAndUnder = width && width <= tabletMax;
-  const isRolled = augmentedData?.l1RequestTxHash === "rolled";
+  const isRolled = rollCount > 0;
   const wrapperRef = useRef<HTMLTableRowElement>(null);
   const existingVote = getDecryptedVoteAsFormattedString();
-
   useEffect(() => {
     if (!options) return;
 
@@ -334,7 +333,7 @@ export function VotesListItem({
                       href="https://docs.umaproject.org"
                       target="_blank"
                     >
-                      Rolled
+                      Roll #{rollCount}
                     </RolledLink>
                   </RolledWrapper>
                 </Tooltip>

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -94,6 +94,8 @@ export async function getPastVotesV2() {
         time
         ancillaryData
         resolvedPriceRequestIndex
+        isGovernance
+        rollCount
         latestRound {
           totalVotesRevealed
           groups {

--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -71,6 +71,10 @@ function formatPriceRequest(
     ancillaryData
   );
   const isV1 = priceRequest.isV1 ? true : false;
+  const isGovernance = priceRequest.isGovernance
+    ? true
+    : priceRequest.isGovernance;
+  const rollCount = priceRequest.rollCount || 0;
 
   return {
     time,
@@ -86,5 +90,7 @@ function formatPriceRequest(
     results,
     uniqueKey,
     isV1,
+    isGovernance,
+    rollCount,
   };
 }

--- a/pages/api/augment-request.ts
+++ b/pages/api/augment-request.ts
@@ -214,7 +214,7 @@ async function augmentRequests({ l1Requests, chainId }: RequestBody) {
   const requestPriceTable = createLookupTable(requestPriceEvents);
 
   return l1Requests.map((l1Request) => {
-    const votingPriceRequestEvent =
+    const votingRequestEvent =
       votingPriceRequestTable?.[l1Request.identifier.toLowerCase()]?.[
         l1Request.time
       ] || {};
@@ -224,7 +224,7 @@ async function augmentRequests({ l1Requests, chainId }: RequestBody) {
       ] || {};
     return {
       ...l1Request,
-      l1RequestTxHash: votingPriceRequestEvent.transactionHash ?? "rolled",
+      l1RequestTxHash: votingRequestEvent.transactionHash,
       ooRequestUrl: constructOoUiLink(
         oracleRequestPriceEvent.transactionHash,
         oracleRequestPriceEvent.chainId,

--- a/stories/mocks/votes.ts
+++ b/stories/mocks/votes.ts
@@ -60,6 +60,7 @@ export const voteWithoutUserVote = {
     staking: false,
     slashAmount: BigNumber.from(0),
   },
+  rollCount: 0,
 };
 
 export const userVote = {

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -227,7 +227,6 @@ export const AugmentedVoteDataResponseT = ss.object({
   time: ss.number(),
   identifier: ss.string(),
   l1RequestTxHash: ss.optional(ss.string()),
-  rollCount: ss.defaulted(ss.number(), 0),
   ooRequestUrl: ss.optional(ss.string()),
   originatingChainTxHash: ss.optional(ss.string()),
   originatingChainId: ss.optional(ss.number()),

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -30,6 +30,8 @@ export type PriceRequestT = {
   decodedAncillaryData: string;
   uniqueKey: UniqueKeyT;
   isV1: boolean;
+  isGovernance?: boolean;
+  rollCount: number;
 };
 
 export type ParticipationT = {
@@ -225,6 +227,7 @@ export const AugmentedVoteDataResponseT = ss.object({
   time: ss.number(),
   identifier: ss.string(),
   l1RequestTxHash: ss.optional(ss.string()),
+  rollCount: ss.defaulted(ss.number(), 0),
   ooRequestUrl: ss.optional(ss.string()),
   originatingChainTxHash: ss.optional(ss.string()),
   originatingChainId: ss.optional(ss.number()),
@@ -249,7 +252,7 @@ export type AugmentedVoteDataT = {
 
 export type AugmentedVoteDataByKeyT = Record<UniqueKeyT, AugmentedVoteDataT>;
 
-export type TransactionHashT = string | "rolled";
+export type TransactionHashT = string;
 
 export type RawDiscordMessageT = {
   content: string;

--- a/web3/queries/votes/getActiveVotes.ts
+++ b/web3/queries/votes/getActiveVotes.ts
@@ -5,7 +5,6 @@ export async function getActiveVotes(votingContract: VotingV2Ethers) {
   const pendingRequests = await votingContract.callStatic.getPendingRequests();
   const activeVotes = makePriceRequestsByKey(pendingRequests);
   const hasActiveVotes = Object.keys(activeVotes).length > 0;
-
   return {
     hasActiveVotes,
     activeVotes,


### PR DESCRIPTION
## motivation
new contract keeps track of roll count, so we dont need to do this bsaed on the augmented data api call

## changes
this uses the rollcount number returned from get active requests
![image](https://user-images.githubusercontent.com/4429761/212985941-c55dfe2b-1ed5-4560-a8eb-e91239e1e820.png)


## must change base from #173 after its merged