### PR TITLE
feat: show upcoming votes when active vote

### DIFF
--- a/components/Votes/ActiveVotes.tsx
+++ b/components/Votes/ActiveVotes.tsx
@@ -1,0 +1,440 @@
+import { useConnectWallet } from "@web3-onboard/react";
+import {
+  Button,
+  IconWrapper,
+  Pagination,
+  Tooltip,
+  VotesList,
+  VotesListItem,
+  VotesTableHeadings,
+} from "components";
+import { defaultResultsPerPage } from "constant";
+import { formatVotesToCommit, getEntriesForPage } from "helpers";
+import { config } from "helpers/config";
+import {
+  useCommitVotes,
+  useContractsContext,
+  useDelegationContext,
+  usePaginationContext,
+  usePanelContext,
+  useRevealVotes,
+  useStakingContext,
+  useUserContext,
+  useVotesContext,
+  useVoteTimingContext,
+  useWalletContext,
+} from "hooks";
+import Warning from "public/assets/icons/warning.svg";
+import { useState, ReactNode } from "react";
+import styled from "styled-components";
+import { SelectedVotesByKeyT, VoteT } from "types";
+
+export function ActiveVotes({
+  votes,
+  children,
+}: {
+  votes: VoteT[];
+  children?: ReactNode;
+}) {
+  const { getUserDependentIsFetching } = useVotesContext();
+  const [{ connecting: isConnectingWallet }, connect] = useConnectWallet();
+  const { phase, roundId } = useVoteTimingContext();
+  const { address, hasSigningKey, correctChainConnected, signingKey } =
+    useUserContext();
+  const { signer, sign, isSigning, setCorrectChain, isSettingChain } =
+    useWalletContext();
+  const { votingWriter } = useContractsContext();
+  const { stakedBalance } = useStakingContext();
+  const { getDelegationStatus, getDelegatorAddress } = useDelegationContext();
+  const { commitVotesMutation, isCommittingVotes } = useCommitVotes();
+  const { revealVotesMutation, isRevealingVotes } = useRevealVotes();
+  const { openPanel } = usePanelContext();
+  const {
+    pageStates: {
+      activeVotesPage: { resultsPerPage, pageNumber },
+    },
+  } = usePaginationContext();
+  const [selectedVotes, setSelectedVotes] = useState<SelectedVotesByKeyT>({});
+  const [dirtyInputs, setDirtyInput] = useState<boolean[]>([]);
+  const isDelegate = getDelegationStatus() === "delegate";
+  const isDelegator = getDelegationStatus() === "delegator";
+  const delegatorAddress = isDelegate ? getDelegatorAddress() : undefined;
+
+  function isDirty(): boolean {
+    return dirtyInputs.some((x) => x);
+  }
+  const votesToShow = getEntriesForPage(pageNumber, resultsPerPage, votes);
+  const actionStatus = calculateActionStatus();
+  type ActionStatus = {
+    tooltip?: string;
+    label: string;
+    infoText?: { label: string; tooltip: string };
+    onClick: () => void;
+    disabled?: boolean;
+    hidden?: boolean;
+    canCommit: boolean;
+    canReveal: boolean;
+  };
+  function calculateActionStatus(): ActionStatus {
+    const actionConfig: ActionStatus = {
+      hidden: true,
+      tooltip: undefined,
+      label: "",
+      infoText: undefined,
+      onClick: () => undefined,
+      disabled: true,
+      canCommit: false,
+      canReveal: false,
+    };
+
+    const isCommit = phase === "commit";
+    const isReveal = phase === "reveal";
+    const hasStaked = stakedBalance?.gt(0) ?? false;
+    const hasSigner = !!signer;
+
+    const hasPreviouslyCommittedAll =
+      votes.filter((vote) => vote.decryptedVote).length === votes.length;
+    // counting how many votes we have edited with commitable values ( non empty )
+    const selectedVotesCount = Object.values(selectedVotes).filter(
+      (x) => x
+    ).length;
+    // check if we have votes to commit by seeing there are more than 1 and its dirty
+    const hasVotesToCommit =
+      selectedVotesCount > 0
+        ? hasPreviouslyCommittedAll
+          ? isDirty()
+          : true
+        : false;
+    const hasVotesToReveal = getVotesToReveal().length > 0;
+    // the current account is editing a previoulsy committed value from antoher account, either delegate or delegator
+    const isEditingUnknownVote =
+      votes.filter((vote) => {
+        return (
+          vote.commitHash &&
+          !vote.decryptedVote &&
+          selectedVotes[vote.uniqueKey]
+        );
+      }).length > 0;
+
+    if (!hasSigner || !address) {
+      actionConfig.hidden = false;
+      actionConfig.disabled = false;
+      actionConfig.label = "Connect Wallet";
+      actionConfig.onClick = () => {
+        connect().catch(console.error);
+      };
+
+      if (isConnectingWallet) {
+        actionConfig.disabled = true;
+      }
+      return actionConfig;
+    }
+    if (!correctChainConnected) {
+      actionConfig.hidden = false;
+      actionConfig.disabled = false;
+      actionConfig.label = `Switch To ${config.properName}`;
+      actionConfig.onClick = () => setCorrectChain();
+
+      if (isSettingChain) {
+        actionConfig.disabled = true;
+      }
+      return actionConfig;
+    }
+
+    if (isCommit) {
+      actionConfig.label = "Commit";
+      actionConfig.hidden = false;
+      if (isEditingUnknownVote && (isDelegate || isDelegator)) {
+        const otherAccount = isDelegate ? "delegator" : "delegate";
+        actionConfig.infoText = {
+          label: `Editing ${otherAccount}'s vote.`,
+          tooltip: `Your ${otherAccount} has already commited a vote for you, there is no need to re-vote on this account. Only do this if you want to change the vote or change which account can reveal, otherwise you will waste gas.`,
+        };
+      }
+      if (isCommittingVotes) {
+        actionConfig.disabled = true;
+        actionConfig.tooltip = "Committing votes in progress...";
+        return actionConfig;
+      }
+      if (isDelegate) {
+        if (!hasStaked) {
+          actionConfig.disabled = true;
+          actionConfig.tooltip =
+            "You cannot commit because your delegator has no UMA Staked.";
+          return actionConfig;
+        }
+      } else {
+        if (!hasStaked) {
+          actionConfig.disabled = true;
+          actionConfig.tooltip =
+            "You cannot commit because you have no UMA Staked.";
+          return actionConfig;
+        }
+      }
+      if (!hasSigningKey) {
+        actionConfig.label = "Sign";
+        actionConfig.onClick = () => sign();
+        actionConfig.infoText = {
+          label: "Why do I need to sign?",
+          tooltip:
+            "UMA uses this signature to verify that you are the owner of this address. We must do this to prevent double voting.",
+        };
+        actionConfig.disabled = false;
+
+        if (isSigning) {
+          actionConfig.disabled = true;
+          actionConfig.tooltip =
+            "Confirm the request for a signature in your wallet software.";
+          return actionConfig;
+        }
+        return actionConfig;
+      }
+      if (!hasVotesToCommit) {
+        actionConfig.disabled = true;
+        actionConfig.tooltip =
+          "You must enter your votes before you can continue.";
+        return actionConfig;
+      }
+      actionConfig.canCommit = true;
+      actionConfig.disabled = false;
+      actionConfig.onClick = () => {
+        commitVotes().catch(console.error);
+      };
+      return actionConfig;
+    }
+    if (isReveal) {
+      actionConfig.hidden = false;
+      actionConfig.label = "Reveal";
+      if (!hasSigningKey) {
+        actionConfig.label = "Sign";
+        actionConfig.onClick = () => sign();
+        actionConfig.infoText = {
+          label: "Why do I need to sign?",
+          tooltip:
+            "UMA uses this signature to verify that you are the owner of this address. We must do this to prevent double voting.",
+        };
+        actionConfig.disabled = false;
+        if (isSigning) {
+          actionConfig.disabled = true;
+          actionConfig.tooltip =
+            "Confirm the request for a signature in your wallet software.";
+          return actionConfig;
+        }
+        return actionConfig;
+      }
+      if (isRevealingVotes) {
+        actionConfig.disabled = true;
+        actionConfig.tooltip = "Revealing votes in progress...";
+        return actionConfig;
+      }
+      if (!hasVotesToReveal) {
+        actionConfig.disabled = true;
+        actionConfig.tooltip = "You have no votes to reveal.";
+        return actionConfig;
+      }
+      actionConfig.canReveal = true;
+      actionConfig.disabled = false;
+      actionConfig.onClick = () => revealVotes();
+      return actionConfig;
+    }
+    return actionConfig;
+  }
+
+  async function commitVotes() {
+    if (!actionStatus.canCommit || !signingKey || !votingWriter) return;
+
+    const formattedVotes = await formatVotesToCommit({
+      votes,
+      selectedVotes,
+      roundId,
+      address: delegatorAddress ? delegatorAddress : address,
+      signingKey,
+    });
+    commitVotesMutation(
+      {
+        voting: votingWriter,
+        formattedVotes,
+      },
+      {
+        onSuccess: () => {
+          setSelectedVotes({});
+        },
+      }
+    );
+  }
+
+  function revealVotes() {
+    if (!actionStatus.canReveal || !votingWriter) return;
+
+    revealVotesMutation({
+      voting: votingWriter,
+      votesToReveal: getVotesToReveal(),
+    });
+  }
+
+  function getVotesToReveal() {
+    return votes.filter(
+      (vote) =>
+        vote.isCommitted &&
+        !!vote.decryptedVote &&
+        vote.isRevealed === false &&
+        vote.canReveal
+    );
+  }
+
+  function selectVote(value: string, vote: VoteT) {
+    setSelectedVotes((selected) => ({ ...selected, [vote.uniqueKey]: value }));
+  }
+
+  function openVotePanel(vote: VoteT) {
+    openPanel("vote", vote);
+  }
+
+  return (
+    <>
+      <Title> Active votes: </Title>
+      {children}
+      <VotesTableWrapper>
+        <VotesList
+          headings={<VotesTableHeadings activityStatus="active" />}
+          rows={votesToShow.map((vote, index) => (
+            <VotesListItem
+              vote={vote}
+              phase={phase}
+              selectedVote={selectedVotes[vote.uniqueKey]}
+              selectVote={(value) => selectVote(value, vote)}
+              activityStatus="active"
+              moreDetailsAction={() => openVotePanel(vote)}
+              key={vote.uniqueKey}
+              delegationStatus={getDelegationStatus()}
+              isDirty={dirtyInputs[index]}
+              setDirty={(dirty: boolean) => {
+                setDirtyInput((inputs) => {
+                  inputs[index] = dirty;
+                  return [...inputs];
+                });
+              }}
+              isFetching={
+                getUserDependentIsFetching() ||
+                isCommittingVotes ||
+                isRevealingVotes
+              }
+            />
+          ))}
+        />
+      </VotesTableWrapper>
+      {votes.length > defaultResultsPerPage && (
+        <PaginationWrapper>
+          <Pagination
+            paginateFor="activeVotesPage"
+            numberOfEntries={votes.length}
+          />
+        </PaginationWrapper>
+      )}
+      {isDirty() ? (
+        <RecommittingVotesMessage>
+          * Changes to committed votes need to be re-committed
+        </RecommittingVotesMessage>
+      ) : null}
+      <ButtonOuterWrapper>
+        {actionStatus.infoText ? (
+          <Tooltip label={actionStatus.infoText.tooltip}>
+            <InfoText>
+              <IconWrapper width={20} height={20}>
+                <WarningIcon />
+              </IconWrapper>
+              {actionStatus.infoText.label}
+            </InfoText>
+          </Tooltip>
+        ) : null}
+        <ButtonInnerWrapper>
+          {isDirty() ? (
+            <>
+              <Button
+                variant="secondary"
+                label="Reset Changes"
+                onClick={() => setSelectedVotes({})}
+              />
+              <ButtonSpacer />
+            </>
+          ) : undefined}
+          {!actionStatus.hidden ? (
+            actionStatus.tooltip ? (
+              <Tooltip label={actionStatus.tooltip}>
+                <div>
+                  <Button
+                    variant="primary"
+                    label={actionStatus.label}
+                    onClick={actionStatus.onClick}
+                    disabled={actionStatus.disabled}
+                  />
+                </div>
+              </Tooltip>
+            ) : (
+              <Button
+                variant="primary"
+                label={actionStatus.label}
+                onClick={actionStatus.onClick}
+                disabled={actionStatus.disabled}
+              />
+            )
+          ) : null}
+        </ButtonInnerWrapper>
+      </ButtonOuterWrapper>
+    </>
+  );
+}
+
+const VotesTableWrapper = styled.div`
+  margin-top: var(--margin-top, 35px);
+`;
+
+const Title = styled.h1`
+  font: var(--header-md);
+  margin-bottom: 20px;
+`;
+
+const ButtonOuterWrapper = styled.div`
+  margin-top: 30px;
+`;
+
+const ButtonInnerWrapper = styled.div`
+  display: flex;
+  justify-content: end;
+  gap: 15px;
+
+  button {
+    text-transform: capitalize;
+  }
+`;
+
+const InfoText = styled.p`
+  display: flex;
+  gap: 15px;
+  width: fit-content;
+  margin-left: auto;
+  margin-bottom: 15px;
+  font: var(--text-md);
+`;
+
+const WarningIcon = styled(Warning)`
+  path {
+    stroke: var(--black);
+    fill: transparent;
+  }
+`;
+
+const PaginationWrapper = styled.div`
+  margin-block: 30px;
+`;
+
+const ButtonSpacer = styled.div`
+  width: 10px;
+`;
+
+const RecommittingVotesMessage = styled.p`
+  width: fit-content;
+  font: var(--text-sm);
+  margin-left: auto;
+  margin-top: 10px;
+`;

