### PR TITLE
fix: sign info text alignment

### DIFF
--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -163,6 +163,11 @@ export function Votes() {
       if (!hasSigningKey) {
         actionConfig.label = "Sign";
         actionConfig.onClick = () => sign();
+        actionConfig.infoText = {
+          label: "Why do I need to sign?",
+          tooltip:
+            "UMA uses this signature to verify that you are the owner of this address. We must do this to prevent double voting.",
+        };
         actionConfig.disabled = false;
 
         if (isSigning) {

--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -342,38 +342,7 @@ export function Votes() {
         </RecommittingVotesMessage>
       ) : null}
       {getActivityStatus() === "active" ? (
-        <ButtonWrapper>
-          {isDirty() ? (
-            <>
-              <Button
-                variant="secondary"
-                label="Reset Changes"
-                onClick={() => setSelectedVotes({})}
-              />
-              <ButtonSpacer />
-            </>
-          ) : undefined}
-          {!actionStatus.hidden ? (
-            actionStatus.tooltip ? (
-              <Tooltip label={actionStatus.tooltip}>
-                <div>
-                  <Button
-                    variant="primary"
-                    label={actionStatus.label}
-                    onClick={actionStatus.onClick}
-                    disabled={actionStatus.disabled}
-                  />
-                </div>
-              </Tooltip>
-            ) : (
-              <Button
-                variant="primary"
-                label={actionStatus.label}
-                onClick={actionStatus.onClick}
-                disabled={actionStatus.disabled}
-              />
-            )
-          ) : null}
+        <ButtonOuterWrapper>
           {actionStatus.infoText ? (
             <Tooltip label={actionStatus.infoText.tooltip}>
               <InfoText>
@@ -384,7 +353,40 @@ export function Votes() {
               </InfoText>
             </Tooltip>
           ) : null}
-        </ButtonWrapper>
+          <ButtonInnerWrapper>
+            {isDirty() ? (
+              <>
+                <Button
+                  variant="secondary"
+                  label="Reset Changes"
+                  onClick={() => setSelectedVotes({})}
+                />
+                <ButtonSpacer />
+              </>
+            ) : undefined}
+            {!actionStatus.hidden ? (
+              actionStatus.tooltip ? (
+                <Tooltip label={actionStatus.tooltip}>
+                  <div>
+                    <Button
+                      variant="primary"
+                      label={actionStatus.label}
+                      onClick={actionStatus.onClick}
+                      disabled={actionStatus.disabled}
+                    />
+                  </div>
+                </Tooltip>
+              ) : (
+                <Button
+                  variant="primary"
+                  label={actionStatus.label}
+                  onClick={actionStatus.onClick}
+                  disabled={actionStatus.disabled}
+                />
+              )
+            ) : null}
+          </ButtonInnerWrapper>
+        </ButtonOuterWrapper>
       ) : null}
       {determineVotesToShow().length > defaultResultsPerPage && (
         <PaginationWrapper>
@@ -417,9 +419,9 @@ export function Votes() {
                 ))}
             />
           </VotesTableWrapper>
-          <ButtonWrapper>
+          <ButtonInnerWrapper>
             <Button label="See all" href="/past-votes" variant="primary" />
-          </ButtonWrapper>
+          </ButtonInnerWrapper>
         </>
       )}
     </>
@@ -435,11 +437,14 @@ const Title = styled.h1`
   margin-bottom: 20px;
 `;
 
-const ButtonWrapper = styled.div`
+const ButtonOuterWrapper = styled.div`
+  margin-top: 30px;
+`;
+
+const ButtonInnerWrapper = styled.div`
   display: flex;
   justify-content: end;
   gap: 15px;
-  margin-top: 30px;
 
   button {
     text-transform: capitalize;
@@ -449,6 +454,9 @@ const ButtonWrapper = styled.div`
 const InfoText = styled.p`
   display: flex;
   gap: 15px;
+  width: fit-content;
+  margin-left: auto;
+  margin-bottom: 15px;
   font: var(--text-md);
 `;
 


### PR DESCRIPTION
### Motivation

The "Why do I need to sign?" text was incorrectly aligned, and also missing in the commit phase.

<img width="258" alt="Screenshot 2023-02-27 at 10 12 04" src="https://user-images.githubusercontent.com/39741965/221509353-922b17df-ba84-418d-9da9-a0b440393325.png">

<img width="482" alt="Screenshot 2023-02-27 at 10 11 55" src="https://user-images.githubusercontent.com/39741965/221509334-643a019d-ad09-4a18-a70f-da02c3bb1057.png">

### Changes

* Add sign info text in commit phase
* Move sign info text out of buttons wrapper so that it sits above the buttons