### PR TITLE
fix: delegate address tooltip formatting

### DIFF
--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -3,16 +3,16 @@ import { tabletAndUnder } from "constant";
 import { BigNumber } from "ethers";
 import { formatNumberForDisplay, parseEther } from "helpers";
 import {
+  useDelegationContext,
   usePanelContext,
   useStakingContext,
   useUserContext,
-  useDelegationContext,
 } from "hooks";
+import NextLink from "next/link";
 import One from "public/assets/icons/one.svg";
 import Three from "public/assets/icons/three.svg";
 import Two from "public/assets/icons/two.svg";
 import styled from "styled-components";
-import NextLink from "next/link";
 
 export function HowItWorks() {
   const { openPanel } = usePanelContext();
@@ -75,9 +75,13 @@ export function HowItWorks() {
               {isDelegate ? (
                 <Tooltip
                   label={
-                    delegatorAddress
-                      ? `Delegator address ${delegatorAddress}`
-                      : ""
+                    delegatorAddress ? (
+                      <>
+                        <strong>Delegator address</strong> {delegatorAddress}
+                      </>
+                    ) : (
+                      ""
+                    )
                   }
                 >
                   <span>

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -41,7 +41,7 @@ const AnimatedTooltipContent = animated(TooltipPopup);
 
 const LabelWrapper = styled.div`
   display: inline-block;
-  max-width: min(80vw, 300px);
+  max-width: min(80vw, 328px);
   white-space: pre-line;
   overflow-wrap: break-word;
   word-wrap: break-word;

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -1,13 +1,13 @@
 import { TooltipPopup, useTooltip } from "@reach/tooltip";
 import "@reach/tooltip/styles.css";
 import { animated, useTransition } from "@react-spring/web";
-import { cloneElement } from "react";
+import { cloneElement, ReactElement, ReactNode } from "react";
 import styled from "styled-components";
 
 interface Props {
   "aria-label"?: string;
-  children: React.ReactElement;
-  label: string;
+  children: ReactElement;
+  label: ReactNode;
 }
 export function Tooltip({ children, label, ...rest }: Props) {
   const [trigger, tooltip, isVisible] = useTooltip();

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -46,6 +46,9 @@ const LabelWrapper = styled.div`
   overflow-wrap: break-word;
   word-wrap: break-word;
 
+  strong {
+    font-weight: 700;
+  }
 `;
 
 const TooltipContent = styled(AnimatedTooltipContent)`

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -45,7 +45,7 @@ const LabelWrapper = styled.div`
   white-space: pre-line;
   overflow-wrap: break-word;
   word-wrap: break-word;
-  hyphens: auto;
+
 `;
 
 const TooltipContent = styled(AnimatedTooltipContent)`


### PR DESCRIPTION
### Motivation 

Formatting of this tooltip looked a bit off. Remove a redundant line of css that fixes this weird hyphenation (was a mistake to add it in the first place).

Also changed the label type to `ReactNode` so that we can pass in content in `<strong>` tags so that it can be made bold.

**To test:** connect with **Account 8** on **Goerli**

before:

<img width="404" alt="2023-03-01 at 12 02 31@2x" src="https://user-images.githubusercontent.com/39741965/222128086-72167b08-1db5-4be3-a1f0-28cabf8bdf51.png">

after:

<img width="399" alt="Screenshot 2023-03-01 at 13 30 05" src="https://user-images.githubusercontent.com/39741965/222128149-ae09ab1f-3b53-4009-8fc4-22a9a2bdaf3f.png">

### Changes

* remove redundant hyphens
* slightly increase tooltip max width
* allow `ReactNode` as tooltip label
* add strong tag font weight
* make tooltip title bold