### PR TITLE
fix: show resolved vote numbers in details page

### DIFF
--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -16,7 +16,7 @@ export function VotePanel({ content }: Props) {
   const {
     title,
     decodedIdentifier,
-    voteNumber,
+    resolvedPriceRequestIndex,
     origin,
     participation,
     results,
@@ -54,7 +54,7 @@ export function VotePanel({ content }: Props) {
         title={title ?? decodedIdentifier}
         origin={origin}
         isGovernance={isGovernance}
-        voteNumber={voteNumber?.toString()}
+        voteNumber={resolvedPriceRequestIndex}
       />
       {hasResults ? (
         <Tabs tabs={tabs} defaultValue="Result" />

--- a/components/VoteHistoryTable/VoteHistoryTableRow.tsx
+++ b/components/VoteHistoryTable/VoteHistoryTableRow.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
   const {
-    voteNumber,
+    resolvedPriceRequestIndex,
     voteHistory: { voted, correctness, staking, slashAmount },
   } = vote;
   const scoreColor = slashAmount.lt(0) ? red500 : green;
@@ -19,9 +19,9 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
   return (
     <Tr>
       <VoteNumberTd>
-        {voteNumber ? (
+        {resolvedPriceRequestIndex ? (
           <VoteNumberButton onClick={onVoteClicked}>
-            #{formatNumberForDisplay(voteNumber, { isFormatEther: false })}
+            #{resolvedPriceRequestIndex}
           </VoteNumberButton>
         ) : (
           <Tooltip label="This vote is from version one (previous version) of the voting contract. Sequential vote numbers were introduced in version two (current version).">

--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -62,7 +62,7 @@ export function VotesListItem({
     revealHash,
     decryptedVote,
     correctVote,
-    voteNumber,
+    resolvedPriceRequestIndex,
     isV1,
     isGovernance,
     timeAsDate,
@@ -340,8 +340,10 @@ export function VotesListItem({
               ) : null}
               <VoteOrigin>
                 {origin}{" "}
-                {!isV1 && voteNumber && `| Vote #${voteNumber.toString()}`} |{" "}
-                {format(timeAsDate, "Pp")}
+                {!isV1 &&
+                  resolvedPriceRequestIndex &&
+                  `| Vote #${resolvedPriceRequestIndex}`}{" "}
+                | {format(timeAsDate, "Pp")}
               </VoteOrigin>
             </VoteDetailsInnerWrapper>
           </VoteDetailsWrapper>

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -1,5 +1,4 @@
 import { config } from "helpers/config";
-import { BigNumber } from "ethers";
 import request, { gql } from "graphql-request";
 import { formatBytes32String, makePriceRequestsByKey } from "helpers";
 import { PastVotesQuery } from "types";
@@ -126,7 +125,6 @@ export async function getPastVotesV2() {
     }) => {
       const identifier = formatBytes32String(id);
       const correctVote = price;
-      const priceRequestIndex = BigNumber.from(resolvedPriceRequestIndex);
       const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
       const participation = {
         uniqueCommitAddresses: revealedVotes.length,
@@ -142,7 +140,7 @@ export async function getPastVotesV2() {
         time: Number(time),
         correctVote,
         ancillaryData,
-        priceRequestIndex,
+        resolvedPriceRequestIndex,
         isV1: false,
         participation,
         results,

--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -72,6 +72,7 @@ function formatPriceRequest(
     ? true
     : priceRequest.isGovernance;
   const rollCount = priceRequest.rollCount || 0;
+  const resolvedPriceRequestIndex = priceRequest.resolvedPriceRequestIndex;
 
   return {
     time,
@@ -81,6 +82,7 @@ function formatPriceRequest(
     timeAsDate,
     decodedIdentifier,
     decodedAncillaryData,
+    resolvedPriceRequestIndex,
     correctVote,
     participation,
     results,

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -21,7 +21,6 @@ export type PriceRequestT = {
   time: number;
   identifier: string;
   ancillaryData: string;
-  voteNumber?: BigNumber;
   correctVote?: string;
   // computed values
   timeMilliseconds: number;
@@ -32,6 +31,7 @@ export type PriceRequestT = {
   isV1: boolean;
   isGovernance?: boolean;
   rollCount: number;
+  resolvedPriceRequestIndex?: string;
 };
 
 export type ParticipationT = {
@@ -64,6 +64,7 @@ export type RawPriceRequestDataT = {
   isV1?: boolean;
   rollCount?: number;
   isGovernance?: boolean;
+  resolvedPriceRequestIndex?: string;
 };
 
 export type VoteHistoryDataT = {


### PR DESCRIPTION
Signed-off-by: david <david@umaproject.org>

## motivation
vote numbers are only available on resolved requests. its now known as `resolvedPriceRequestIndex`

## changes
this uses `resolvedPriceRequestIndex` when its available
![image](https://user-images.githubusercontent.com/4429761/213473244-3f30b313-cc35-4f23-80c9-4f4c1037bf9b.png)
![image](https://user-images.githubusercontent.com/4429761/213473334-0552ac11-8c11-4ab2-8208-fc58dedabfe6.png)
![image](https://user-images.githubusercontent.com/4429761/213474780-3e42933b-066c-41c8-9eee-9f73056abf28.png)
