### PR TITLE
improve: use json file for past votes v1

### DIFF
--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -1,49 +1,14 @@
-import { config } from "helpers/config";
+import { utils } from "ethers";
 import request, { gql } from "graphql-request";
 import { formatBytes32String, makePriceRequestsByKey } from "helpers";
+import { config } from "helpers/config";
 import { PastVotesQuery, RevealedVotesByAddress } from "types";
-import { utils } from "ethers";
 
-const { graphEndpoint, graphEndpointV1 } = config;
+const { graphEndpoint } = config;
 
 export async function getPastVotesV1() {
-  const endpoint = graphEndpointV1;
-  if (!endpoint) throw new Error("V1 subgraph is disabled");
-
-  const pastVotesQuery = gql`
-    {
-      priceRequests(
-        where: { isResolved: true }
-        orderBy: time
-        orderDirection: desc
-      ) {
-        identifier {
-          id
-        }
-        price
-        time
-        ancillaryData
-        latestRound {
-          totalVotesRevealed
-          groups {
-            price
-            totalVoteAmount
-          }
-        }
-        committedVotes {
-          id
-        }
-        revealedVotes {
-          id
-          voter {
-            address
-          }
-          price
-        }
-      }
-    }
-  `;
-  const result = await request<PastVotesQuery>(endpoint, pastVotesQuery);
+  const result = (await import("data/pastVotesV1.json"))
+    .default as PastVotesQuery;
   return result?.priceRequests?.map(
     ({
       identifier: { id },


### PR DESCRIPTION
### Motivation

The v1 past votes subgraph is often quite slow, and this would be made much worse by increasing the number of entries requested from the default 100 to the actual 309.

My question is this: why are we even querying this from the graph every time in the first place? We know the results for v1 will never change. At first I thought perhaps we should put this logic behind a serverless function and cache the result, but why even make it that complicated?

In this solution, I've simply downloaded the result of this query and saved it as a json file. I've replaced the fetching logic with code that asynchronously downloads this json file with a dynamic import. This way our processing logic does not need to be affected, i.e. if we decide to add or remove parsing logic in the future we can do so without fiddling with this file.

this json file now loads almost instantly, so the v2 query for past votes is now the limiting factor for how quickly past votes load, and the v2 query is quite fast. Also this file is treated as a code-split module, which means browsers will cache it and not request it every time like we are doing now with the graph query.

In the future we can use a similar solution for v2 when there are enough votes to warrant it — we can save the oldest votes which aren't going to change in a file, and get the still-in-flux ones from the graph as usual.

### Changes

* Add `pastVotesV1.json` file
* Use result of loading that file as the result for the `getPastVotesV1` query