### PR TITLE
fix: inconsistent spacing in upcoming votes

### DIFF
--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -27,7 +27,7 @@ import {
 } from "hooks";
 import Warning from "public/assets/icons/warning.svg";
 import { useState } from "react";
-import styled from "styled-components";
+import styled, { CSSProperties } from "styled-components";
 import { SelectedVotesByKeyT, VoteT } from "types";
 
 export function Votes() {
@@ -393,7 +393,13 @@ export function Votes() {
         <>
           <Divider />
           <Title>Recent past votes:</Title>
-          <VotesTableWrapper>
+          <VotesTableWrapper
+            style={
+              {
+                "--margin-top": "0px",
+              } as CSSProperties
+            }
+          >
             <VotesList
               headings={<VotesTableHeadings activityStatus="past" />}
               rows={getPastVotes()
@@ -422,7 +428,7 @@ export function Votes() {
 }
 
 const VotesTableWrapper = styled.div`
-  margin-top: 35px;
+  margin-top: var(--margin-top, 35px);
 `;
 
 const Title = styled.h1`

--- a/stories/Pages/VotePage/VotePage.stories.tsx
+++ b/stories/Pages/VotePage/VotePage.stories.tsx
@@ -85,6 +85,12 @@ Upcoming.args = {
     voteWithoutUserVote,
     voteWithoutUserVote,
   ],
+  pastVotes: [
+    voteWithCorrectVoteWithUserVote,
+    voteWithCorrectVoteWithoutUserVote,
+    voteWithCorrectVoteWithUserVote,
+    voteWithCorrectVoteWithoutUserVote,
+  ],
 };
 
 export const Past = Template.bind({});


### PR DESCRIPTION
### Changes

* Make the margin between the title and votes table the same for both the top and bottom tables in upcoming votes.

<img width="614" alt="Screenshot 2023-02-27 at 10 35 46" src="https://user-images.githubusercontent.com/39741965/221513900-2982675a-ef33-4f3e-95e2-18dc2128093f.png">


<img width="675" alt="Screenshot 2023-02-27 at 10 33 47" src="https://user-images.githubusercontent.com/39741965/221513861-e59a0404-8810-41c2-8e43-3123aea32c65.png">
