### PR TITLE
feat: remove error clearing from rq queries

### DIFF
--- a/hooks/queries/rewards/useIsOldDesignatedVotingAccount.ts
+++ b/hooks/queries/rewards/useIsOldDesignatedVotingAccount.ts
@@ -6,7 +6,7 @@ import { getIsOldDesignatedVotingAccount } from "web3";
 export function useIsOldDesignatedVotingAccount() {
   const { address } = useAccountDetails();
   const { isWrongChain } = useWalletContext();
-  const { onError, clearErrors } = useHandleError({ isDataFetching: true });
+  const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery({
     queryKey: [isOldDesignatedVotingAccountKey, address],
@@ -18,7 +18,6 @@ export function useIsOldDesignatedVotingAccount() {
     },
     enabled: !!address && !isWrongChain,
     onError,
-    onSuccess: clearErrors,
   });
 
   return queryResult;

--- a/hooks/queries/rewards/useV1Rewards.ts
+++ b/hooks/queries/rewards/useV1Rewards.ts
@@ -10,7 +10,7 @@ export function useV1Rewards() {
   const { address } = useAccountDetails();
   const { isWrongChain } = useWalletContext();
   const [{ connectedChain }] = useSetChain();
-  const { onError, clearErrors } = useHandleError({ isDataFetching: true });
+  const { onError } = useHandleError({ isDataFetching: true });
 
   const queryResult = useQuery({
     queryKey: [v1RewardsKey, address, connectedChain],
@@ -19,7 +19,6 @@ export function useV1Rewards() {
     initialData: { multicallPayload: [], totalRewards: BigNumber.from(0) },
     enabled: !!address && !!connectedChain && !isWrongChain,
     onError,
-    onSuccess: clearErrors,
   });
 
   return queryResult;

--- a/hooks/queries/staking/useDelegatorStakedBalance.ts
+++ b/hooks/queries/staking/useDelegatorStakedBalance.ts
@@ -11,7 +11,7 @@ export function useDelegatorStakedBalance() {
   const { voting } = useContractsContext();
   const { data: address } = useVoterFromDelegate();
   const { isWrongChain } = useWalletContext();
-  const { onError, clearErrors } = useHandleError({ isDataFetching: true });
+  const { onError } = useHandleError({ isDataFetching: true });
   const queryResult = useQuery({
     queryKey: [stakedBalanceKey, address],
     queryFn: () =>
@@ -19,7 +19,6 @@ export function useDelegatorStakedBalance() {
     enabled: !!address && !isWrongChain,
     initialData: BigNumber.from(0),
     onError,
-    onSuccess: clearErrors,
   });
 
   return queryResult;

--- a/hooks/queries/staking/useStakedBalance.ts
+++ b/hooks/queries/staking/useStakedBalance.ts
@@ -13,7 +13,7 @@ export function useStakedBalance(addressOverride?: string) {
   const { voting } = useContractsContext();
   const { address: defaultAddress } = useAccountDetails();
   const { isWrongChain } = useWalletContext();
-  const { onError, clearErrors } = useHandleError({ isDataFetching: true });
+  const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
 
   const queryResult = useQuery({
@@ -22,7 +22,6 @@ export function useStakedBalance(addressOverride?: string) {
     enabled: !!address && !isWrongChain,
     initialData,
     onError,
-    onSuccess: clearErrors,
   });
 
   return queryResult;

--- a/hooks/queries/staking/useUnstakeCoolDown.ts
+++ b/hooks/queries/staking/useUnstakeCoolDown.ts
@@ -6,14 +6,13 @@ import { getUnstakeCoolDown } from "web3";
 
 export function useUnstakeCoolDown() {
   const { voting } = useContractsContext();
-  const { onError, clearErrors } = useHandleError({ isDataFetching: true });
+  const { onError } = useHandleError({ isDataFetching: true });
   // only need to fetch this one time
   const queryResult = useQuery({
     queryKey: [unstakeCoolDownKey],
     queryFn: () => getUnstakeCoolDown(voting),
     initialData: BigNumber.from(0),
     onError,
-    onSuccess: clearErrors,
   });
 
   return queryResult;


### PR DESCRIPTION
## motivation
errors are flashing, unable to be read when on main page, such as cancelling a tx

## changes
this removes the clear errors from react query queries, these tend to run frequently, particularly when re-focusing on page.  this means error banner sticks around until user manually closes it. 

future work - may need to have some kind of global error manager to clear errors after some seconds