### PR TITLE
feat: use graph for revealing past votes

### DIFF
--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -65,7 +65,6 @@ export function UserProvider({ children }: { children: ReactNode }) {
     undefined
   );
   const { signingKeys, connectedChainId } = useWalletContext();
-
   const {
     data: {
       apr,

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -1,7 +1,8 @@
 import { config } from "helpers/config";
 import request, { gql } from "graphql-request";
 import { formatBytes32String, makePriceRequestsByKey } from "helpers";
-import { PastVotesQuery } from "types";
+import { PastVotesQuery, RevealedVotesByAddress } from "types";
+import { utils } from "ethers";
 
 const { graphEndpoint, graphEndpointV1 } = config;
 
@@ -34,6 +35,10 @@ export async function getPastVotesV1() {
         }
         revealedVotes {
           id
+          voter {
+            address
+          }
+          price
         }
       }
     }
@@ -62,6 +67,13 @@ export async function getPastVotesV1() {
         vote: price,
         tokensVotedWith: Number(totalVoteAmount),
       }));
+
+      const init: RevealedVotesByAddress = {};
+      const revealedVoteByAddress = revealedVotes.reduce((result, vote) => {
+        result[utils.getAddress(vote.voter.address)] = vote.price;
+        return result;
+      }, init);
+
       return {
         identifier,
         time: Number(time),
@@ -71,6 +83,7 @@ export async function getPastVotesV1() {
         participation,
         results,
         isV1: true,
+        revealedVoteByAddress,
       };
     }
   );
@@ -107,6 +120,10 @@ export async function getPastVotesV2() {
         }
         revealedVotes {
           id
+          voter {
+            address
+          }
+          price
         }
       }
     }
@@ -135,6 +152,11 @@ export async function getPastVotesV2() {
         vote: price,
         tokensVotedWith: Number(totalVoteAmount),
       }));
+      const init: RevealedVotesByAddress = {};
+      const revealedVoteByAddress = revealedVotes.reduce((result, vote) => {
+        result[utils.getAddress(vote.voter.address)] = vote.price;
+        return result;
+      }, init);
       return {
         identifier,
         time: Number(time),
@@ -144,6 +166,7 @@ export async function getPastVotesV2() {
         isV1: false,
         participation,
         results,
+        revealedVoteByAddress,
       };
     }
   );

--- a/helpers/config.ts
+++ b/helpers/config.ts
@@ -1,5 +1,6 @@
 import * as ss from "superstruct";
 import { SupportedChainIds } from "types";
+import { getDesignatedVotingFactoryAddress } from "@uma/contracts-frontend";
 
 // we want to create a raw type for the env, so we can alert the developer immediately when something does not exist
 // and give them information as to which env was missing. We don't want the app to run without required variables.
@@ -22,6 +23,7 @@ const Env = ss.object({
   NEXT_PUBLIC_SIGNING_MESSAGE: ss.optional(ss.string()),
   NEXT_PUBLIC_CHAIN_ID: ss.optional(ss.string()),
   NEXT_PUBLIC_OVERRIDE_APR: ss.optional(ss.string()),
+  NEXT_PUBLIC_DESIGNATED_VOTING_FACTORY_V1_ADDRESS: ss.optional(ss.string()),
 });
 export type Env = ss.Infer<typeof Env>;
 
@@ -51,6 +53,8 @@ export const env = ss.create(
       process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN,
     NEXT_PUBLIC_CHAIN_ID: process.env.NEXT_PUBLIC_CHAIN_ID,
     NEXT_PUBLIC_OVERRIDE_APR: process.env.NEXT_PUBLIC_OVERRIDE_APR,
+    NEXT_PUBLIC_DESIGNATED_VOTING_FACTORY_V1_ADDRESS:
+      process.env.NEXT_PUBLIC_DESIGNATED_VOTING_FACTORY_V1_ADDRESS,
   },
   Env
 );