--- a/components/Votes/PastVotes.tsx
+++ b/components/Votes/PastVotes.tsx
@@ -1,0 +1,92 @@
+import {
+  Button,
+  Pagination,
+  VotesList,
+  VotesListItem,
+  VotesTableHeadings,
+} from "components";
+import { defaultResultsPerPage } from "constant";
+import { getEntriesForPage } from "helpers";
+import {
+  usePaginationContext,
+  usePanelContext,
+  useVotesContext,
+  useVoteTimingContext,
+} from "hooks";
+import styled, { CSSProperties } from "styled-components";
+import { VoteT } from "types";
+
+export function PastVotes({ votes }: { votes: VoteT[] }) {
+  const { openPanel } = usePanelContext();
+  const { phase } = useVoteTimingContext();
+  const {
+    pageStates: {
+      pastVotesComponent: { resultsPerPage, pageNumber },
+    },
+  } = usePaginationContext();
+  const { getUserDependentIsFetching } = useVotesContext();
+  const votesToShow = getEntriesForPage(pageNumber, resultsPerPage, votes);
+
+  return (
+    <>
+      <Title>Recent past votes:</Title>
+      <VotesTableWrapper
+        style={
+          {
+            "--margin-top": "0px",
+          } as CSSProperties
+        }
+      >
+        <VotesList
+          headings={<VotesTableHeadings activityStatus="past" />}
+          rows={votesToShow.map((vote) => (
+            <VotesListItem
+              vote={vote}
+              phase={phase}
+              selectedVote={undefined}
+              selectVote={() => null}
+              activityStatus="past"
+              moreDetailsAction={() => openPanel("vote", vote)}
+              key={vote.uniqueKey}
+              isFetching={getUserDependentIsFetching()}
+            />
+          ))}
+        />
+      </VotesTableWrapper>
+      {votes.length > defaultResultsPerPage && (
+        <PaginationWrapper>
+          <Pagination
+            paginateFor="pastVotesComponent"
+            numberOfEntries={votes.length}
+          />
+        </PaginationWrapper>
+      )}
+      <ButtonInnerWrapper>
+        <Button label="See all" href="/past-votes" variant="primary" />
+      </ButtonInnerWrapper>
+    </>
+  );
+}
+
+const VotesTableWrapper = styled.div`
+  margin-top: var(--margin-top, 35px);
+`;
+
+const Title = styled.h1`
+  font: var(--header-md);
+  margin-bottom: 20px;
+`;
+
+const ButtonInnerWrapper = styled.div`
+  display: flex;
+  justify-content: end;
+  gap: 15px;
+
+  button {
+    text-transform: capitalize;
+  }
+`;
+
+const PaginationWrapper = styled.div`
+  margin-block: 30px;
+`;

