### PR TITLE
feat: add request augmentation for OOv3

### DIFF
--- a/types/voting.ts
+++ b/types/voting.ts
@@ -240,6 +240,18 @@ export const AugmentedVoteDataResponseT = ss.object({
   originatingChainTxHash: ss.optional(ss.string()),
   originatingChainId: ss.optional(ss.number()),
   originatingOracleType: ss.optional(ss.string()),
+  optimisticOracleV3Data: ss.optional(
+    ss.object({
+      assertionId: ss.optional(ss.string()),
+      domainId: ss.optional(ss.string()),
+      claim: ss.optional(ss.string()),
+      asserter: ss.optional(ss.string()),
+      callbackRecipient: ss.optional(ss.string()),
+      escalationManager: ss.optional(ss.string()),
+      expirationTime: ss.optional(ss.number()),
+      caller: ss.optional(ss.string()),
+    })
+  ),
 });
 export type AugmentedVoteDataResponseT = ss.Infer<
   typeof AugmentedVoteDataResponseT


### PR DESCRIPTION
This PR adds request augmentation for OOv3. Below is a sample of the augmentation made for a v3 request:
```
{
		"uniqueKey": "ASSERT_TRUTH-1681309815-0x617373657274696f6e49643a636134366539353932663162366364383865363330613566383136333162626138303635623966326535353232336664626331366161643336643565306434332c6f6f41737365727465723a396138663932613833306135636238396133383136653364323637636237373931633136623034642c6368696c64436861696e49643a3130",
		"time": 1681309815,
		"identifier": "0x4153534552545f54525554480000000000000000000000000000000000000000",
		"l1RequestTxHash": "0xb7ccbb7d540fab2ba3d710d19c9f73c3335ec1f649115f04de7f9ffa73de6f15",
		"ooRequestUrl": "https://oracle.uma.xyz/request?transactionHash=0xccc611ad66f69af8fbccd30ddf5a61f060cbf5d67faaeb98527951d2b5d24059&chainId=10&oracleType=OptimisticV3",
		"originatingChainTxHash": "0xccc611ad66f69af8fbccd30ddf5a61f060cbf5d67faaeb98527951d2b5d24059",
		"originatingChainId": 10,
		"originatingOracleType": "OptimisticOracleV3",
		"optimisticOracleV3Data": {
			"domainId": "0x0000000000000000000000000000000000000000000000000000000000000000",
			"claim": "0x312b313d33",
			"asserter": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D",
			"callbackRecipient": "0x0000000000000000000000000000000000000000",
			"escalationManager": "0x0000000000000000000000000000000000000000",
			"expirationTime": 1681317015,
			"caller": "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D"
		}
	},
```
Critically, see the data for `optimisticOracleV3Data`. this is the new datastructure added to enable this data rendering in the UI.

I think we'll need to update this once the new oracle UI is released as the ULR produced here at this point is bad.