### PR TITLE
fix: increase past vote lookback

### DIFF
--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -16,6 +16,7 @@ export async function getPastVotesV1() {
         where: { isResolved: true }
         orderBy: time
         orderDirection: desc
+        first: 1000
       ) {
         identifier {
           id
@@ -98,6 +99,7 @@ export async function getPastVotesV2() {
         where: { isResolved: true }
         orderBy: resolvedPriceRequestIndex
         orderDirection: desc
+        first: 1000
       ) {
         identifier {
           id


### PR DESCRIPTION
## motivation
we were not seeing the full vote history

## changes
apparently by not specifying a limit, it limits us to like the first 100 elements. so we increase this to 1000 to get the full history.  this may significantly slow down load times, but we can optimize in future prs. 