### PR TITLE
fix: handle magic number more robustly

### DIFF
--- a/components/Panel/VotePanel/Result.tsx
+++ b/components/Panel/VotePanel/Result.tsx
@@ -5,7 +5,7 @@ import {
   PanelErrorBanner,
   Tooltip,
 } from "components";
-import { mobileAndUnder } from "constant";
+import { mobileAndUnder, isEarlyVote } from "constant";
 import { formatVoteStringWithPrecision, truncateDecimals } from "helpers";
 import { usePanelWidth } from "hooks";
 import Portion from "public/assets/icons/portion.svg";
@@ -35,7 +35,8 @@ export function Result({
 
   const resultsWithLabels = results.map(({ vote, tokensVotedWith }) => {
     const formatted = formatVoteStringWithPrecision(vote, decodedIdentifier);
-    const label = findVoteInOptions(formatted)?.label ?? formatted;
+    const label =
+      findVoteInOptionsDetectEarlyVote(formatted)?.label ?? formatted;
     const value = tokensVotedWith;
 
     return {
@@ -50,6 +51,10 @@ export function Result({
     return options?.find((option) => {
       return option.value === value;
     });
+  }
+  function findVoteInOptionsDetectEarlyVote(value: string | undefined) {
+    if (isEarlyVote(value)) return { label: "Early request" };
+    return findVoteInOptions(value);
   }
 
   return (

--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -5,7 +5,14 @@ import {
   TextInput,
   Tooltip,
 } from "components";
-import { green, grey100, red500, tabletAndUnder, tabletMax } from "constant";
+import {
+  green,
+  grey100,
+  red500,
+  tabletAndUnder,
+  tabletMax,
+  isEarlyVote,
+} from "constant";
 import { format } from "date-fns";
 import {
   formatVoteStringWithPrecision,
@@ -81,7 +88,7 @@ export function VotesListItem({
     // if options exist but the existing decrypted vote is not one from the list,
     // then we must be using a custom input
     const decryptedVote = getDecryptedVoteAsFormattedString();
-    if (decryptedVote && !findVoteInOptions(decryptedVote)) {
+    if (decryptedVote && !findVoteInOptionsDetectEarlyVote(decryptedVote)) {
       setIsCustomInput(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -170,7 +177,8 @@ export function VotesListItem({
     }
     if (!decryptedVote) return "Did not vote";
     return (
-      findVoteInOptions(getDecryptedVoteAsFormattedString())?.label ??
+      findVoteInOptionsDetectEarlyVote(getDecryptedVoteAsFormattedString())
+        ?.label ??
       formatVoteStringWithPrecision(
         decryptedVote?.price?.toString(),
         decodedIdentifier
@@ -185,13 +193,17 @@ export function VotesListItem({
       decodedIdentifier
     );
 
-    return findVoteInOptions(formatted)?.label ?? formatted;
+    return findVoteInOptionsDetectEarlyVote(formatted)?.label ?? formatted;
   }
 
   function findVoteInOptions(value: string | undefined) {
     return options?.find((option) => {
       return option.value === value;
     });
+  }
+  function findVoteInOptionsDetectEarlyVote(value: string | undefined) {
+    if (isEarlyVote(value)) return { label: "Early request" };
+    return findVoteInOptions(value);
   }
 
   function getCommittedOrRevealed() {

--- a/constant/voting/earlyRequestMagicNumber.ts
+++ b/constant/voting/earlyRequestMagicNumber.ts
@@ -1,2 +1,10 @@
 export const earlyRequestMagicNumber =
   "-57896044618658097711785492504343953926634992332820282019728.792003956564819968";
+export const earlyRequestMagicNumberWei =
+  "-57896044618658097711785492504343953926634992332820282019728792003956564819968";
+
+export function isEarlyVote(value: string | undefined):boolean{
+  if(value === undefined) return false
+  return [earlyRequestMagicNumber, earlyRequestMagicNumberWei].includes(value)
+}
+


### PR DESCRIPTION
## motivation
we have a magic number, which is really long, and represents a vote of "too early" for a yes or no query.  if the ancillary data of the request does not include this specifically as an option, we dont convert the number to the label "too early" since we cant find that as an option. this leaves us to show this really long number in the ui.

## changes
we now treat the magic number as a unique thing, regardless of the vote type, or if its found in options. This assumes that it will only ever be used to represent "too early". this allows us to decode the number in the UI and show "too early" in place of the number even if its not included in ancillary data. we can easily undo this change if needed. 

![image](https://user-images.githubusercontent.com/4429761/221595791-44795c66-6281-44b8-8ccf-1396fd40591c.png)
![image](https://user-images.githubusercontent.com/4429761/221595936-bf0edb5a-ebc6-48b7-83fa-003c2c28b580.png)

previously these would show magic number