### PR TITLE
fix: remove unintended bottom margin from button wrapper

### DIFF
--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -186,7 +186,7 @@ const InnerWrapper = styled.div`
   padding-block: 30px;
   max-width: var(--page-width);
   margin-inline: auto;
-  div {
+  > div {
     margin-bottom: 5px;
   }
   @media ${tabletAndUnder} {


### PR DESCRIPTION
### Motivation

We're applying bottom margin to each of the divs that contain the `InfoBar` components to make space between them. To do this we're targeting divs with the child selector (just a blank space in the css). This selector grabs _all_ divs down the cascade, which means that it also applies the margin to the divs that wrap the action buttons - not what we want. Instead we should use the direct child selector `>` which applies only to the _immediate_ child divs in the cascade.

Before:

<img width="180" alt="Screenshot 2023-03-06 at 10 12 00" src="https://user-images.githubusercontent.com/39741965/223054187-2147d00a-fbce-43e0-88cf-1a203d9c70d3.png">

After:

<img width="184" alt="Screenshot 2023-03-06 at 10 12 13" src="https://user-images.githubusercontent.com/39741965/223054236-4e46b4bc-7d85-42cb-9165-b7e18b2c244e.png">

### Changes

* Use `>` instead of ` ` selector to grab only direct child divs
