### PR TITLE
fix: merge revealed queries with existing cache

### DIFF
--- a/hooks/queries/votes/useRevealedVotes.ts
+++ b/hooks/queries/votes/useRevealedVotes.ts
@@ -1,4 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { VoteExistsByKeyT } from "types";
 import { revealedVotesKey } from "constant";
 import {
   useAccountDetails,
@@ -10,6 +11,7 @@ import {
 import { getRevealedVotes } from "web3";
 
 export function useRevealedVotes(addressOverride?: string) {
+  const queryClient = useQueryClient();
   const { voting } = useContractsContext();
   const { address: myAddress } = useAccountDetails();
   const { isWrongChain } = useWalletContext();
@@ -19,7 +21,25 @@ export function useRevealedVotes(addressOverride?: string) {
 
   const queryResult = useQuery(
     [revealedVotesKey, address, roundId],
-    () => getRevealedVotes(voting, address, roundId),
+    // we update cache client side when we know we successfully revealed, so we want to merge data in the cache,
+    // and not override, in case the web3 call returns empty as we use a different provider to query vs write.
+    async () => {
+      const result = await getRevealedVotes(voting, address, roundId);
+      // this is really ugly, but I cant figure out a better way to merge cache and stil return the data
+      return new Promise<VoteExistsByKeyT>((res) =>
+        queryClient.setQueryData<VoteExistsByKeyT>(
+          [revealedVotesKey, address, roundId],
+          (oldRevealedVotes) => {
+            const merged = {
+              ...oldRevealedVotes,
+              ...result,
+            };
+            res(merged);
+            return merged;
+          }
+        )
+      );
+    },
     {
       enabled: !!address && !isWrongChain,
       initialData: {},

--- a/web3/queries/votes/getRevealedVotes.ts
+++ b/web3/queries/votes/getRevealedVotes.ts
@@ -6,7 +6,7 @@ export async function getRevealedVotes(
   votingContract: VotingV2Ethers,
   address: string,
   roundId: number
-) {
+): Promise<VoteExistsByKeyT> {
   const filter = votingContract.filters.VoteRevealed(
     address,
     null,


### PR DESCRIPTION
## motivation
theres an intermittent problem people are reporting, where they reveal but the app doesnt recognize they reveal.

## changes
unfortunately not able to reliably reproduce this problem, but it may be due to out of sync providers. when we write the reveal, we use the wallets signer, but when we read if we have revealed we use an infura provider, its possible these are sometimes out of sync.  this will cause problems with react query overwriting an empty revealed query after we have updated that cache locally when we know our tx revealed.  this change tries to merge the revealed table when a query to web3 is done to not blow away any locally modified values. 