### PR TITLE
fix: filter null results in decode admin

### DIFF
--- a/pages/api/decode-admin.ts
+++ b/pages/api/decode-admin.ts
@@ -180,14 +180,16 @@ async function generateReadableAdminTransactionData(identifiers: string[]) {
     ])
   ).flat();
 
-  const transactionSets = identifiers.map(
-    (identifier) =>
-      events.find(
-        (event) =>
-          event?.args?.id.toString() ===
-          identifier.substring(identifier.indexOf(" ") + 1)
-      )?.args?.transactions || null
-  );
+  const transactionSets = identifiers
+    .map(
+      (identifier) =>
+        events.find(
+          (event) =>
+            event?.args?.id.toString() ===
+            identifier.substring(identifier.indexOf(" ") + 1)
+        )?.args?.transactions || null
+    )
+    .filter(Boolean);
 
   return transactionSets.map((transactions, index) => {
     return {


### PR DESCRIPTION
### Summary

Defaulting to null in the `transactionSets` map and then attempting to map those results leads to an error.

### Changes

* Filter null results from the `transactionSets`