### PR TITLE
fix: remove svg global styling affecting qr codes

### DIFF
--- a/components/GlobalStyle/GlobalStyle.ts
+++ b/components/GlobalStyle/GlobalStyle.ts
@@ -119,8 +119,6 @@ body {
   /* Remove fill and set stroke color to the inherited font color */
   stroke: currentColor;
   fill: none;
-  /* Rounded stroke */
-  stroke-linecap: round;
   stroke-linejoin: round;
 }
 


### PR DESCRIPTION
## motivation
qr codes are not being rendered correctly

## changes
there was a global style causing edges to be rounded for svgs, this was removed