### PR TITLE
fix: do not parses your vote as number

### DIFF
--- a/components/VotesList/VotesListItem.tsx
+++ b/components/VotesList/VotesListItem.tsx
@@ -130,12 +130,7 @@ export function VotesListItem({
   }
 
   function getDecryptedVoteAsString() {
-    return getDecryptedVoteAsNumber()?.toString();
-  }
-
-  function getDecryptedVoteAsNumber() {
-    const formattedString = getDecryptedVoteAsFormattedString();
-    return formattedString ? Number(formattedString) : undefined;
+    return getDecryptedVoteAsFormattedString();
   }
 
   function showVoteInput() {


### PR DESCRIPTION
## motivation
we are seeing magic number shown in a truncated form, this makes it difficult to verify we committed the right value

## changes
this removes a line that parses the value as  a number, and just passes through the raw decoded string
![image](https://user-images.githubusercontent.com/4429761/225072761-de3cc353-beae-4f80-85f8-2771f02847db.png)