--- a/components/Votes/UpcomingVotes.tsx
+++ b/components/Votes/UpcomingVotes.tsx
@@ -1,0 +1,82 @@
+import {
+  Pagination,
+  VotesList,
+  VotesListItem,
+  VotesTableHeadings,
+} from "components";
+import { defaultResultsPerPage } from "constant";
+import { getEntriesForPage } from "helpers";
+import {
+  usePaginationContext,
+  usePanelContext,
+  useVotesContext,
+  useVoteTimingContext,
+} from "hooks";
+import { ReactNode } from "react";
+import styled from "styled-components";
+import { VoteT } from "types";
+
+export function UpcomingVotes({
+  votes,
+  children,
+}: {
+  votes: VoteT[];
+  children?: ReactNode;
+}) {
+  const { openPanel } = usePanelContext();
+  const { phase } = useVoteTimingContext();
+  const { getUserDependentIsFetching } = useVotesContext();
+  function openVotePanel(vote: VoteT) {
+    openPanel("vote", vote);
+  }
+  const {
+    pageStates: {
+      upcomingVotesPage: { resultsPerPage, pageNumber },
+    },
+  } = usePaginationContext();
+  const votesToShow = getEntriesForPage(pageNumber, resultsPerPage, votes);
+  return (
+    <>
+      <Title>Upcoming votes:</Title>
+      {children}
+      <VotesTableWrapper>
+        <VotesList
+          headings={<VotesTableHeadings activityStatus="upcoming" />}
+          rows={votesToShow.map((vote) => (
+            <VotesListItem
+              vote={vote}
+              phase={phase}
+              selectedVote={undefined}
+              selectVote={() => null}
+              activityStatus="upcoming"
+              moreDetailsAction={() => openVotePanel(vote)}
+              key={vote.uniqueKey}
+              isFetching={getUserDependentIsFetching()}
+            />
+          ))}
+        />
+      </VotesTableWrapper>
+      {votes.length > defaultResultsPerPage && (
+        <PaginationWrapper>
+          <Pagination
+            paginateFor="upcomingVotesPage"
+            numberOfEntries={votes.length}
+          />
+        </PaginationWrapper>
+      )}
+    </>
+  );
+}
+
+const VotesTableWrapper = styled.div`
+  margin-top: var(--margin-top, 35px);
+`;
+
+const Title = styled.h1`
+  font: var(--header-md);
+  margin-bottom: 20px;
+`;
+
+const PaginationWrapper = styled.div`
+  margin-block: 30px;
+`;