@@ -73,6 +77,7 @@ const AppConfig = ss.object({
   graphV2Enabled: ss.defaulted(ss.boolean(), false),
   contentfulEnabled: ss.defaulted(ss.boolean(), false),
   overrideApr: ss.optional(ss.string()),
+  designatedVotingFactoryV1Address: ss.string(),
 });
 export type AppConfig = ss.Infer<typeof AppConfig>;
 
@@ -101,6 +106,11 @@ export const appConfig = ss.create(
       !!env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN &&
       !!env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
     overrideApr: env.NEXT_PUBLIC_OVERRIDE_APR,
+    designatedVotingFactoryV1Address:
+      env.NEXT_PUBLIC_DESIGNATED_VOTING_FACTORY_V1_ADDRESS ??
+      getDesignatedVotingFactoryAddress(
+        Number(env.NEXT_PUBLIC_CHAIN_ID ?? "1")
+      ),
   },
   AppConfig
 );

--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -42,6 +42,7 @@ function formatPriceRequest(
   const ancillaryData = priceRequest.ancillaryData;
   let decodedIdentifier = "";
   let decodedAncillaryData = "";
+  const revealedVoteByAddress = priceRequest.revealedVoteByAddress || {};
   try {
     decodedIdentifier = decodeHexString(identifier);
   } catch (e) {
@@ -90,5 +91,6 @@ function formatPriceRequest(
     isV1,
     isGovernance,
     rollCount,
+    revealedVoteByAddress,
   };
 }

--- a/helpers/web3/wallet.ts
+++ b/helpers/web3/wallet.ts
@@ -1,6 +1,7 @@
 import { DisconnectOptions, WalletState } from "@web3-onboard/core";
 import { ethers } from "ethers";
 import { getAddress, truncateEthAddress } from "helpers";
+import { createDesignatedVotingFactoryV1Instance } from "web3";
 
 export function handleDisconnectWallet(
   wallet: WalletState | null,
@@ -27,4 +28,11 @@ export function getAccountDetails(connectedWallets?: WalletState[]) {
     address,
     truncatedAddress,
   };
+}
+
+export async function getDesignatedVotingV1Address(
+  address: string
+): Promise<string | undefined> {
+  const contract = createDesignatedVotingFactoryV1Instance();
+  return contract.designatedVotingContracts(address);
 }

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -68,3 +68,4 @@ export { usePastVotes } from "./queries/votes/usePastVotes";
 export { useRevealedVotes } from "./queries/votes/useRevealedVotes";
 export { useUpcomingVotes } from "./queries/votes/useUpcomingVotes";
 export { useVoteDiscussion } from "./queries/votes/useVoteDiscussion";
+export { useDesignatedVotingV1Address } from "./queries/user/useDesignatedVotingV1Address";

--- a/hooks/queries/user/useDesignatedVotingV1Address.ts
+++ b/hooks/queries/user/useDesignatedVotingV1Address.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { getDesignatedVotingV1Address } from "helpers";
+
+export function useDesignatedVotingV1Address(address: string) {
+  return useQuery(
+    ["designatedVotingV1Address", address],
+    () => getDesignatedVotingV1Address(address),
+    {
+      enabled: !!address,
+      initialData: undefined,
+      onError: (err) =>
+        console.error("Error fetching designated voting v1 address", err),
+    }
+  );
+}

--- a/hooks/queries/user/useDesignatedVotingV1Address.ts
+++ b/hooks/queries/user/useDesignatedVotingV1Address.ts
@@ -1,12 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import { getDesignatedVotingV1Address } from "helpers";
+import { useWalletContext } from "hooks";
 
 export function useDesignatedVotingV1Address(address: string) {
+  const { isWrongChain } = useWalletContext();
   return useQuery(
     ["designatedVotingV1Address", address],
     () => getDesignatedVotingV1Address(address),
     {
-      enabled: !!address,
+      enabled: !!address && !isWrongChain,
       initialData: undefined,
       onError: (err) =>
         console.error("Error fetching designated voting v1 address", err),

--- a/stories/mocks/votes.ts
+++ b/stories/mocks/votes.ts
@@ -61,6 +61,7 @@ export const voteWithoutUserVote = {
     slashAmount: BigNumber.from(0),
   },
   rollCount: 0,
+  revealedVoteByAddress: {},
 };
 
 export const userVote = {
@@ -83,6 +84,7 @@ export const voteCommitted = {
   commitHash:
     "0xb7013512cb5f4e59fd08c299d8534373457f0f02aeb294e4f61611bfc8f43286",
   revealHash: undefined,
+  revealedVoteByAddress: {},
 };
 
 export const voteCommittedButNotRevealed = { ...voteCommitted };

--- a/types/queries.ts
+++ b/types/queries.ts
@@ -19,6 +19,10 @@ export type PastVotesQuery = {
     }[];
     revealedVotes: {
       id: string;
+      voter: {
+        address: string;
+      };
+      price: string;
     }[];
   }[];
 };

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -32,6 +32,7 @@ export type PriceRequestT = {
   isGovernance?: boolean;
   rollCount: number;
   resolvedPriceRequestIndex?: string;
+  revealedVoteByAddress: RevealedVotesByAddress;
 };
 
 export type ParticipationT = {
@@ -53,6 +54,8 @@ export type VoteResultsT = {
   results?: ResultsT;
 };
 
+export type RevealedVotesByAddress = Record<string, string>;
+
 export type RawPriceRequestDataT = {
   time: BigNumber | number;
   identifier: string;
@@ -65,6 +68,7 @@ export type RawPriceRequestDataT = {
   rollCount?: number;
   isGovernance?: boolean;
   resolvedPriceRequestIndex?: string;
+  revealedVoteByAddress?: RevealedVotesByAddress;
 };
 
 export type VoteHistoryDataT = {

--- a/web3/contracts/createDesignatedVotingFactoryV1Instance.ts
+++ b/web3/contracts/createDesignatedVotingFactoryV1Instance.ts
@@ -1,0 +1,14 @@
+import { DesignatedVotingFactoryEthers__factory } from "@uma/contracts-frontend";
+import { ethers } from "ethers";
+import { config } from "helpers/config";
+
+export function createDesignatedVotingFactoryV1Instance() {
+  const provider = new ethers.providers.InfuraProvider(
+    config.infuraName,
+    config.infuraId
+  );
+  return DesignatedVotingFactoryEthers__factory.connect(
+    config.designatedVotingFactoryV1Address,
+    provider
+  );
+}

--- a/web3/index.ts
+++ b/web3/index.ts
@@ -1,6 +1,7 @@
 export { createVotingContractInstance } from "./contracts/createVotingContractInstance";
 export { createVotingTokenContractInstance } from "./contracts/createVotingTokenContractInstance";
 export { createVotingV1ContractInstance } from "./contracts/createVotingV1ContractInstance";
+export { createDesignatedVotingFactoryV1Instance } from "./contracts/createDesignatedVotingFactoryV1Instance";
 export { removeDelegate } from "./mutations/delegation/removeDelegate";
 export { removeDelegator } from "./mutations/delegation/removeDelegator";
 export { setDelegate } from "./mutations/delegation/setDelegate";


### PR DESCRIPTION
## motivation
We currently arent able to decode historical votes made from the v1 contract.

## changes
This switches the app to defer to the graphs reveal values when looking up past votes, but maintains the onchain decription for active votes. This automatically looks up desinated voting factory address, but we can override if needed with env var.  btw, i realize now theres a serverless function for this, could switch to that if desired. 

![image](https://user-images.githubusercontent.com/4429761/222810904-5f54ae2d-3084-4961-bf72-605092e3f9c1.png)
