### PR TITLE
feat: add dynamic polymarket dropdown parsing

### DIFF
--- a/helpers/voting/polymarket.ts
+++ b/helpers/voting/polymarket.ts
@@ -1,5 +1,6 @@
 import { earlyRequestMagicNumber } from "constant";
 import { DropdownItemT } from "types";
+import chunk from "lodash/chunk";
 
 export function checkIfIsPolymarket(
   decodedIdentifier: string,
@@ -13,6 +14,46 @@ export function checkIfIsPolymarket(
     decodedAncillaryData.includes(resultDataToken);
 
   return isPolymarket;
+}
+
+// this will only work when there are exactly 3 or more options, which should match most polymarket requests
+// it will only parse 3 options, omitting p4, which is assumed to be "too early".
+function dynamicPolymarketOptions(
+  decodedAncillaryData: string
+): DropdownItemT[] {
+  const resData = decodedAncillaryData.match(
+    /res_data: (p\d): (\d+\.\d+|\d+), (p\d): (\d+\.\d+|\d+), (p\d): (\d+\.\d+|\d+)/
+  );
+  const correspondence = decodedAncillaryData.match(
+    /Where (p\d) corresponds to ([^,]+), (p\d) to ([^,]+), (p\d) to ([^,]+)/
+  );
+
+  if (!resData || !correspondence) return [];
+
+  const cleanCorrespondence = correspondence.map((data) => {
+    if (data.toLowerCase().includes("a no")) {
+      return "No";
+    }
+    return data.trim();
+  });
+
+  const correspondenceTable = Object.fromEntries(
+    chunk(cleanCorrespondence.slice(1), 2)
+  ) as Record<string, string>;
+  const resDataTable = Object.fromEntries(chunk(resData.slice(1), 2)) as Record<
+    string,
+    string
+  >;
+
+  return Object.keys(resDataTable)
+    .filter((pValue) => correspondenceTable[pValue] && resDataTable[pValue])
+    .map((pValue) => {
+      return {
+        label: correspondenceTable[pValue],
+        value: resDataTable[pValue],
+        secondaryLabel: pValue,
+      };
+    });
 }
 /** Polymarket yes or no queries follow a semi-predictable pattern.
  * If both the res data and the correspondence to the res data are present,
@@ -33,6 +74,8 @@ export function maybeMakePolymarketOptions(
     corresponds:
       "Where p1 corresponds to No, p2 to a Yes, p3 to unknown, and p4 to an early request",
   };
+
+  const dynamicOptions = dynamicPolymarketOptions(decodedAncillaryData);
 
   if (
     decodedAncillaryData.includes(options1.resData) &&
@@ -81,6 +124,23 @@ export function maybeMakePolymarketOptions(
         value: "0.5",
         secondaryLabel: "p3",
       },
+      {
+        label: "Early request",
+        value: earlyRequestMagicNumber,
+        secondaryLabel: "p4",
+      },
+      {
+        label: "Custom",
+        value: "custom",
+      },
+    ];
+  }
+
+  // this will only display if we have dynamically found 3 options, otherwise fallback to custom input
+  if (dynamicOptions.length >= 3) {
+    return [
+      ...dynamicOptions,
+      // we will always append early request and custom input
       {
         label: "Early request",
         value: earlyRequestMagicNumber,


### PR DESCRIPTION
## motivation
people are having a hard time selecting correct options when selecting polymarket votes, and we arent able to detect the options

## changes
this uses a regex to match the p1,p2,p3 values, which only works in the case where there are those 3 options, and builds up options list based on matches. it will also always append magic number ( too early ) and a custom input

![image](https://user-images.githubusercontent.com/4429761/225639792-0f502280-90e9-415c-9b76-c1453d992197.png)


This will only display if its able to find at least 3 options.