### PR TITLE
feat: clean up delegate view for disabled features

### DIFF
--- a/components/Panel/ClaimPanel.tsx
+++ b/components/Panel/ClaimPanel.tsx
@@ -88,10 +88,12 @@ export function ClaimPanel() {
           </ClaimAndStakeWrapper>
           <ClaimToWalletWrapper>
             <PanelSectionTitle>Claim to Wallet</PanelSectionTitle>
-            <PanelSectionText>
-              You will not be able to vote or earn rewards with UMA claimed to
-              your wallet.
-            </PanelSectionText>
+            {!isDelegate && (
+              <PanelSectionText>
+                You will not be able to vote or earn rewards with UMA claimed to
+                your wallet.
+              </PanelSectionText>
+            )}
             {isDelegate ? (
               <PanelWarningText>
                 Delegate wallets can only claim and restake. You cannot claim

--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -77,11 +77,13 @@ export function Stake({
   return (
     <Wrapper>
       <PanelSectionTitle>Stake</PanelSectionTitle>
-      <PanelSectionText>
-        Staked tokens are used to vote and earn rewards. Staked tokens cannot be
-        claimed until {unstakeCoolDownFormatted} after an unstaking request is
-        submitted.
-      </PanelSectionText>
+      {!isDelegate && (
+        <PanelSectionText>
+          Staked tokens are used to vote and earn rewards. Staked tokens cannot
+          be claimed until {unstakeCoolDownFormatted} after an unstaking request
+          is submitted.
+        </PanelSectionText>
+      )}
       {isDelegate ? (
         <PanelWarningText>
           You are currently a delegate. Staking is controlled by the delegator.

--- a/components/Panel/StakeUnstakePanel/Unstake.tsx
+++ b/components/Panel/StakeUnstakePanel/Unstake.tsx
@@ -59,31 +59,36 @@ export function Unstake({
   return (
     <Wrapper>
       <PanelSectionTitle>Unstake</PanelSectionTitle>
-      <PanelSectionText>
-        After submitting an unstake request, you must wait{" "}
-        {unstakeCoolDownFormatted} before you can claim your unstaked tokens.
-      </PanelSectionText>
-      <HowItWorks>
-        <HowItWorksTitle>How it works</HowItWorksTitle>
-        <UnstakeStep>
-          <IconWrapper>
-            <OneIcon />
-          </IconWrapper>
-          Unstake tokens
-        </UnstakeStep>
-        <UnstakeStep>
-          <IconWrapper>
-            <TwoIcon />
-          </IconWrapper>
-          Wait {unstakeCoolDownFormatted}
-        </UnstakeStep>
-        <UnstakeStep>
-          <IconWrapper>
-            <ThreeIcon />
-          </IconWrapper>
-          Claim unstaked tokens
-        </UnstakeStep>
-      </HowItWorks>
+      {!isDelegate && (
+        <>
+          <PanelSectionText>
+            After submitting an unstake request, you must wait{" "}
+            {unstakeCoolDownFormatted} before you can claim your unstaked
+            tokens.
+          </PanelSectionText>
+          <HowItWorks>
+            <HowItWorksTitle>How it works</HowItWorksTitle>
+            <UnstakeStep>
+              <IconWrapper>
+                <OneIcon />
+              </IconWrapper>
+              Unstake tokens
+            </UnstakeStep>
+            <UnstakeStep>
+              <IconWrapper>
+                <TwoIcon />
+              </IconWrapper>
+              Wait {unstakeCoolDownFormatted}
+            </UnstakeStep>
+            <UnstakeStep>
+              <IconWrapper>
+                <ThreeIcon />
+              </IconWrapper>
+              Claim unstaked tokens
+            </UnstakeStep>
+          </HowItWorks>
+        </>
+      )}
       {!isDelegate && (phase === "commit" || !hasActiveVotes) && (
         <>
           <AmountInputWrapper>


### PR DESCRIPTION
## motivation
we are showing unecessary information when logged in as delegate, we want to remove that information.

## changes
this deletes certain elements when logged in as delegator for claim panel, stake, and unstake panels.
![image](https://user-images.githubusercontent.com/4429761/221645354-3593a598-a5b7-448f-abae-91b01abe70f3.png)
![image](https://user-images.githubusercontent.com/4429761/221645402-60e223b2-0da2-4c7f-9275-00a7a2bebd5d.png)
![image](https://user-images.githubusercontent.com/4429761/221645459-542722bf-b210-4795-837a-64343709fd1c.png)
