### PR TITLE
feat: add notification that user is delegator

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -62,15 +62,18 @@ export function Header() {
   const status = getDelegationStatus();
   const showDelegationNotification =
     !getDelegationDataLoading() &&
-    (status === "delegate" || status === "delegate-pending");
+    (status === "delegate" ||
+      status === "delegate-pending" ||
+      status === "delegator");
   const showV1RewardsNotification = v1Rewards?.totalRewards.gt(0);
   const isDelegate = status === "delegate";
+  const isDelegator = status === "delegator";
   const isDelegatePending = status === "delegate-pending";
 
   const delegationNotificationStyle = {
-    "--color": isDelegate ? green : red500,
-    "--border-color": isDelegate ? "transparent" : red500,
-    "--background-color": isDelegate ? "transparent" : red100,
+    "--color": isDelegate || isDelegator ? green : red500,
+    "--border-color": isDelegate || isDelegator ? "transparent" : red500,
+    "--background-color": isDelegate || isDelegator ? "transparent" : red100,
   } as CSSProperties;
 
   const v1RewardsNotificationStyle = {
@@ -115,6 +118,13 @@ export function Header() {
                     <Dot />
                     &nbsp;&nbsp;Connected as{" "}
                     <Link href="/wallet-settings">delegate wallet</Link>
+                  </>
+                )}
+                {isDelegator && (
+                  <>
+                    <Dot />
+                    &nbsp;&nbsp;Connected as{" "}
+                    <Link href="/wallet-settings">delegator wallet</Link>
                   </>
                 )}
               </NotificationText>

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -116,14 +116,14 @@ export function Header() {
                 {isDelegate && (
                   <>
                     <Dot />
-                    &nbsp;&nbsp;Connected as{" "}
+                    Connected as{" "}
                     <Link href="/wallet-settings">delegate wallet</Link>
                   </>
                 )}
                 {isDelegator && (
                   <>
                     <Dot />
-                    &nbsp;&nbsp;Connected as{" "}
+                    Connected as{" "}
                     <Link href="/wallet-settings">delegator wallet</Link>
                   </>
                 )}
@@ -305,7 +305,8 @@ const NotificationIconWrapper = styled.div`
 const Dot = styled.span`
   height: 8px;
   width: 8px;
-  background-color: ${green};
+  margin-right: 8px;
+  background-color: var(--color);
   border-radius: 50%;
   display: inline-block;
 `;


### PR DESCRIPTION
## motivation
We currently show the user they are delegate, but not delegator. We should show both

## changes
this just enables the same type of notification if the user is curently a delegator, identical in style to the delegate

![image](https://user-images.githubusercontent.com/4429761/221651056-6924bb34-f9e1-4be4-83db-17ea8c4f2629.png)
