### PR TITLE
fix: fix revealed issue for delegate

### DIFF
--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -210,9 +210,17 @@ export function VotesListItem({
       if (!isCommitted) return "Not committed";
       if (!decryptedVote || !canReveal) {
         if (delegationStatus === "delegator") {
-          return "Delegate Must Reveal";
+          if (isRevealed) {
+            return "Delegate Revealed";
+          } else {
+            return "Delegate Must Reveal";
+          }
         } else if (delegationStatus === "delegate") {
-          return "Delegator Must Reveal";
+          if (isRevealed) {
+            return "Delegator Revealed";
+          } else {
+            return "Delegator Must Reveal";
+          }
         } else {
           return "Unable to reveal";
         }

--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -211,15 +211,15 @@ export function VotesListItem({
       if (!decryptedVote || !canReveal) {
         if (delegationStatus === "delegator") {
           if (isRevealed) {
-            return "Delegate Revealed";
+            return "Delegate revealed";
           } else {
-            return "Delegate Must Reveal";
+            return "Delegate must reveal";
           }
         } else if (delegationStatus === "delegate") {
           if (isRevealed) {
-            return "Delegator Revealed";
+            return "Delegator revealed";
           } else {
-            return "Delegator Must Reveal";
+            return "Delegator must reveal";
           }
         } else {
           return "Unable to reveal";

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -85,6 +85,7 @@ export const VotesContext = createContext<VotesContextState>(
 );
 
 export function VotesProvider({ children }: { children: ReactNode }) {
+  // usually you can add this extra address as your delegator if you are a delegate.
   const [addressOverride, setAddressOverride] = useState<string | undefined>(
     undefined
   );
@@ -128,7 +129,8 @@ export function VotesProvider({ children }: { children: ReactNode }) {
     data: revealedVotes,
     isLoading: revealedVotesIsLoading,
     isFetching: revealedVotesIsFetching,
-  } = useRevealedVotes();
+    // if we are a delegate we need to override to our delegators address
+  } = useRevealedVotes(addressOverride);
   const {
     data: encryptedVotes,
     isLoading: encryptedVotesIsLoading,

--- a/hooks/queries/votes/useRevealedVotes.ts
+++ b/hooks/queries/votes/useRevealedVotes.ts
@@ -8,11 +8,12 @@ import {
 } from "hooks";
 import { getRevealedVotes } from "web3";
 
-export function useRevealedVotes() {
+export function useRevealedVotes(addressOverride?: string) {
   const { voting } = useContractsContext();
-  const { address } = useAccountDetails();
+  const { address: myAddress } = useAccountDetails();
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
+  const address = addressOverride ?? myAddress;
 
   const queryResult = useQuery(
     [revealedVotesKey, address, roundId],


### PR DESCRIPTION
## motivation
the ui would not show delegates who commmitted and revealed

## changes
this fixes it so it correctly detects when a delegate has revealed by using the delegators address when querying for revealed events.  this also should show you when logged in as a delegate or delegator if your sibling address has revealed