### PR TITLE
fix: set rewards to 0 on claim and withdraw

### DIFF
--- a/hooks/mutations/rewards/useWithdrawAndRestake.ts
+++ b/hooks/mutations/rewards/useWithdrawAndRestake.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   stakedBalanceKey,
-  outstandingRewardsKey,
+  stakerDetailsKey,
   rewardsCalculationInputsKey,
 } from "constant";
 import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError, useStakingContext } from "hooks";
-import { ErrorOriginT, RewardCalculationT } from "types";
+import { ErrorOriginT, RewardCalculationT, StakerDetailsT } from "types";
 import { withdrawAndRestake } from "web3";
 
 export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
@@ -24,10 +24,14 @@ export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
         [stakedBalanceKey, address],
         (oldStakedBalance) => {
           // change outstanding rewards from contract to 0
-          queryClient.setQueryData<BigNumber>(
-            [outstandingRewardsKey, address],
-            () => {
-              return BigNumber.from(0);
+          queryClient.setQueryData<StakerDetailsT>(
+            [stakerDetailsKey, address],
+            (oldDetails) => {
+              if (oldDetails === undefined) return oldDetails;
+              return {
+                ...oldDetails,
+                outstandingRewards: BigNumber.from(0),
+              };
             }
           );
 
@@ -51,7 +55,6 @@ export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
             return;
 
           const newStakedBalance = oldStakedBalance.add(outstandingRewards);
-
           return newStakedBalance;
         }
       );

--- a/hooks/mutations/rewards/useWithdrawRewards.ts
+++ b/hooks/mutations/rewards/useWithdrawRewards.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   unstakedBalanceKey,
-  outstandingRewardsKey,
+  stakerDetailsKey,
   rewardsCalculationInputsKey,
 } from "constant";
 import { BigNumber } from "ethers";
 import { useAccountDetails, useHandleError, useStakingContext } from "hooks";
-import { ErrorOriginT, RewardCalculationT } from "types";
+import { ErrorOriginT, RewardCalculationT, StakerDetailsT } from "types";
 import { withdrawRewards } from "web3";
 
 export function useWithdrawRewards(errorOrigin?: ErrorOriginT) {
@@ -24,9 +24,15 @@ export function useWithdrawRewards(errorOrigin?: ErrorOriginT) {
         [unstakedBalanceKey, address],
         (oldUnstakedBalance) => {
           // change outstanding rewards from contract to 0
-          queryClient.setQueryData<BigNumber>(
-            [outstandingRewardsKey, address],
-            () => BigNumber.from(0)
+          queryClient.setQueryData<StakerDetailsT>(
+            [stakerDetailsKey, address],
+            (oldDetails) => {
+              if (oldDetails === undefined) return oldDetails;
+              return {
+                ...oldDetails,
+                outstandingRewards: BigNumber.from(0),
+              };
+            }
           );
           // change our update time to calculate the correct new rewards based on amount staked
           // this happens every minute on an interval

--- a/types/staking.ts
+++ b/types/staking.ts
@@ -4,6 +4,8 @@ export type StakerDetailsT = {
   pendingUnstake: BigNumber;
   canUnstakeTime: Date | undefined;
   delegate: string;
+  rewardsPaidPerToken: BigNumber;
+  outstandingRewards: BigNumber;
 };
 
 export type V1RewardsT = {


### PR DESCRIPTION
## motivation
it seems like sometimes especially on mobile, when we claim and stake the amount to claim doesnt zero out as expected

## changes
difficult to repro on desktop, but it looks like we were trying to reset outstanding rewards on a defunct key, so updated the reset to the correct rq key. 