--- a/components/Votes/Votes.tsx
+++ b/components/Votes/Votes.tsx
@@ -1,573 +1,64 @@
-import { useConnectWallet } from "@web3-onboard/react";
-import {
-  Button,
-  IconWrapper,
-  Pagination,
-  Tooltip,
-  VotesList,
-  VotesListItem,
-  VotesTableHeadings,
-  VoteTimeline,
-} from "components";
-import { defaultResultsPerPage } from "constant";
-import { formatVotesToCommit, getEntriesForPage } from "helpers";
-import { config } from "helpers/config";
-import {
-  useCommitVotes,
-  useContractsContext,
-  useDelegationContext,
-  usePaginationContext,
-  usePanelContext,
-  useRevealVotes,
-  useStakingContext,
-  useUserContext,
-  useVotesContext,
-  useVoteTimingContext,
-  useWalletContext,
-} from "hooks";
-import Warning from "public/assets/icons/warning.svg";
-import { useState } from "react";
-import styled, { CSSProperties } from "styled-components";
-import { SelectedVotesByKeyT, VoteT } from "types";
+import styled from "styled-components";
+
+import { ActiveVotes } from "./ActiveVotes";
+import { PastVotes } from "./PastVotes";
+import { UpcomingVotes } from "./UpcomingVotes";
+import { useVotesContext } from "hooks";
+import { VoteTimeline } from "components";
 
 export function Votes() {
   const {
+    hasActiveVotes,
+    hasUpcomingVotes,
     getActiveVotes,
     getUpcomingVotes,
     getPastVotes,
-    getActivityStatus,
-    getUserDependentIsFetching,
   } = useVotesContext();
-  const [{ connecting: isConnectingWallet }, connect] = useConnectWallet();
-  const { phase, roundId } = useVoteTimingContext();
-  const { address, hasSigningKey, correctChainConnected, signingKey } =
-    useUserContext();
-  const { signer, sign, isSigning, setCorrectChain, isSettingChain } =
-    useWalletContext();
-  const { votingWriter } = useContractsContext();
-  const { stakedBalance } = useStakingContext();
-  const { getDelegationStatus, getDelegatorAddress } = useDelegationContext();
-  const { commitVotesMutation, isCommittingVotes } = useCommitVotes();
-  const { revealVotesMutation, isRevealingVotes } = useRevealVotes();
-  const { openPanel } = usePanelContext();
-  const {
-    pageStates: {
-      activeVotesPage: { resultsPerPage, pageNumber },
-    },
-  } = usePaginationContext();
-  const [selectedVotes, setSelectedVotes] = useState<SelectedVotesByKeyT>({});
-  const [dirtyInputs, setDirtyInput] = useState<boolean[]>([]);
-  const isDelegate = getDelegationStatus() === "delegate";
-  const isDelegator = getDelegationStatus() === "delegator";
-  const delegatorAddress = isDelegate ? getDelegatorAddress() : undefined;
 
-  function isDirty(): boolean {
-    return dirtyInputs.some((x) => x);
-  }
-  const votesToShow = getEntriesForPage(
-    pageNumber,
-    resultsPerPage,
-    determineVotesToShow()
-  );
-  const actionStatus = calculateActionStatus();
-  type ActionStatus = {
-    tooltip?: string;
-    label: string;
-    infoText?: { label: string; tooltip: string };
-    onClick: () => void;
-    disabled?: boolean;
-    hidden?: boolean;
-    canCommit: boolean;
-    canReveal: boolean;
-  };
-  function calculateActionStatus(): ActionStatus {
-    const actionConfig: ActionStatus = {
-      hidden: true,
-      tooltip: undefined,
-      label: "",
-      infoText: undefined,
-      onClick: () => undefined,
-      disabled: true,
-      canCommit: false,
-      canReveal: false,
-    };
-
-    const isCommit = phase === "commit";
-    const isReveal = phase === "reveal";
-    const hasStaked = stakedBalance?.gt(0) ?? false;
-    const hasSigner = !!signer;
-
-    const votesToShow = determineVotesToShow();
-    const hasPreviouslyCommittedAll =
-      votesToShow.filter((vote) => vote.decryptedVote).length ===
-      votesToShow.length;
-    // counting how many votes we have edited with commitable values ( non empty )
-    const selectedVotesCount = Object.values(selectedVotes).filter(
-      (x) => x
-    ).length;
-    // check if we have votes to commit by seeing there are more than 1 and its dirty
-    const hasVotesToCommit =
-      selectedVotesCount > 0
-        ? hasPreviouslyCommittedAll
-          ? isDirty()
-          : true
-        : false;
-    const hasVotesToReveal = getVotesToReveal().length > 0;
-    // the current account is editing a previoulsy committed value from antoher account, either delegate or delegator
-    const isEditingUnknownVote =
-      votesToShow.filter((vote) => {
-        return (
-          vote.commitHash &&
-          !vote.decryptedVote &&
-          selectedVotes[vote.uniqueKey]
-        );
-      }).length > 0;
-
-    if (!hasSigner || !address) {
-      actionConfig.hidden = false;
-      actionConfig.disabled = false;
-      actionConfig.label = "Connect Wallet";
-      actionConfig.onClick = () => {
-        connect().catch(console.error);
-      };
-
-      if (isConnectingWallet) {
-        actionConfig.disabled = true;
-      }
-      return actionConfig;
-    }
-    if (!correctChainConnected) {
-      actionConfig.hidden = false;
-      actionConfig.disabled = false;
-      actionConfig.label = `Switch To ${config.properName}`;
-      actionConfig.onClick = () => setCorrectChain();
-
-      if (isSettingChain) {
-        actionConfig.disabled = true;
-      }
-      return actionConfig;
-    }
-
-    if (isCommit) {
-      actionConfig.label = "Commit";
-      actionConfig.hidden = false;
-      if (isEditingUnknownVote && (isDelegate || isDelegator)) {
-        const otherAccount = isDelegate ? "delegator" : "delegate";
-        actionConfig.infoText = {
-          label: `Editing ${otherAccount}'s vote.`,
-          tooltip: `Your ${otherAccount} has already commited a vote for you, there is no need to re-vote on this account. Only do this if you want to change the vote or change which account can reveal, otherwise you will waste gas.`,
-        };
-      }
-      if (isCommittingVotes) {
-        actionConfig.disabled = true;
-        actionConfig.tooltip = "Committing votes in progress...";
-        return actionConfig;
-      }
-      if (isDelegate) {
-        if (!hasStaked) {
-          actionConfig.disabled = true;
-          actionConfig.tooltip =
-            "You cannot commit because your delegator has no UMA Staked.";
-          return actionConfig;
-        }
-      } else {
-        if (!hasStaked) {
-          actionConfig.disabled = true;
-          actionConfig.tooltip =
-            "You cannot commit because you have no UMA Staked.";
-          return actionConfig;
-        }
-      }
-      if (!hasSigningKey) {
-        actionConfig.label = "Sign";
-        actionConfig.onClick = () => sign();
-        actionConfig.infoText = {
-          label: "Why do I need to sign?",
-          tooltip:
-            "UMA uses this signature to verify that you are the owner of this address. We must do this to prevent double voting.",
-        };
-        actionConfig.disabled = false;
-
-        if (isSigning) {
-          actionConfig.disabled = true;
-          actionConfig.tooltip =
-            "Confirm the request for a signature in your wallet software.";
-          return actionConfig;
-        }
-        return actionConfig;
-      }
-      if (!hasVotesToCommit) {
-        actionConfig.disabled = true;
-        actionConfig.tooltip =
-          "You must enter your votes before you can continue.";
-        return actionConfig;
-      }
-      actionConfig.canCommit = true;
-      actionConfig.disabled = false;
-      actionConfig.onClick = () => {
-        commitVotes().catch(console.error);
-      };
-      return actionConfig;
-    }
-    if (isReveal) {
-      actionConfig.hidden = false;
-      actionConfig.label = "Reveal";
-      if (!hasSigningKey) {
-        actionConfig.label = "Sign";
-        actionConfig.onClick = () => sign();
-        actionConfig.infoText = {
-          label: "Why do I need to sign?",
-          tooltip:
-            "UMA uses this signature to verify that you are the owner of this address. We must do this to prevent double voting.",
-        };
-        actionConfig.disabled = false;
-        if (isSigning) {
-          actionConfig.disabled = true;
-          actionConfig.tooltip =
-            "Confirm the request for a signature in your wallet software.";
-          return actionConfig;
-        }
-        return actionConfig;
-      }
-      if (isRevealingVotes) {
-        actionConfig.disabled = true;
-        actionConfig.tooltip = "Revealing votes in progress...";
-        return actionConfig;
-      }
-      if (!hasVotesToReveal) {
-        actionConfig.disabled = true;
-        actionConfig.tooltip = "You have no votes to reveal.";
-        return actionConfig;
-      }
-      actionConfig.canReveal = true;
-      actionConfig.disabled = false;
-      actionConfig.onClick = () => revealVotes();
-      return actionConfig;
-    }
-    return actionConfig;
-  }
-
-  async function commitVotes() {
-    if (!actionStatus.canCommit || !signingKey || !votingWriter) return;
-
-    const formattedVotes = await formatVotesToCommit({
-      votes: getActiveVotes(),
-      selectedVotes,
-      roundId,
-      address: delegatorAddress ? delegatorAddress : address,
-      signingKey,
-    });
-    commitVotesMutation(
-      {
-        voting: votingWriter,
-        formattedVotes,
-      },
-      {
-        onSuccess: () => {
-          setSelectedVotes({});
-        },
-      }
-    );
-  }
-
-  function revealVotes() {
-    if (!actionStatus.canReveal || !votingWriter) return;
-
-    revealVotesMutation({
-      voting: votingWriter,
-      votesToReveal: getVotesToReveal(),
-    });
-  }
-
-  function getVotesToReveal() {
-    return getActiveVotes().filter(
-      (vote) =>
-        vote.isCommitted &&
-        !!vote.decryptedVote &&
-        vote.isRevealed === false &&
-        vote.canReveal
-    );
-  }
-
-  function selectVote(value: string, vote: VoteT) {
-    setSelectedVotes((selected) => ({ ...selected, [vote.uniqueKey]: value }));
-  }
-
-  function openVotePanel(vote: VoteT) {
-    openPanel("vote", vote);
-  }
-
-  function determineVotesToShow() {
-    const status = getActivityStatus();
-    switch (status) {
-      case "active":
-        return getActiveVotes();
-      case "upcoming":
-        return getUpcomingVotes();
-      default:
-        return [];
-    }
-  }
-
-  const activityStatus = getActivityStatus();
-
-  // this is the view for past votes when no active or upcoming votes
-  function pastView() {
-    const pastVotes = getPastVotes().slice(0, 5);
-    if (pastVotes.length === 0) return null;
+  const pastVotes = getPastVotes().slice(0, 5);
+  const pastVotesComponent = pastVotes.length ? (
+    <PastVotes votes={pastVotes} />
+  ) : null;
+  const upcomingVotes = getUpcomingVotes();
+  const activeVotes = getActiveVotes();
+  if (hasActiveVotes && hasUpcomingVotes) {
     return (
       <>
-        <Title>Recent past votes:</Title>
-        <VotesTableWrapper
-          style={
-            {
-              "--margin-top": "0px",
-            } as CSSProperties
-          }
-        >
-          <VotesList
-            headings={<VotesTableHeadings activityStatus="past" />}
-            rows={pastVotes.map((vote) => (
-              <VotesListItem
-                vote={vote}
-                phase={phase}
-                selectedVote={undefined}
-                selectVote={() => null}
-                activityStatus="past"
-                moreDetailsAction={() => openPanel("vote", vote)}
-                key={vote.uniqueKey}
-                isFetching={getUserDependentIsFetching()}
-              />
-            ))}
-          />
-        </VotesTableWrapper>
-        <ButtonInnerWrapper>
-          <Button label="See all" href="/past-votes" variant="primary" />
-        </ButtonInnerWrapper>
+        <ActiveVotes votes={activeVotes}>
+          <VoteTimeline />
+        </ActiveVotes>
+        <Divider />
+        <UpcomingVotes votes={upcomingVotes} />
+        <Divider />
+        {pastVotesComponent}
+      </>
+    );
+  } else if (hasActiveVotes) {
+    return (
+      <>
+        <ActiveVotes votes={activeVotes}>
+          <VoteTimeline />
+        </ActiveVotes>
+        <Divider />
+        {pastVotesComponent}
+      </>
+    );
+  } else if (hasUpcomingVotes) {
+    return (
+      <>
+        <UpcomingVotes votes={upcomingVotes}>
+          <VoteTimeline />
+        </UpcomingVotes>
+        <Divider />
+        {pastVotesComponent}
       </>
     );
   }
-  // show this view when votes are active
-  function activeView() {
-    const pv = pastView();
-    return (
-      <>
-        <Title> Active votes: </Title>
-        <VoteTimeline />
-        <VotesTableWrapper>
-          <VotesList
-            headings={<VotesTableHeadings activityStatus={activityStatus} />}
-            rows={votesToShow.map((vote, index) => (
-              <VotesListItem
-                vote={vote}
-                phase={phase}
-                selectedVote={selectedVotes[vote.uniqueKey]}
-                selectVote={(value) => selectVote(value, vote)}
-                activityStatus={activityStatus}
-                moreDetailsAction={() => openVotePanel(vote)}
-                key={vote.uniqueKey}
-                delegationStatus={getDelegationStatus()}
-                isDirty={dirtyInputs[index]}
-                setDirty={(dirty: boolean) => {
-                  setDirtyInput((inputs) => {
-                    inputs[index] = dirty;
-                    return [...inputs];
-                  });
-                }}
-                isFetching={
-                  getUserDependentIsFetching() ||
-                  isCommittingVotes ||
-                  isRevealingVotes
-                }
-              />
-            ))}
-          />
-        </VotesTableWrapper>
-        {determineVotesToShow().length > defaultResultsPerPage && (
-          <PaginationWrapper>
-            <Pagination
-              paginateFor="activeVotesPage"
-              numberOfEntries={determineVotesToShow().length}
-            />
-          </PaginationWrapper>
-        )}
-        {isDirty() ? (
-          <RecommittingVotesMessage>
-            * Changes to committed votes need to be re-committed
-          </RecommittingVotesMessage>
-        ) : null}
-        <ButtonOuterWrapper>
-          {actionStatus.infoText ? (
-            <Tooltip label={actionStatus.infoText.tooltip}>
-              <InfoText>
-                <IconWrapper width={20} height={20}>
-                  <WarningIcon />
-                </IconWrapper>
-                {actionStatus.infoText.label}
-              </InfoText>
-            </Tooltip>
-          ) : null}
-          <ButtonInnerWrapper>
-            {isDirty() ? (
-              <>
-                <Button
-                  variant="secondary"
-                  label="Reset Changes"
-                  onClick={() => setSelectedVotes({})}
-                />
-                <ButtonSpacer />
-              </>
-            ) : undefined}
-            {!actionStatus.hidden ? (
-              actionStatus.tooltip ? (
-                <Tooltip label={actionStatus.tooltip}>
-                  <div>
-                    <Button
-                      variant="primary"
-                      label={actionStatus.label}
-                      onClick={actionStatus.onClick}
-                      disabled={actionStatus.disabled}
-                    />
-                  </div>
-                </Tooltip>
-              ) : (
-                <Button
-                  variant="primary"
-                  label={actionStatus.label}
-                  onClick={actionStatus.onClick}
-                  disabled={actionStatus.disabled}
-                />
-              )
-            ) : null}
-          </ButtonInnerWrapper>
-        </ButtonOuterWrapper>
-        {pv ? (
-          <>
-            <Divider />
-            {pv}
-          </>
-        ) : null}
-      </>
-    );
-  }
-  function upcomingView() {
-    const pv = pastView();
-    return (
-      <>
-        <Title>Upcoming votes:</Title>
-        <VoteTimeline />
-        <VotesTableWrapper>
-          <VotesList
-            headings={<VotesTableHeadings activityStatus={activityStatus} />}
-            rows={votesToShow.map((vote, index) => (
-              <VotesListItem
-                vote={vote}
-                phase={phase}
-                selectedVote={selectedVotes[vote.uniqueKey]}
-                selectVote={(value) => selectVote(value, vote)}
-                activityStatus={activityStatus}
-                moreDetailsAction={() => openVotePanel(vote)}
-                key={vote.uniqueKey}
-                delegationStatus={getDelegationStatus()}
-                isDirty={dirtyInputs[index]}
-                setDirty={(dirty: boolean) => {
-                  setDirtyInput((inputs) => {
-                    inputs[index] = dirty;
-                    return [...inputs];
-                  });
-                }}
-                isFetching={
-                  getUserDependentIsFetching() ||
-                  isCommittingVotes ||
-                  isRevealingVotes
-                }
-              />
-            ))}
-          />
-        </VotesTableWrapper>
-        {determineVotesToShow().length > defaultResultsPerPage && (
-          <PaginationWrapper>
-            <Pagination
-              paginateFor="upcomingVotesPage"
-              numberOfEntries={determineVotesToShow().length}
-            />
-          </PaginationWrapper>
-        )}
-        {pv ? (
-          <>
-            <Divider />
-            {pv}
-          </>
-        ) : null}
-      </>
-    );
-  }
-  if (activityStatus === "active") {
-    return activeView();
-  } else if (activityStatus === "upcoming") {
-    return upcomingView();
-  } else {
-    return pastView();
-  }
+  return <PastVotes votes={pastVotes} />;
 }
-
-const VotesTableWrapper = styled.div`
-  margin-top: var(--margin-top, 35px);
-`;
-
-const Title = styled.h1`
-  font: var(--header-md);
-  margin-bottom: 20px;
-`;
-
-const ButtonOuterWrapper = styled.div`
-  margin-top: 30px;
-`;
-
-const ButtonInnerWrapper = styled.div`
-  display: flex;
-  justify-content: end;
-  gap: 15px;
-
-  button {
-    text-transform: capitalize;
-  }
-`;
-
-const InfoText = styled.p`
-  display: flex;
-  gap: 15px;
-  width: fit-content;
-  margin-left: auto;
-  margin-bottom: 15px;
-  font: var(--text-md);
-`;
-
-const WarningIcon = styled(Warning)`
-  path {
-    stroke: var(--black);
-    fill: transparent;
-  }
-`;
-
-const PaginationWrapper = styled.div`
-  margin-block: 30px;
-`;
-
-const ButtonSpacer = styled.div`
-  width: 10px;
-`;
-
 const Divider = styled.div`
   height: 1px;
   margin-top: 45px;
   margin-bottom: 45px;
   background: var(--black-opacity-25);
-`;
-
-const RecommittingVotesMessage = styled.p`
-  width: fit-content;
-  font: var(--text-sm);
-  margin-left: auto;
-  margin-top: 10px;
 `;

--- a/components/Votes/index.ts
+++ b/components/Votes/index.ts
@@ -1,1 +1,4 @@
 export { Votes } from "./Votes";
+export { ActiveVotes } from "./ActiveVotes";
+export { PastVotes } from "./PastVotes";
+export { UpcomingVotes } from "./UpcomingVotes";

--- a/contexts/PaginationContext.tsx
+++ b/contexts/PaginationContext.tsx
@@ -24,6 +24,7 @@ export const defaultPageStates = {
   activeVotesPage: defaultPageState,
   upcomingVotesPage: defaultPageState,
   pastVotesPage: defaultPageState,
+  pastVotesComponent: defaultPageState,
   voteHistoryPage: defaultPageState,
 };
 
@@ -49,6 +50,9 @@ export function PaginationProvider({ children }: { children: ReactNode }) {
     ...defaultPageState,
   });
   const [pastVotesPage, setPastVotesPage] = useState({ ...defaultPageState });
