### PR TITLE
fix: handle 0 and -0 slash amounts

### DIFF
--- a/components/VoteHistoryTable/VoteHistoryTableRow.tsx
+++ b/components/VoteHistoryTable/VoteHistoryTableRow.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from "components/Tooltip/Tooltip";
-import { green, grey500, red500 } from "constant";
+import { black, green, grey500, red500 } from "constant";
 import { formatNumberForDisplay } from "helpers";
 import { CSSProperties } from "react";
 import styled from "styled-components";
@@ -14,7 +14,22 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
     resolvedPriceRequestIndex,
     voteHistory: { voted, correctness, staking, slashAmount },
   } = vote;
-  const scoreColor = slashAmount.lt(0) ? red500 : green;
+  const formattedSlashAmount = makeFormattedSlashAmount();
+  const scoreColor = getScoreColor();
+
+  function makeFormattedSlashAmount() {
+    const formattedSlashAmount = formatNumberForDisplay(slashAmount, {
+      decimals: 3,
+    });
+    if (formattedSlashAmount === "-0") return "0";
+    return formattedSlashAmount;
+  }
+
+  function getScoreColor() {
+    if (formattedSlashAmount === "0") return black;
+    if (formattedSlashAmount.startsWith("-")) return red500;
+    return green;
+  }
 
   return (
     <Tr>
@@ -45,7 +60,7 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
         </Correctness>
       </CorrectnessTd>
       <ScoreTd style={{ "--color": scoreColor } as CSSProperties}>
-        {formatNumberForDisplay(slashAmount)}
+        {formattedSlashAmount}
       </ScoreTd>
     </Tr>
   );

--- a/components/VoteHistoryTable/VoteHistoryTableRow.tsx
+++ b/components/VoteHistoryTable/VoteHistoryTableRow.tsx
@@ -18,9 +18,7 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
   const scoreColor = getScoreColor();
 
   function makeFormattedSlashAmount() {
-    const formattedSlashAmount = formatNumberForDisplay(slashAmount, {
-      decimals: 3,
-    });
+    const formattedSlashAmount = formatNumberForDisplay(slashAmount);
     if (formattedSlashAmount === "-0") return "0";
     return formattedSlashAmount;
   }


### PR DESCRIPTION
### Motivation

In the vote history panel, we show the value "0" as green, which is confusing. We also have several occurrences of "-0" because of rounding. We can fix this by removing the "-" when we encounter "-0" after formatting. 

Old 

<img width="110" alt="Screenshot 2023-03-01 at 14 21 58" src="https://user-images.githubusercontent.com/39741965/222139046-3a4d0476-71d1-4301-85e1-0407488c4b85.png">

New

<img width="88" alt="Screenshot 2023-03-01 at 14 56 55" src="https://user-images.githubusercontent.com/39741965/222145560-b1727296-573b-4b6e-8b24-4c4e756d8d73.png">


### Changes

* Remove negative sign from negative zero
* Show zero as black color