### PR TITLE
fix: copy around connected wallet delegate

### DIFF
--- a/components/pages/WalletSettings/ConnectedWallet.tsx
+++ b/components/pages/WalletSettings/ConnectedWallet.tsx
@@ -23,10 +23,23 @@ export function ConnectedWallet({ status }: Props) {
         Connected Wallet {status === "delegate" && "(Delegate)"}
         {status === "delegator" && "(Delegator)"}
       </Header>
-      <Text>
-        A delegator is a wallet that has chosen to delegate its voting power to
-        another party. Delegators can only delegate to one address at a time.
-      </Text>
+      {status === "delegator" && (
+        <Text>
+          A delegator is a wallet that has chosen to delegate its voting power
+          to another party. Delegators can only delegate to one address at a
+          time.
+        </Text>
+      )}
+      {status === "delegate" && (
+        <Text>
+          A delegate is a wallet that has been chosen to vote on behalf of
+          another party. If acting as a delegate, a delegate can no longer vote
+          for themselves. Delegates can commit & reveal votes on behalf of a
+          delegator, as well as claim and stake reward tokens. A delegate cannot
+          unstake tokens for a delegator. A delegate can only be a delegate for
+          a single delegator.
+        </Text>
+      )}
       <BarWrapper>
         <WalletWrapper>
           <WalletIcon icon={walletIcon} />


### PR DESCRIPTION
## motivation
copy was wrong when logged in as a delegate in wallet settings

## changes
corrrectly switch between copy given delegate/delegator setting

![image](https://user-images.githubusercontent.com/4429761/220909205-5e307983-4dc1-4e2f-87e8-25ffe2fa033c.png)
![image](https://user-images.githubusercontent.com/4429761/220909281-e435af7e-a909-4553-90e0-4087b959e76e.png)