+  const [pastVotesComponent, setPastVotesComponent] = useState({
+    ...defaultPageState,
+  });
   const [voteHistoryPage, setVoteHistoryPage] = useState({
     ...defaultPageState,
   });
@@ -56,6 +60,7 @@ export function PaginationProvider({ children }: { children: ReactNode }) {
     activeVotesPage,
     upcomingVotesPage,
     pastVotesPage,
+    pastVotesComponent,
     voteHistoryPage,
   };
 
@@ -63,6 +68,7 @@ export function PaginationProvider({ children }: { children: ReactNode }) {
     activeVotesPage: setActiveVotesPage,
     upcomingVotesPage: setUpcomingVotesPage,
     pastVotesPage: setPastVotesPage,
+    pastVotesComponent: setPastVotesComponent,
     voteHistoryPage: setVoteHistoryPage,
   };
 

--- a/types/ui.ts
+++ b/types/ui.ts
@@ -26,6 +26,7 @@ export type PaginateForT =
   | "activeVotesPage"
   | "upcomingVotesPage"
   | "pastVotesPage"
+  | "pastVotesComponent"
   | "voteHistoryPage";
 
 export type PageStateT = {


### PR DESCRIPTION
## motivation
we currently do not show an upcoming vote if there is an active vote

## changes
this simple feature was very risky to implement with current code base. this needed to be refactored to isolate past, upcoming, and active components, primarily to avoid breaking the delicate logic during an active vote.  the state between these components were previously shared with assumptions that we would only ever have active votes or upcoming votes independently.

This pr creates a new component for each table, and in the higher level page, composes them based on 4 different potential states: no active or upcoming votes, only an active vote, only upcoming vote, active and upcoming vote and no votes (active,upcoming,past). 

Things should look the same in the base case (active votes, with nothing upcoming, or just a single upcoming vote):
![active-vote](https://user-images.githubusercontent.com/4429761/225691546-b3682c12-3d94-4124-84a6-031c510f5612.PNG)
![revealed](https://user-images.githubusercontent.com/4429761/225691558-cdce403d-a927-4fed-b345-0b41cae8ac3c.PNG)
![image](https://user-images.githubusercontent.com/4429761/225693514-f350a7a1-6a84-4a20-9aa8-174dff3c47fb.png)

now active + upcoming 
![image](https://user-images.githubusercontent.com/4429761/225696379-304c64cc-d234-4060-9fb5-576d941791bc.png)
