### PR TITLE
fix: handle wrong chain

### DIFF
--- a/components/ErrorBanner/ErrorBanner.tsx
+++ b/components/ErrorBanner/ErrorBanner.tsx
@@ -1,5 +1,6 @@
 import { EthersErrorLink } from "components/EthersErrorLink/EthersErrorLink";
-import { useErrorContext } from "hooks";
+import { wrongChainMessage } from "constant";
+import { useErrorContext, useWalletContext } from "hooks";
 import { ErrorOriginT } from "types";
 import {
   CloseButton,
@@ -12,27 +13,52 @@ import {
 } from "./styles";
 
 export function ErrorBanner({ errorOrigin }: { errorOrigin?: ErrorOriginT }) {
+  const { isWrongChain } = useWalletContext();
   const { errorMessages, removeErrorMessage } = useErrorContext(errorOrigin);
 
-  if (!errorMessages.length) return null;
+  if (!errorMessages.length && !isWrongChain) return null;
 
   return (
     <Wrapper>
-      {errorMessages.map((message) => (
-        <ErrorMessageWrapper key={message?.toString()}>
-          <IconWrapper>
-            <WarningIcon />
-          </IconWrapper>
-          <ErrorMessage>
-            <EthersErrorLink errorMessage={message} />
-          </ErrorMessage>
-          <CloseButton onClick={() => removeErrorMessage(message)}>
-            <IconWrapper>
-              <CloseIcon />
-            </IconWrapper>
-          </CloseButton>
-        </ErrorMessageWrapper>
-      ))}
+      {isWrongChain ? (
+        <Error message={wrongChainMessage} />
+      ) : (
+        <>
+          {errorMessages.map((message) => (
+            <Error
+              key={message}
+              message={message}
+              removeErrorMessage={removeErrorMessage}
+            />
+          ))}
+        </>
+      )}
     </Wrapper>
+  );
+}
+
+function Error({
+  message,
+  removeErrorMessage,
+}: {
+  message: string;
+  removeErrorMessage?: (message: string) => void;
+}) {
+  return (
+    <ErrorMessageWrapper>
+      <IconWrapper>
+        <WarningIcon />
+      </IconWrapper>
+      <ErrorMessage>
+        <EthersErrorLink errorMessage={message} />
+      </ErrorMessage>
+      {!!removeErrorMessage && (
+        <CloseButton onClick={() => removeErrorMessage(message)}>
+          <IconWrapper>
+            <CloseIcon />
+          </IconWrapper>
+        </CloseButton>
+      )}
+    </ErrorMessageWrapper>
   );
 }

--- a/components/Wallet/Wallet.tsx
+++ b/components/Wallet/Wallet.tsx
@@ -1,9 +1,7 @@
-import { useConnectWallet, useSetChain, useWallets } from "@web3-onboard/react";
-import { wrongChainMessage } from "constant";
+import { useConnectWallet, useWallets } from "@web3-onboard/react";
 import { ethers } from "ethers";
 import {
   useContractsContext,
-  useErrorContext,
   usePanelContext,
   useUserContext,
   useWalletContext,
@@ -15,27 +13,14 @@ import {
   createVotingTokenContractInstance,
 } from "web3";
 import { WalletIcon } from "./WalletIcon";
-import { config } from "helpers/config";
 
 export function Wallet() {
   const [{ wallet, connecting }, connect] = useConnectWallet();
-  const [{ connectedChain }] = useSetChain();
   const connectedWallets = useWallets();
-  const { setProvider, setSigner } = useWalletContext();
+  const { setProvider, setSigner, isWrongChain } = useWalletContext();
   const { setVoting, setVotingToken } = useContractsContext();
   const { openPanel } = usePanelContext();
   const { truncatedAddress } = useUserContext();
-  const { addErrorMessage, removeErrorMessage } = useErrorContext();
-
-  useEffect(() => {
-    if (!connectedChain) return;
-    if (connectedChain.id !== config.onboardConfig.id) {
-      addErrorMessage(wrongChainMessage);
-    } else {
-      removeErrorMessage(wrongChainMessage);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectedChain?.id]);
 
   useEffect(() => {
     if (!connectedWallets.length) return;
@@ -71,7 +56,7 @@ export function Wallet() {
   }, [connect]);
 
   useEffect(() => {
-    if (!wallet?.provider) {
+    if (!wallet?.provider || isWrongChain) {
       setProvider(null);
       setSigner(null);
       setVoting(createVotingContractInstance());
@@ -88,7 +73,7 @@ export function Wallet() {
       setVotingToken(createVotingTokenContractInstance(signer));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wallet]);
+  }, [wallet, isWrongChain]);
 
   function openMenuPanel() {
     openPanel("menu");

--- a/contexts/WalletContext.tsx
+++ b/contexts/WalletContext.tsx
@@ -1,11 +1,11 @@
 import { OnboardAPI } from "@web3-onboard/core";
 import { useSetChain } from "@web3-onboard/react";
 import { ethers } from "ethers";
-import { initOnboard, getSavedSigningKeys } from "helpers";
+import { getSavedSigningKeys, initOnboard } from "helpers";
+import { config } from "helpers/config";
+import { useSign } from "hooks";
 import { createContext, ReactNode, useState } from "react";
 import { SigningKeys } from "types";
-import { useSign } from "hooks";
-import { config } from "helpers/config";
 
 export interface WalletContextState {
   onboard: OnboardAPI | null;
@@ -20,6 +20,7 @@ export interface WalletContextState {
   isSigning: boolean;
   connectedChainId: number | undefined;
   isSettingChain: boolean;
+  isWrongChain: boolean;
   setCorrectChain: () => void;
 }
 
@@ -36,6 +37,7 @@ export const defaultWalletContextState = {
   isSigning: false,
   connectedChainId: undefined,
   isSettingChain: false,
+  isWrongChain: false,
   setCorrectChain: () => undefined,
 };
 
@@ -66,9 +68,15 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const connectedChainId = connectedChain
     ? parseInt(connectedChain.id)
     : undefined;
+
+  const isWrongChain = connectedChainId
+    ? connectedChainId !== parseInt(config.onboardConfig.id)
+    : false;
+
   return (
     <WalletContext.Provider
       value={{
+        isWrongChain,
         onboard,
         setOnboard,
         provider,

--- a/hooks/queries/delegation/useCommittedVotesForDelegator.ts
+++ b/hooks/queries/delegation/useCommittedVotesForDelegator.ts
@@ -6,12 +6,14 @@ import {
   useHandleError,
   useUserContext,
   useVoteTimingContext,
+  useWalletContext,
 } from "hooks";
-import { getCommittedVotes } from "web3";
 import { VoteExistsByKeyT } from "types";
+import { getCommittedVotes } from "web3";
 
 export function useCommittedVotesForDelegator() {
   const { address } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const { voting } = useContractsContext();
   const { getDelegationStatus, getDelegatorAddress } = useDelegationContext();
   const { roundId } = useVoteTimingContext();
@@ -28,7 +30,11 @@ export function useCommittedVotesForDelegator() {
         : {},
     {
       refetchInterval: status === "delegate" ? oneMinute : false,
-      enabled: !!address && !!delegatorAddress && status === "delegate",
+      enabled:
+        !!address &&
+        !isWrongChain &&
+        !!delegatorAddress &&
+        status === "delegate",
       initialData: {},
       onError,
     }

--- a/hooks/queries/delegation/useDelegateToStaker.ts
+++ b/hooks/queries/delegation/useDelegateToStaker.ts
@@ -6,6 +6,7 @@ import {
   useHandleError,
   useStakerDetails,
   useUserContext,
+  useWalletContext,
 } from "hooks";
 import { getDelegateToStaker } from "web3";
 
@@ -15,13 +16,14 @@ export function useDelegateToStaker() {
     data: { delegate },
   } = useStakerDetails();
   const { address } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [delegateToStakerKey, address],
     () => getDelegateToStaker(voting, delegate ?? zeroAddress),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       onError,
     }
   );

--- a/hooks/queries/delegation/useDelegatorSetEventsForDelegate.ts
+++ b/hooks/queries/delegation/useDelegatorSetEventsForDelegate.ts
@@ -1,18 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 import { delegatorSetEventForDelegateKey } from "constant";
-import { useContractsContext, useHandleError, useUserContext } from "hooks";
+import {
+  useContractsContext,
+  useHandleError,
+  useUserContext,
+  useWalletContext,
+} from "hooks";
 import { getDelegatorSetEvents } from "web3";
 
 export function useDelegatorSetEventsForDelegate() {
   const { voting } = useContractsContext();
   const { address } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [delegatorSetEventForDelegateKey, address],
     () => getDelegatorSetEvents(voting, address, "delegate"),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       onError,
     }
   );

--- a/hooks/queries/delegation/useDelegatorSetEventsForDelegator.ts
+++ b/hooks/queries/delegation/useDelegatorSetEventsForDelegator.ts
@@ -1,18 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 import { delegatorSetEventsForDelegatorKey } from "constant";
-import { useContractsContext, useHandleError, useUserContext } from "hooks";
+import {
+  useContractsContext,
+  useHandleError,
+  useUserContext,
+  useWalletContext,
+} from "hooks";
 import { getDelegatorSetEvents } from "web3";
 
 export function useDelegatorSetEventsForDelegator() {
   const { voting } = useContractsContext();
   const { address } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [delegatorSetEventsForDelegatorKey, address],
     () => getDelegatorSetEvents(voting, address, "delegator"),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       onError,
     }
   );

--- a/hooks/queries/delegation/useIgnoredRequestToBeDelegateAddresses.ts
+++ b/hooks/queries/delegation/useIgnoredRequestToBeDelegateAddresses.ts
@@ -1,17 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import { ignoredRequestToBeDelegateAddressesKey } from "constant";
-import { useHandleError, useUserContext } from "hooks";
+import { useHandleError, useUserContext, useWalletContext } from "hooks";
 import { getIgnoredRequestToBeDelegateAddresses } from "web3";
 
 export function useIgnoredRequestToBeDelegateAddresses() {
   const { address } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [ignoredRequestToBeDelegateAddressesKey, address],
     () => getIgnoredRequestToBeDelegateAddresses(address),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       onError,
     }
   );

--- a/hooks/queries/delegation/useNewReceivedRequestsToBeDelegate.ts
+++ b/hooks/queries/delegation/useNewReceivedRequestsToBeDelegate.ts
@@ -7,10 +7,11 @@ export function useNewReceivedRequestsToBeDelegate() {
   const { voting } = useContractsContext();
   const { provider } = useWalletContext();
   const { address } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const [newRequests, setNewRequests] = useState(0);
 
   useEffect(() => {
-    if (!provider || !address) return;
+    if (!provider || !address || isWrongChain) return;
 
     const filter = voting.filters.DelegateSet(null, address);
 

--- a/hooks/queries/delegation/useReceivedRequestsToBeDelegate.ts
+++ b/hooks/queries/delegation/useReceivedRequestsToBeDelegate.ts
@@ -5,12 +5,14 @@ import {
   useHandleError,
   useNewReceivedRequestsToBeDelegate,
   useUserContext,
+  useWalletContext,
 } from "hooks";
 import { getDelegateSetEvents } from "web3";
 
 export function useReceivedRequestsToBeDelegate() {
   const { voting } = useContractsContext();
   const { address } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
   const newRequests = useNewReceivedRequestsToBeDelegate();
 
@@ -18,7 +20,7 @@ export function useReceivedRequestsToBeDelegate() {
     [receivedRequestsToBeDelegateKey, address, newRequests],
     () => getDelegateSetEvents(voting, address, "delegate"),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       onError,
     }
   );

--- a/hooks/queries/delegation/useSentRequestsToBeDelegate.ts
+++ b/hooks/queries/delegation/useSentRequestsToBeDelegate.ts
@@ -1,18 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 import { sentRequestsToBeDelegateKey } from "constant";
-import { useContractsContext, useHandleError, useUserContext } from "hooks";
+import {
+  useContractsContext,
+  useHandleError,
+  useUserContext,
+  useWalletContext,
+} from "hooks";
 import { getDelegateSetEvents } from "web3";
 
 export function useSentRequestsToBeDelegate() {
   const { voting } = useContractsContext();
   const { address } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [sentRequestsToBeDelegateKey, address],
     () => getDelegateSetEvents(voting, address, "delegator"),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       onError,
     }
   );

--- a/hooks/queries/delegation/useVoterFromDelegate.ts
+++ b/hooks/queries/delegation/useVoterFromDelegate.ts
@@ -1,17 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import { voterFromDelegateKey } from "constant";
-import { useContractsContext, useUserContext } from "hooks";
+import { useContractsContext, useUserContext, useWalletContext } from "hooks";
 import { getVoterFromDelegate } from "web3";
 
 export function useVoterFromDelegate() {
   const { voting } = useContractsContext();
   const { address } = useUserContext();
+  const { isWrongChain } = useWalletContext();
 
   const queryResult = useQuery(
     [voterFromDelegateKey, address],
     () => getVoterFromDelegate(voting, address),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
     }
   );
 

--- a/hooks/queries/rewards/useIsOldDesignatedVotingAccount.ts
+++ b/hooks/queries/rewards/useIsOldDesignatedVotingAccount.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { isOldDesignatedVotingAccountKey } from "constant";
-import { useAccountDetails, useHandleError } from "hooks";
+import { useAccountDetails, useHandleError, useWalletContext } from "hooks";
 import { getIsOldDesignatedVotingAccount } from "web3";
 
 export function useIsOldDesignatedVotingAccount() {
   const { address } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const { onError, clearErrors } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery({
@@ -15,7 +16,7 @@ export function useIsOldDesignatedVotingAccount() {
       message: "",
       designatedVotingContract: "",
     },
-    enabled: !!address,
+    enabled: !!address && !isWrongChain,
     onError,
     onSuccess: clearErrors,
   });

--- a/hooks/queries/rewards/useOutstandingRewards.ts
+++ b/hooks/queries/rewards/useOutstandingRewards.ts
@@ -1,12 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import { outstandingRewardsKey } from "constant";
 import { BigNumber } from "ethers";
-import { useContractsContext, useHandleError, useUserContext } from "hooks";
+import {
+  useContractsContext,
+  useHandleError,
+  useUserContext,
+  useWalletContext,
+} from "hooks";
 import { getOutstandingRewards } from "web3";
 
 export function useOutstandingRewards(addressOverride?: string) {
   const { voting } = useContractsContext();
   const { address: defaultAddress } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
 
@@ -14,7 +20,7 @@ export function useOutstandingRewards(addressOverride?: string) {
     [outstandingRewardsKey, address],
     () => getOutstandingRewards(voting, address),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       initialData: BigNumber.from(0),
       onError,
     }

--- a/hooks/queries/rewards/useRewardsCalculationInputs.ts
+++ b/hooks/queries/rewards/useRewardsCalculationInputs.ts
@@ -1,12 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import { oneMinute, rewardsCalculationInputsKey } from "constant";
 import { BigNumber } from "ethers";
-import { useContractsContext, useHandleError, useUserContext } from "hooks";
+import {
+  useContractsContext,
+  useHandleError,
+  useUserContext,
+  useWalletContext,
+} from "hooks";
 import { getRewardsCalculationInputs } from "web3";
 
 export function useRewardsCalculationInputs(addressOverride?: string) {
   const { voting } = useContractsContext();
   const { address: defaultAddress } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
 
@@ -15,7 +21,7 @@ export function useRewardsCalculationInputs(addressOverride?: string) {
     () => getRewardsCalculationInputs(voting),
     {
       refetchInterval: oneMinute,
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       initialData: {
         emissionRate: BigNumber.from(0),
         rewardPerTokenStored: BigNumber.from(0),

--- a/hooks/queries/rewards/useV1Rewards.ts
+++ b/hooks/queries/rewards/useV1Rewards.ts
@@ -2,12 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import { useSetChain } from "@web3-onboard/react";
 import { v1RewardsKey } from "constant";
 import { BigNumber } from "ethers";
-import { useAccountDetails, useHandleError } from "hooks";
+import { useAccountDetails, useHandleError, useWalletContext } from "hooks";
 import { MainnetOrGoerli } from "types";
 import { getV1Rewards } from "web3";
 
 export function useV1Rewards() {
   const { address } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const [{ connectedChain }] = useSetChain();
   const { onError, clearErrors } = useHandleError({ isDataFetching: true });
 
@@ -16,7 +17,7 @@ export function useV1Rewards() {
     queryFn: () =>
       getV1Rewards(address, Number(connectedChain?.id ?? 1) as MainnetOrGoerli),
     initialData: { multicallPayload: [], totalRewards: BigNumber.from(0) },
-    enabled: !!address && !!connectedChain,
+    enabled: !!address && !!connectedChain && !isWrongChain,
     onError,
     onSuccess: clearErrors,
   });

--- a/hooks/queries/staking/useDelegatorStakedBalance.ts
+++ b/hooks/queries/staking/useDelegatorStakedBalance.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { stakedBalanceKey } from "constant";
 import { BigNumber } from "ethers";
 import { useContractsContext } from "hooks/contexts/useContractsContext";
+import { useWalletContext } from "hooks/contexts/useWalletContext";
 import { useHandleError } from "hooks/helpers/useHandleError";
 import { getStakedBalance } from "web3";
 import { useVoterFromDelegate } from "../delegation/useVoterFromDelegate";
@@ -9,12 +10,13 @@ import { useVoterFromDelegate } from "../delegation/useVoterFromDelegate";
 export function useDelegatorStakedBalance() {
   const { voting } = useContractsContext();
   const { data: address } = useVoterFromDelegate();
+  const { isWrongChain } = useWalletContext();
   const { onError, clearErrors } = useHandleError({ isDataFetching: true });
   const queryResult = useQuery({
     queryKey: [stakedBalanceKey, address],
     queryFn: () =>
       address ? getStakedBalance(voting, address) : BigNumber.from(0),
-    enabled: !!address,
+    enabled: !!address && !isWrongChain,
     initialData: BigNumber.from(0),
     onError,
     onSuccess: clearErrors,

--- a/hooks/queries/staking/useStakedBalance.ts
+++ b/hooks/queries/staking/useStakedBalance.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { stakedBalanceKey } from "constant";
 import { BigNumber } from "ethers";
 import { useContractsContext } from "hooks/contexts/useContractsContext";
+import { useWalletContext } from "hooks/contexts/useWalletContext";
 import { useHandleError } from "hooks/helpers/useHandleError";
 import { getStakedBalance } from "web3";
 import { useAccountDetails } from "../user/useAccountDetails";
@@ -11,13 +12,14 @@ const initialData = BigNumber.from(0);
 export function useStakedBalance(addressOverride?: string) {
   const { voting } = useContractsContext();
   const { address: defaultAddress } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const { onError, clearErrors } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
 
   const queryResult = useQuery({
     queryKey: [stakedBalanceKey, address],
     queryFn: () => (address ? getStakedBalance(voting, address) : initialData),
-    enabled: !!address,
+    enabled: !!address && !isWrongChain,
     initialData,
     onError,
     onSuccess: clearErrors,

--- a/hooks/queries/staking/useStakerDetails.ts
+++ b/hooks/queries/staking/useStakerDetails.ts
@@ -2,7 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 import { stakerDetailsKey } from "constant";
 import { BigNumber } from "ethers";
 import { zeroAddress } from "helpers";
-import { useAccountDetails, useContractsContext, useHandleError } from "hooks";
+import {
+  useAccountDetails,
+  useContractsContext,
+  useHandleError,
+  useWalletContext,
+} from "hooks";
 import { getStakerDetails } from "web3";
 
 const initialData = {
@@ -15,13 +20,14 @@ const initialData = {
 export function useStakerDetails(addressOverride?: string) {
   const { voting } = useContractsContext();
   const { address: defaultAddress } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
   return useQuery(
     [stakerDetailsKey, address],
     () => (address ? getStakerDetails(voting, address) : initialData),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       initialData,
       onError,
     }

--- a/hooks/queries/staking/useTokenAllowance.ts
+++ b/hooks/queries/staking/useTokenAllowance.ts
@@ -1,19 +1,25 @@
 import { useQuery } from "@tanstack/react-query";
 import { tokenAllowanceKey } from "constant";
 import { BigNumber } from "ethers";
-import { useAccountDetails, useContractsContext, useHandleError } from "hooks";
+import {
+  useAccountDetails,
+  useContractsContext,
+  useHandleError,
+  useWalletContext,
+} from "hooks";
 import { getTokenAllowance } from "web3";
 
 export function useTokenAllowance() {
   const { votingToken } = useContractsContext();
   const { address } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [tokenAllowanceKey, address],
     () => getTokenAllowance(votingToken, address),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       initialData: BigNumber.from(0),
       onError,
     }

--- a/hooks/queries/staking/useUnstakedBalance.ts
+++ b/hooks/queries/staking/useUnstakedBalance.ts
@@ -1,14 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
 import { unstakedBalanceKey } from "constant";
-import { useAccountDetails, useContractsContext, useHandleError } from "hooks";
-import { getUnstakedBalance } from "web3";
 import { BigNumber } from "ethers";
+import {
+  useAccountDetails,
+  useContractsContext,
+  useHandleError,
+  useWalletContext,
+} from "hooks";
+import { getUnstakedBalance } from "web3";
 
 const initialData = BigNumber.from(0);
 
 export function useUnstakedBalance(addressOverride?: string) {
   const { votingToken } = useContractsContext();
   const { address: defaultAddress } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
 
@@ -16,7 +22,7 @@ export function useUnstakedBalance(addressOverride?: string) {
     [unstakedBalanceKey, address],
     () => (address ? getUnstakedBalance(votingToken, address) : initialData),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       onError,
       initialData,
     }

--- a/hooks/queries/user/useUserVotingAndStakingDetails.ts
+++ b/hooks/queries/user/useUserVotingAndStakingDetails.ts
@@ -2,11 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 import { oneMinute, userDataKey } from "constant";
 import { BigNumber } from "ethers";
 import { getUserData } from "graph";
-import { useAccountDetails, useHandleError } from "hooks";
 import { config } from "helpers/config";
+import { useAccountDetails, useHandleError, useWalletContext } from "hooks";
 
 export function useUserVotingAndStakingDetails(addressOverride?: string) {
   const { address: defaultAddress } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
 
@@ -14,7 +15,7 @@ export function useUserVotingAndStakingDetails(addressOverride?: string) {
     [userDataKey, address],
     () => getUserData(address),
     {
-      enabled: !!address && config.graphV2Enabled,
+      enabled: !!address && !isWrongChain && config.graphV2Enabled,
       refetchInterval: oneMinute,
       initialData: {
         apr: BigNumber.from(0),

--- a/hooks/queries/votes/useActiveVotes.ts
+++ b/hooks/queries/votes/useActiveVotes.ts
@@ -4,12 +4,14 @@ import {
   useContractsContext,
   useHandleError,
   useVoteTimingContext,
+  useWalletContext,
 } from "hooks";
 import { getActiveVotes } from "web3";
 
 export function useActiveVotes() {
   const { voting } = useContractsContext();
   const { roundId } = useVoteTimingContext();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
   const { phase, millisecondsUntilPhaseEnds } = useVoteTimingContext();
 
@@ -26,6 +28,7 @@ export function useActiveVotes() {
         activeVotes: {},
         hasActiveVotes: false,
       },
+      enabled: !isWrongChain,
       onError,
     }
   );

--- a/hooks/queries/votes/useCommittedVotes.ts
+++ b/hooks/queries/votes/useCommittedVotes.ts
@@ -5,12 +5,14 @@ import {
   useContractsContext,
   useHandleError,
   useVoteTimingContext,
+  useWalletContext,
 } from "hooks";
 import { getCommittedVotes } from "web3";
 
 export function useCommittedVotes() {
   const { voting } = useContractsContext();
   const { address } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
@@ -18,7 +20,7 @@ export function useCommittedVotes() {
     [committedVotesKey, address, roundId],
     () => getCommittedVotes(voting, address, roundId),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       initialData: {},
       onError,
     }

--- a/hooks/queries/votes/useCommittedVotesByCaller.ts
+++ b/hooks/queries/votes/useCommittedVotesByCaller.ts
@@ -5,12 +5,14 @@ import {
   useContractsContext,
   useHandleError,
   useVoteTimingContext,
+  useWalletContext,
 } from "hooks";
 import { getCommittedVotesByCaller } from "web3";
 
 export function useCommittedVotesByCaller() {
   const { voting } = useContractsContext();
   const { address } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
@@ -18,7 +20,7 @@ export function useCommittedVotesByCaller() {
     [committedVotesKeyByCaller, address, roundId],
     () => getCommittedVotesByCaller(voting, address, roundId),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       initialData: {},
       onError,
     }

--- a/hooks/queries/votes/useDecryptedVotes.ts
+++ b/hooks/queries/votes/useDecryptedVotes.ts
@@ -1,7 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { decryptedVotesKey } from "constant";
 import { decryptMessage } from "helpers";
-import { useEncryptedVotes, useHandleError, useUserContext } from "hooks";
+import {
+  useEncryptedVotes,
+  useHandleError,
+  useUserContext,
+  useWalletContext,
+} from "hooks";
 import {
   DecryptedVotesByKeyT,
   DecryptedVoteT,
@@ -10,6 +15,7 @@ import {
 
 export function useDecryptedVotes(roundId?: number) {
   const { address, signingKey } = useUserContext();
+  const { isWrongChain } = useWalletContext();
   const { data: encryptedVotes } = useEncryptedVotes(roundId);
   const { onError } = useHandleError({ isDataFetching: true });
 
@@ -17,7 +23,7 @@ export function useDecryptedVotes(roundId?: number) {
     [decryptedVotesKey, encryptedVotes, address],
     () => decryptVotes(signingKey?.privateKey, encryptedVotes),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       initialData: {},
       onError,
     }

--- a/hooks/queries/votes/useEncryptedVotes.ts
+++ b/hooks/queries/votes/useEncryptedVotes.ts
@@ -1,18 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 import { encryptedVotesKey } from "constant";
-import { useAccountDetails, useContractsContext, useHandleError } from "hooks";
+import {
+  useAccountDetails,
+  useContractsContext,
+  useHandleError,
+  useWalletContext,
+} from "hooks";
 import { getEncryptedVotes } from "web3";
 
 export function useEncryptedVotes(roundId?: number) {
   const { voting, votingV1 } = useContractsContext();
   const { address } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [encryptedVotesKey, address, roundId],
     () => getEncryptedVotes(voting, votingV1, address, roundId),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       initialData: {},
       onError,
     }

--- a/hooks/queries/votes/useRevealedVotes.ts
+++ b/hooks/queries/votes/useRevealedVotes.ts
@@ -5,12 +5,14 @@ import {
   useContractsContext,
   useHandleError,
   useVoteTimingContext,
+  useWalletContext,
 } from "hooks";
 import { getRevealedVotes } from "web3";
 
 export function useRevealedVotes(addressOverride?: string) {
   const { voting } = useContractsContext();
   const { address: myAddress } = useAccountDetails();
+  const { isWrongChain } = useWalletContext();
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride ?? myAddress;
@@ -19,7 +21,7 @@ export function useRevealedVotes(addressOverride?: string) {
     [revealedVotesKey, address, roundId],
     () => getRevealedVotes(voting, address, roundId),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       initialData: {},
       onError,
     }


### PR DESCRIPTION
### Motivation

Having the wrong chain logic tied up with the general error handling logic was causing some issues. When you connect with the wrong chain, the app would flash the "wrong chain" message and then quickly remove it. The app would then show an "error fetching data" message instead. 

Since being connected to the wrong chain is a special situation that makes it so that no user dependent data has meaning and no actions can be taken, I've elected to move the logic for handling this situation out of the `ErrorContext`. Instead, we add a property to the `WalletContext` called `isWrongChain` which we can use to show/hide a special error banner. This error banner looks the same as the others but is different in that it does not have a "close" button — the only way to get rid of this error is to switch to the correct chain.

I've also added `!isWrongChain` to all of the queries which depend on the connected chain. I have not disabled the query for past votes and non-chain queries like contentful data and augmented requests as these still work when given past votes.

### Changes

* Add wrong chain error banner
* Move wrong chain logic to wallet context
* Erase provider and signer when is wrong chain
* Disable chain queries when is wrong chain