### PR TITLE
fix: reduce code font size in decoded admin transactions

### DIFF
--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -304,6 +304,7 @@ const ToggleText = styled.span`
 `;
 
 const Pre = styled.pre`
+  font-size: 12px;
   overflow-x: auto;
   white-space: pre-wrap;
   word-wrap: break-word;


### PR DESCRIPTION
### Changes

* Change font size in decoded admin transactions code blocks (`<pre>` tags) to be 12px.

<img width="520" alt="Screenshot 2023-02-27 at 10 40 12" src="https://user-images.githubusercontent.com/39741965/221514892-f6aeda12-3c52-455f-9ced-435920495717.png">
