### PR TITLE
fix: address link for delegate

### DIFF
--- a/components/Panel/MenuPanel/MenuPanel.tsx
+++ b/components/Panel/MenuPanel/MenuPanel.tsx
@@ -162,7 +162,7 @@ export function MenuPanel() {
                         </Link>{" "}
                         to be a delegate {toOrFrom} address{" "}
                         <Link
-                          href={config.makeTransactionHashLink(
+                          href={config.makeAddressLink(
                             getPendingRequestAddress(delegator, delegate)
                           )}
                           target="_blank"

--- a/components/pages/WalletSettings/PendingRequests.tsx
+++ b/components/pages/WalletSettings/PendingRequests.tsx
@@ -107,8 +107,9 @@ export function PendingRequests({
               <NextLink
                 href={config.makeTransactionHashLink(transactionHash)}
                 passHref
+                target="_blank"
               >
-                <A target="_blank">View Transaction</A>
+                <A>View Transaction</A>
               </NextLink>
             </Text>
           </WaitingForApprovalWrapper>

--- a/helpers/config.ts
+++ b/helpers/config.ts
@@ -106,6 +106,7 @@ export type ChainConstants = {
   infuraName: string;
   properName: string;
   makeTransactionHashLink: (transactionHash: string) => string;
+  makeAddressLink: (address: string) => string;
   onboardConfig: {
     id: string;
     token: string;
@@ -125,6 +126,8 @@ export const chainConstantsList: ChainConstantsList = [
     properName: "Ethereum",
     makeTransactionHashLink: (transactionHash: string) =>
       `https://etherscan.io/tx/${transactionHash}`,
+    makeAddressLink: (address: string) =>
+      `https://etherscan.io/address/${address}`,
     onboardConfig: {
       id: "0x1",
       token: "ETH",
@@ -138,6 +141,8 @@ export const chainConstantsList: ChainConstantsList = [
     properName: "Görli",
     makeTransactionHashLink: (transactionHash: string) =>
       `https://goerli.etherscan.io/tx/${transactionHash}`,
+    makeAddressLink: (address: string) =>
+      `https://goerli.etherscan.io/address/${address}`,
     onboardConfig: {
       id: "0x5",
       token: "GOR",
@@ -151,6 +156,8 @@ export const chainConstantsList: ChainConstantsList = [
     properName: "Polygon",
     makeTransactionHashLink: (transactionHash: string) =>
       `https://polygonscan.com/tx/${transactionHash}`,
+    makeAddressLink: (address: string) =>
+      `https://polygonscan.etherscan.io/address/${address}`,
     // this may or may not work, but we shouldnt ever need to use this
     onboardConfig: {
       id: "0x137",


### PR DESCRIPTION
## motivation
links to address were being incorrectly formatted inside panel when notifying of a pending delegate request

## changes
we did not have a function for configuring address links in the config, were incorrectly using the transaction link generator. this adds an address link generator for each chain. 