### PR TITLE
fix: add width constraints to input and dropdown

### DIFF
--- a/components/Dropdown/Dropdown.tsx
+++ b/components/Dropdown/Dropdown.tsx
@@ -86,6 +86,8 @@ const Wrapper = styled(Menu)``;
 
 const ToggleButton = styled(MenuButton)`
   width: 100%;
+  max-width: 510px;
+  min-width: 224px;
   height: 40px;
   display: flex;
   align-items: center;

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 export const Wrapper = styled.div`
   font: var(--text-md);
   max-width: 510px;
+  min-width: 224px;
 `;
 
 export const Input = styled.input`


### PR DESCRIPTION
### Motivation

Vote text inputs and dropdowns need a minimum width set in addition to their existing maximum width so that they do not squash their content on smaller screens.

### Changes

Add minimum width to vote dropdown and text input

<img width="319" alt="Screenshot 2023-02-27 at 09 20 36" src="https://user-images.githubusercontent.com/39741965/221499564-5a8df5eb-9276-4a65-a760-ad49df98d03c.png">
