### PR TITLE
 fix: use non wallet provider for reading data 

### DIFF
--- a/components/Panel/ClaimPanel.tsx
+++ b/components/Panel/ClaimPanel.tsx
@@ -22,7 +22,7 @@ import {
 const minimumAmountClaimable = parseEtherSafe(".01");
 
 export function ClaimPanel() {
-  const { voting } = useContractsContext();
+  const { votingWriter } = useContractsContext();
   const { getDelegationStatus } = useDelegationContext();
   const { withdrawRewardsMutation, isWithdrawingRewards } =
     useWithdrawRewards("claim");
@@ -32,15 +32,15 @@ export function ClaimPanel() {
   const isDelegate = getDelegationStatus() === "delegate";
 
   function withdrawRewards() {
-    if (!outstandingRewards) return;
+    if (!outstandingRewards || !votingWriter) return;
 
-    withdrawRewardsMutation({ voting, outstandingRewards });
+    withdrawRewardsMutation({ voting: votingWriter, outstandingRewards });
   }
 
   function withdrawAndRestake() {
-    if (!outstandingRewards) return;
+    if (!outstandingRewards || !votingWriter) return;
 
-    withdrawAndRestakeMutation({ voting, outstandingRewards });
+    withdrawAndRestakeMutation({ voting: votingWriter, outstandingRewards });
   }
 
   function isLoading() {

--- a/components/Panel/ClaimV1Panel.tsx
+++ b/components/Panel/ClaimV1Panel.tsx
@@ -13,20 +13,24 @@ import { PanelTitle } from "./PanelTitle";
 import { PanelSectionText, PanelSectionTitle, PanelWrapper } from "./styles";
 
 export function ClaimV1Panel() {
-  const { voting } = useContractsContext();
+  const { votingWriter } = useContractsContext();
   const { withdrawV1RewardsMutation, isWithdrawingV1Rewards } =
     useWithdrawV1Rewards("claimV1");
   const { v1Rewards } = useStakingContext();
   const claimableV1Rewards = v1Rewards?.totalRewards ?? BigNumber.from(0);
 
   function withdrawV1Rewards() {
-    if (!v1Rewards) return;
+    if (!v1Rewards || !votingWriter) return;
 
     const { totalRewards, multicallPayload } = v1Rewards;
 
     if (totalRewards.eq(0) || multicallPayload.length === 0) return;
 
-    withdrawV1RewardsMutation({ voting, totalRewards, multicallPayload });
+    withdrawV1RewardsMutation({
+      voting: votingWriter,
+      totalRewards,
+      multicallPayload,
+    });
   }
 
   function isLoading() {

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -21,7 +21,7 @@ import { Stake } from "./Stake";
 import { Unstake } from "./Unstake";
 
 export function StakeUnstakePanel() {
-  const { voting, votingToken } = useContractsContext();
+  const { votingWriter, votingTokenWriter } = useContractsContext();
   const {
     tokenAllowance,
     stakedBalance,
@@ -57,17 +57,19 @@ export function StakeUnstakePanel() {
   }
 
   function approve(approveAmountInput: string) {
+    if (!votingTokenWriter) return;
     const approveAmount =
       approveAmountInput === maximumApprovalAmountString
         ? maximumApprovalAmount
         : parseEtherSafe(approveAmountInput);
-    approveMutation({ votingToken, approveAmount });
+    approveMutation({ votingToken: votingTokenWriter, approveAmount });
   }
 
   function stake(stakeAmountInput: string, resetStakeAmount: () => void) {
+    if (!votingWriter) return;
     const stakeAmount = parseEther(stakeAmountInput);
     stakeMutation(
-      { voting, stakeAmount },
+      { voting: votingWriter, stakeAmount },
       {
         onSuccess: () => {
           resetStakeAmount();
@@ -77,14 +79,15 @@ export function StakeUnstakePanel() {
   }
 
   function requestUnstake(unstakeAmountInput: string) {
+    if (!votingWriter) return;
     const unstakeAmount = parseEther(unstakeAmountInput);
-    requestUnstakeMutation({ voting, unstakeAmount });
+    requestUnstakeMutation({ voting: votingWriter, unstakeAmount });
   }
 
   function executeUnstake() {
-    if (!pendingUnstake) return;
+    if (!pendingUnstake || !votingWriter) return;
 
-    executeUnstakeMutation({ voting, pendingUnstake });
+    executeUnstakeMutation({ voting: votingWriter, pendingUnstake });
   }
 
   const tabs = [

--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -44,7 +44,7 @@ export function Votes() {
     useUserContext();
   const { signer, sign, isSigning, setCorrectChain, isSettingChain } =
     useWalletContext();
-  const { voting } = useContractsContext();
+  const { votingWriter } = useContractsContext();
   const { stakedBalance } = useStakingContext();
   const { getDelegationStatus, getDelegatorAddress } = useDelegationContext();
   const { commitVotesMutation, isCommittingVotes } = useCommitVotes();
@@ -248,7 +248,7 @@ export function Votes() {
   }
 
   async function commitVotes() {
-    if (!actionStatus.canCommit || !signingKey) return;
+    if (!actionStatus.canCommit || !signingKey || !votingWriter) return;
 
     const formattedVotes = await formatVotesToCommit({
       votes: getActiveVotes(),
@@ -259,7 +259,7 @@ export function Votes() {
     });
     commitVotesMutation(
       {
-        voting,
+        voting: votingWriter,
         formattedVotes,
       },
       {
@@ -271,10 +271,10 @@ export function Votes() {
   }
 
   function revealVotes() {
-    if (!actionStatus.canReveal) return;
+    if (!actionStatus.canReveal || !votingWriter) return;
 
     revealVotesMutation({
-      voting,
+      voting: votingWriter,
       votesToReveal: getVotesToReveal(),
     });
   }

--- a/components/Wallet/Wallet.tsx
+++ b/components/Wallet/Wallet.tsx
@@ -18,7 +18,7 @@ export function Wallet() {
   const [{ wallet, connecting }, connect] = useConnectWallet();
   const connectedWallets = useWallets();
   const { setProvider, setSigner, isWrongChain } = useWalletContext();
-  const { setVoting, setVotingToken } = useContractsContext();
+  const { setVotingWriter, setVotingTokenWriter } = useContractsContext();
   const { openPanel } = usePanelContext();
   const { truncatedAddress } = useUserContext();
 
@@ -59,8 +59,8 @@ export function Wallet() {
     if (!wallet?.provider || isWrongChain) {
       setProvider(null);
       setSigner(null);
-      setVoting(createVotingContractInstance());
-      setVotingToken(createVotingTokenContractInstance());
+      setVotingWriter(undefined);
+      setVotingTokenWriter(undefined);
     } else {
       // After this is set you can use the provider to sign or transact
       const provider = new ethers.providers.Web3Provider(wallet.provider);
@@ -69,8 +69,8 @@ export function Wallet() {
       setProvider(provider);
       setSigner(signer);
       // if a signer exists, we can change the voting contract instance to use it instead of the default `VoidSigner`
-      setVoting(createVotingContractInstance(signer));
-      setVotingToken(createVotingTokenContractInstance(signer));
+      setVotingWriter(createVotingContractInstance(signer));
+      setVotingTokenWriter(createVotingTokenContractInstance(signer));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wallet, isWrongChain]);

--- a/contexts/ContractsContext.tsx
+++ b/contexts/ContractsContext.tsx
@@ -12,11 +12,12 @@ import {
 
 export interface ContractsContextState {
   voting: VotingV2Ethers;
-  setVoting: (voting: VotingV2Ethers) => void;
+  votingWriter: VotingV2Ethers | undefined;
+  setVotingWriter: (voting: VotingV2Ethers | undefined) => void;
   votingToken: VotingTokenEthers;
-  setVotingToken: (votingToken: VotingTokenEthers) => void;
+  votingTokenWriter: VotingTokenEthers | undefined;
+  setVotingTokenWriter: (votingToken: VotingTokenEthers | undefined) => void;
   votingV1: VotingEthers;
-  setVotingV1: (votingV1: VotingEthers) => void;
 }
 
 const defaultVoting = createVotingContractInstance();
@@ -25,11 +26,12 @@ const defaultVotingV1 = createVotingV1ContractInstance();
 
 export const defaultContractContextState = {
   voting: defaultVoting,
-  setVoting: () => null,
+  votingWriter: undefined,
+  setVotingWriter: () => null,
   votingToken: defaultVotingToken,
-  setVotingToken: () => null,
+  votingTokenWriter: undefined,
+  setVotingTokenWriter: () => null,
   votingV1: defaultVotingV1,
-  setVotingV1: () => null,
 };
 
 export const ContractsContext = createContext<ContractsContextState>(
@@ -37,19 +39,23 @@ export const ContractsContext = createContext<ContractsContextState>(
 );
 
 export function ContractsProvider({ children }: { children: ReactNode }) {
-  const [voting, setVoting] = useState(defaultVoting);
-  const [votingToken, setVotingToken] = useState(defaultVotingToken);
-  const [votingV1, setVotingV1] = useState(defaultVotingV1);
+  const [votingTokenWriter, setVotingTokenWriter] = useState<
+    VotingTokenEthers | undefined
+  >(undefined);
+  const [votingWriter, setVotingWriter] = useState<VotingV2Ethers | undefined>(
+    undefined
+  );
 
   return (
     <ContractsContext.Provider
       value={{
-        voting,
-        setVoting,
-        votingToken,
-        setVotingToken,
-        votingV1,
-        setVotingV1,
+        voting: defaultVoting,
+        votingToken: defaultVotingToken,
+        votingV1: defaultVotingV1,
+        setVotingWriter,
+        votingWriter,
+        setVotingTokenWriter,
+        votingTokenWriter,
       }}
     >
       {children}

--- a/contexts/DelegationContext.tsx
+++ b/contexts/DelegationContext.tsx
@@ -118,7 +118,7 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
     terminateRelationshipWithDelegatorMutation,
     isTerminatingRelationshipWithDelegator,
   } = useTerminateRelationshipWithDelegator();
-  const { voting } = useContractsContext();
+  const { votingWriter } = useContractsContext();
   const { address } = useUserContext();
   const {
     data: { delegate },
@@ -269,9 +269,10 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   }
 
   function sendRequestToBeDelegate(delegateAddress: string) {
+    if (!votingWriter) return;
     sendRequestToBeDelegateMutation(
       {
-        voting,
+        voting: votingWriter,
         delegateAddress,
         notificationMessages: {
           pending: `Requesting ${truncateEthAddress(
@@ -294,8 +295,9 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   }
 
   function cancelSentRequestToBeDelegate() {
+    if (!votingWriter) return;
     cancelSentRequestToBeDelegateMutation({
-      voting,
+      voting: votingWriter,
       notificationMessages: {
         pending: "Cancelling request to delegate...",
         success: "Successfully cancelled request to delegate",
@@ -305,8 +307,9 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   }
 
   function acceptReceivedRequestToBeDelegate(delegatorAddress: string) {
+    if (!votingWriter) return;
     acceptReceivedRequestToBeDelegateMutation({
-      voting,
+      voting: votingWriter,
       delegatorAddress,
       notificationMessages: {
         pending: `Accepting request to be delegate from ${truncateEthAddress(
@@ -330,8 +333,9 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   }
 
   function terminateRelationshipWithDelegator() {
+    if (!votingWriter) return;
     terminateRelationshipWithDelegatorMutation({
-      voting,
+      voting: votingWriter,
       notificationMessages: {
         pending: "Removing delegator...",
         success: "Successfully removed delegator",
@@ -341,8 +345,9 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   }
 
   function terminateRelationshipWithDelegate() {
+    if (!votingWriter) return;
     terminateRelationshipWithDelegateMutation({
-      voting,
+      voting: votingWriter,
       notificationMessages: {
         pending: "Removing delegate...",
         success: "Successfully removed delegate",

--- a/hooks/queries/staking/useTokenAllowance.ts
+++ b/hooks/queries/staking/useTokenAllowance.ts
@@ -10,16 +10,16 @@ import {
 import { getTokenAllowance } from "web3";
 
 export function useTokenAllowance() {
-  const { votingToken } = useContractsContext();
+  const { votingTokenWriter } = useContractsContext();
   const { address } = useAccountDetails();
   const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery(
     [tokenAllowanceKey, address],
-    () => getTokenAllowance(votingToken, address),
+    () => getTokenAllowance(votingTokenWriter!, address),
     {
-      enabled: !!address && !isWrongChain,
+      enabled: !!address && !isWrongChain && !!votingTokenWriter,
       initialData: BigNumber.from(0),
       onError,
     }


### PR DESCRIPTION
## motivation
we are seeing some weird behavior when fetching data from providers. it turns out we are using the metmask provider once we connect wallet to pull data.

## changes
previouslly we had a single instance of a voting and voting token contract which was tied to the wallets provider and signer.  now we have 2 instances, one for reading, using our own provider, and one for writing using the wallets signer. this should make quering more predictable and have less errors, hopefully improving usability for people who are having connectivity issues. 