### PR TITLE
fix: remove global 100% width

### DIFF
--- a/components/GlobalStyle/GlobalStyle.ts
+++ b/components/GlobalStyle/GlobalStyle.ts
@@ -86,7 +86,6 @@ html {
 
 html, body, #__next {
   height: 100%;
-  width: 100%;
 }
 
 body {


### PR DESCRIPTION
### Motivation

Having `width: 100%` on the body is redundant, and it causes the panel to do this weird jumping thing when it opens. Adding this was a mistake and removing it fixes this issue.

### Changes

* Remove 100% width on body from `GlobalStyle`