### PR TITLE
fix: make signature match old dapp by default

### DIFF
--- a/helpers/config.ts
+++ b/helpers/config.ts
@@ -97,7 +97,7 @@ export const appConfig = ss.create(
     graphEndpointV1: env.NEXT_PUBLIC_GRAPH_ENDPOINT_V1,
     graphEndpoint: env.NEXT_PUBLIC_GRAPH_ENDPOINT,
     signingMessage:
-      env.NEXT_PUBLIC_SIGNING_MESSAGE ?? "Login to UMA Voter dApp",
+      env.NEXT_PUBLIC_SIGNING_MESSAGE ?? "Login to UMA Voter dApp - 0", // Default to message from old dapp.
     deployBlock: Number(env.NEXT_PUBLIC_DEPLOY_BLOCK ?? "0"),
     chainId: Number(env.NEXT_PUBLIC_CHAIN_ID ?? "1"),
     graphV1Enabled: !!env.NEXT_PUBLIC_GRAPH_ENDPOINT_V1,

--- a/helpers/web3/crypto.ts
+++ b/helpers/web3/crypto.ts
@@ -74,7 +74,7 @@ export function getRandomUnsignedInt(): BigNumber {
 }
 
 export function derivePrivateKey(signature: string) {
-  const pk = solidityKeccak256(["string"], [signature]);
+  const pk = solidityKeccak256(["bytes"], [signature]);
   if (pk) return pk;
   return "";
 }


### PR DESCRIPTION
This change aligns the signature process with the old UMA voter dapp so the derived keys match that dapp. In the future, it could make sense to establish a message "versioning" system that determines which message to use based on which round is being used. However, for now, it makes sense to just align the two messages to start.