### PR TITLE
fix: fix reward estimation

### DIFF
--- a/hooks/queries/rewards/useRewardsCalculationInputs.ts
+++ b/hooks/queries/rewards/useRewardsCalculationInputs.ts
@@ -21,6 +21,7 @@ export function useRewardsCalculationInputs(addressOverride?: string) {
         rewardPerTokenStored: BigNumber.from(0),
         cumulativeStake: BigNumber.from(0),
         updateTime: BigNumber.from(Date.now()),
+        updateTimeSeconds: BigNumber.from(Math.floor(Date.now() / 1000)),
       },
       onError,
     }

--- a/web3/queries/rewards/getRewardsCalculationInputs.ts
+++ b/web3/queries/rewards/getRewardsCalculationInputs.ts
@@ -1,19 +1,23 @@
 import { VotingV2Ethers } from "@uma/contracts-frontend";
-import { BigNumber } from "ethers";
 
 export async function getRewardsCalculationInputs(voting: VotingV2Ethers) {
-  const [emissionRate, rewardPerTokenStored, cumulativeStake, updateTime] =
-    await Promise.all([
-      voting.emissionRate(),
-      voting.rewardPerTokenStored(),
-      voting.cumulativeStake(),
-      BigNumber.from(Date.now()),
-    ]);
+  const [
+    emissionRate,
+    rewardPerTokenStored,
+    cumulativeStake,
+    updateTimeSeconds,
+  ] = await Promise.all([
+    voting.emissionRate(),
+    voting.rewardPerTokenStored(),
+    voting.cumulativeStake(),
+    voting.getCurrentTime(),
+  ]);
 
   return {
     emissionRate,
     rewardPerTokenStored,
     cumulativeStake,
-    updateTime,
+    updateTimeSeconds,
+    updateTime: updateTimeSeconds.mul(1000),
   };
 }


### PR DESCRIPTION
## motivation
when claiming rewards on a quickly accumulating account, we would see actual claim amounts inconsistent with the amount shown on UI. this would sometimes under or overestimate rewards by a large margin.

## changes
In order to calculate the estimated rewards in real time, we need to know the current state of rewards on chain at a specific timestamp, and we need the length of time which has elapsed since that was fetched.  we were not fetching the current block timestamp when querying the data, but rather using "date.now".  this could cause wildly different "fetch times" since block time and date.now can be way off.  as a result estimations could be off by a large amout.  We change this to fetch the block timestamp when we fetch the reward data. This seems to give more consistent estimations, after 5 claims, it underestimates every time, which is expected since we cant estimate when the claim transaction will be mined, and rewards will accrue until tx is mined.

![image](https://user-images.githubusercontent.com/4429761/221576127-3f11a2c0-bdf6-4918-abf3-caa9c141b519.png)
![image](https://user-images.githubusercontent.com/4429761/221576270-2f1d903a-55fb-442b-9e1b-6bd755d822b0.png)

![image](https://user-images.githubusercontent.com/4429761/221576605-144563f1-1262-40e3-987e-f1a156ab1a38.png)
![image](https://user-images.githubusercontent.com/4429761/221576651-590ca581-43b8-4d97-9cc1-fa0db15de52a.png)


