### PR TITLE
fix: let user know commit is over if in reveal phase

### DIFF
--- a/components/VoteTimeline/CommitPhase.tsx
+++ b/components/VoteTimeline/CommitPhase.tsx
@@ -19,6 +19,22 @@ export function CommitPhase({ phase, timeRemaining }: Props) {
     Date.now() + timeRemaining
   );
 
+  let message = (
+    <Message>
+      Commit phase starts in: <Strong>{formattedTimeRemaining}</Strong>
+    </Message>
+  );
+  if (phase === "commit") {
+    message = (
+      <Message>
+        Time remaining to commit votes:{" "}
+        <Strong>{formattedTimeRemaining}</Strong>
+      </Message>
+    );
+  } else if (phase === "reveal") {
+    message = <Message>Commit phase over</Message>;
+  }
+
   return (
     <OuterWrapper>
       <InnerWrapper
@@ -39,16 +55,7 @@ export function CommitPhase({ phase, timeRemaining }: Props) {
             }
           />
         </CommitIconWrapper>
-        {isActive ? (
-          <Message>
-            Time remaining to commit votes:{" "}
-            <Strong>{formattedTimeRemaining}</Strong>
-          </Message>
-        ) : (
-          <Message>
-            Commit phase starts in: <Strong>{formattedTimeRemaining}</Strong>
-          </Message>
-        )}
+        {message}
       </InnerWrapper>
       {isActive && (
         <MobileActiveIndicatorWrapper>


### PR DESCRIPTION
## motivation
people are seeing commit in xx hours, during a reveal phase, this is confusing becuase commit phase is over

## changes
we were assuming there were only 2 states to the active vote banner for commits, "commit phase starting in xx" and "time remaining to commit". added a third state, "commit phase over", which only shows during active reveal phase. 

![image](https://user-images.githubusercontent.com/4429761/225304054-97c484ce-f3be-44e3-bfdc-a4da18a67180.png)
![image](https://user-images.githubusercontent.com/4429761/225304677-9aa53eb3-c24d-4b1e-a613-b0e3ba1b0113.png)

