### PR TITLE
fix: remove vote number for active requests

### DIFF
--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -40,9 +40,6 @@ function formatPriceRequest(
   const timeAsDate = new Date(timeMilliseconds);
   const identifier = priceRequest.identifier;
   const ancillaryData = priceRequest.ancillaryData;
-  const voteNumber = priceRequest.lastVotingRound
-    ? BigNumber.from(priceRequest.lastVotingRound)
-    : undefined;
   let decodedIdentifier = "";
   let decodedAncillaryData = "";
   try {
@@ -80,7 +77,6 @@ function formatPriceRequest(
     time,
     identifier,
     ancillaryData,
-    voteNumber,
     timeMilliseconds,
     timeAsDate,
     decodedIdentifier,

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -21,7 +21,7 @@ export type PriceRequestT = {
   time: number;
   identifier: string;
   ancillaryData: string;
-  voteNumber: BigNumber | undefined;
+  voteNumber?: BigNumber;
   correctVote?: string;
   // computed values
   timeMilliseconds: number;


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

## motivation
there is no vote number on active votes anymore, but its possible this could be used for resolved vote number in the future

