### PR TITLE
fix: unstake cooldown always shown as seconds

### DIFF
--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -1,6 +1,6 @@
 import { AmountInput, Button, Checkbox, PanelErrorBanner } from "components";
-import { mobileAndUnder } from "constant";
-import { maximumApprovalAmountString } from "constant";
+import { maximumApprovalAmountString, mobileAndUnder } from "constant";
+import { intervalToDuration } from "date-fns";
 import formatDuration from "date-fns/formatDuration";
 import { BigNumber } from "ethers";
 import { formatEther, parseEtherSafe } from "helpers";
@@ -33,7 +33,12 @@ export function Stake({
   const [inputAmount, setInputAmount] = useState("");
   const [disclaimerChecked, setDisclaimerChecked] = useState(false);
   const unstakeCoolDownFormatted = unstakeCoolDown
-    ? formatDuration({ seconds: unstakeCoolDown.toNumber() })
+    ? formatDuration(
+        intervalToDuration({
+          start: 0,
+          end: unstakeCoolDown.toNumber() * 1000,
+        })
+      )
     : "0 seconds";
 
   const disclaimer = `I understand that once staked, I will not be able to reclaim my tokens until ${unstakeCoolDownFormatted} after my unstaking request is submitted.`;


### PR DESCRIPTION
### Motivation

The date-fns library assumes that if you pass in a value to format as an interval with a unit like `{ seconds: value }` then you want the output to be in that unit, i.e. seconds in this case. Passing it in as an interval tells date-fns to format it with the least values instead like x days y hours z minutes etc.

### Changes

* Pass `unstakeCoolDown` to date-fns `format` as an interval