### PR TITLE
fix: use yyyy mm dd date format

### DIFF
--- a/components/Panel/VotePanel/Discussion.tsx
+++ b/components/Panel/VotePanel/Discussion.tsx
@@ -1,6 +1,7 @@
 import { Button, LoadingSpinner } from "components";
 import { discordLink, mobileAndUnder, red500 } from "constant";
 import { format } from "date-fns";
+import { enCA } from "date-fns/locale";
 import { addOpacityToHsl } from "helpers";
 import NextImage from "next/image";
 import Discord from "public/assets/icons/discord.svg";
@@ -61,7 +62,9 @@ export function Discussion({ discussion, loading }: Props) {
                             <Strong>{sender}</Strong>
                           </Sender>{" "}
                           <Time>
-                            {format(new Date(Number(time) * 1000), "Pp")}
+                            {format(new Date(Number(time) * 1000), "Pp", {
+                              locale: enCA,
+                            })}
                           </Time>
                         </SenderWrapper>
                         <MessageTextWrapper>

--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -7,10 +7,12 @@ import {
 } from "components";
 import { green, grey100, red500, tabletAndUnder, tabletMax } from "constant";
 import { format } from "date-fns";
+import { enCA } from "date-fns/locale";
 import {
   formatVoteStringWithPrecision,
   getPrecisionForIdentifier,
 } from "helpers";
+import { config } from "helpers/config";
 import { useWalletContext, useWindowSize } from "hooks";
 import NextLink from "next/link";
 import Across from "public/assets/icons/across.svg";
@@ -22,7 +24,6 @@ import UMA from "public/assets/icons/uma.svg";
 import { CSSProperties, ReactNode, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { ActivityStatusT, DropdownItemT, VotePhaseT, VoteT } from "types";
-import { config } from "helpers/config";
 export interface Props {
   vote: VoteT;
   phase: VotePhaseT;
@@ -351,7 +352,10 @@ export function VotesListItem({
                 {!isV1 &&
                   resolvedPriceRequestIndex &&
                   `| Vote #${resolvedPriceRequestIndex}`}{" "}
-                | {format(timeAsDate, "Pp")}
+                |{" "}
+                {format(timeAsDate, "Pp", {
+                  locale: enCA,
+                })}
               </VoteOrigin>
             </VoteDetailsInnerWrapper>
           </VoteDetailsWrapper>


### PR DESCRIPTION
### Motivation

Use the date format that is most common in the world. To specify this format while still using an English-speaking locale, we use the en-CA (Canada) date locale 🍁 

### Changes

* Use en-CA locale when formatting dates
