### PR TITLE
fix: remove non deterministic values from mocks

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -10,11 +10,11 @@ import {
   PanelProvider,
   StakingProvider,
   UserProvider,
-  VotesProvider,
   VoteTimingProvider,
+  VotesProvider,
   WalletProvider,
 } from "../contexts";
-import { mockDate } from "../stories/mocks/misc";
+import { date } from "../stories/mocks/misc";
 import "../styles/fonts.css";
 
 export const parameters = {
@@ -25,7 +25,7 @@ export const parameters = {
       date: /Date$/,
     },
   },
-  date: mockDate,
+  date,
 };
 
 const queryClient = new QueryClient();

--- a/stories/BaseComponents/info/CooldownTimer.stories.tsx
+++ b/stories/BaseComponents/info/CooldownTimer.stories.tsx
@@ -1,10 +1,11 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import { CooldownTimer } from "components";
 import { red500 } from "constant";
 import add from "date-fns/add";
 import { BigNumber } from "ethers";
+import { date } from "stories/mocks/misc";
 
-export default {
+const meta: Meta = {
   title: "Base components/Info/Cooldown Timer",
   component: CooldownTimer,
   decorators: [
@@ -23,24 +24,32 @@ export default {
       </div>
     ),
   ],
-} as ComponentMeta<typeof CooldownTimer>;
-
-const Template: ComponentStory<typeof CooldownTimer> = (args) => (
-  <CooldownTimer {...args} />
-);
-
-export const InCooldown = Template.bind({});
-InCooldown.args = {
-  cooldownEnds: add(new Date(), { hours: 1, minutes: 10 }),
-  pendingUnstake: BigNumber.from(100),
-  isReadyToUnstake: false,
-  onExecuteUnstake: () => alert("Yay rewards!"),
 };
 
-export const ReadyToUnstake = Template.bind({});
-ReadyToUnstake.args = {
-  cooldownEnds: null,
-  pendingUnstake: BigNumber.from(100),
-  isReadyToUnstake: true,
-  onExecuteUnstake: () => alert("Yay rewards!"),
+export default meta;
+
+type Story = StoryObj<typeof CooldownTimer>;
+
+const Template: Story = {
+  render: (args) => <CooldownTimer {...args} />,
+};
+
+export const InCooldown: Story = {
+  ...Template,
+  args: {
+    cooldownEnds: add(date, { hours: 1, minutes: 10 }),
+    pendingUnstake: BigNumber.from(100),
+    isReadyToUnstake: false,
+    onExecuteUnstake: () => alert("Yay rewards!"),
+  },
+};
+
+export const ReadyToUnstake: Story = {
+  ...Template,
+  args: {
+    cooldownEnds: null,
+    pendingUnstake: BigNumber.from(100),
+    isReadyToUnstake: true,
+    onExecuteUnstake: () => alert("Yay rewards!"),
+  },
 };

--- a/stories/BaseComponents/navigation/Panel.stories.tsx
+++ b/stories/BaseComponents/navigation/Panel.stories.tsx
@@ -1,11 +1,6 @@
 import { Decorator, Meta, StoryObj } from "@storybook/react";
 import { Button, Panel } from "components";
 import {
-  defaultDelegationContextState,
-  defaultErrorContextState,
-  defaultPanelContextState,
-  defaultUserContextState,
-  defaultVotesContextState,
   DelegationContext,
   DelegationContextState,
   ErrorContext,
@@ -16,6 +11,11 @@ import {
   UserContextState,
   VotesContext,
   VotesContextState,
+  defaultDelegationContextState,
+  defaultErrorContextState,
+  defaultPanelContextState,
+  defaultUserContextState,
+  defaultVotesContextState,
 } from "contexts";
 import { BigNumber } from "ethers";
 import { bigNumberFromFloatString, zeroAddress } from "helpers";
@@ -373,13 +373,9 @@ export const HistoryPanel: Story = {
   ...Template,
   args: {
     panelType: "history",
-    apr: bigNumberFromFloatString(`${Math.random() * 100}`),
-    cumulativeCalculatedSlash: bigNumberFromFloatString(
-      `${Math.random() * 100}`
-    ),
-    cumulativeCalculatedSlashPercentage: bigNumberFromFloatString(
-      `${Math.random() > 0.5 ? "-" : ""}${Math.random() * 100}`
-    ),
+    apr: bigNumberFromFloatString(`32`),
+    cumulativeCalculatedSlash: bigNumberFromFloatString(`23`),
+    cumulativeCalculatedSlashPercentage: bigNumberFromFloatString("100"),
     votes: makeMockVotesWithHistory(),
   },
   decorators: [userDecorator, votesDecorator],

--- a/stories/Pages/PastVotesPage.stories.tsx
+++ b/stories/Pages/PastVotesPage.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, Story } from "@storybook/react";
-import { defaultVotesContextState, VotesContext } from "contexts";
+import { VotesContext, defaultVotesContextState } from "contexts";
 import { BigNumber } from "ethers";
+import { uniqueId } from "lodash";
 import PastVotesPage from "pages/past-votes";
 import { VoteT } from "types";
 
@@ -17,17 +18,13 @@ const mockPastVotes = Array.from({ length: 200 }).map((_, i) => ({
   decodedAncillaryData:
     'q:"Had the following insured event occurred as of request timestamp: Tom ate Jerry?",ooRequester:0438e738cb7b1eb98b8cb9f26d6a11d59506b9dd',
   correctVote: 0,
-  uniqueKey:
-    "YES_OR_NO_QUERY-1666025124-0x713a224861642074686520666f6c6c6f77696e6720696e7375726564206576656e74206f63637572726564206173206f6620726571756573742074696d657374616d703a20546f6d20617465204a657272793f222c6f6f5265717565737465723a30343338653733386362376231656239386238636239663236643661313164353935303662396464" +
-    Math.random().toString(),
+  uniqueKey: uniqueId(),
   isCommitted: false,
   isRevealed: false,
   transactionHash:
     "0x2a37d6072ef32814755e67e40b118d5c3f8d389fb1d9e80f0a75037aa042ea39",
   voteHistory: {
-    uniqueKey:
-      "YES_OR_NO_QUERY-1666025124-0x713a224861642074686520666f6c6c6f77696e6720696e7375726564206576656e74206f63637572726564206173206f6620726571756573742074696d657374616d703a20546f6d20617465204a657272793f222c6f6f5265717565737465723a30343338653733386362376231656239386238636239663236643661313164353935303662396464" +
-      Math.random().toString(),
+    uniqueKey: uniqueId(),
     voted: false,
     correctness: null,
     slashAmount: BigNumber.from("-0x56bc75e2d631000000"),

--- a/stories/Pages/VotePage/VotePage.stories.tsx
+++ b/stories/Pages/VotePage/VotePage.stories.tsx
@@ -1,11 +1,15 @@
 import { Meta, StoryObj } from "@storybook/react";
 import {
-  defaultVotesContextState,
-  defaultVoteTimingContextState,
+  VoteTimingContext,
   VotesContext,
   VotesContextState,
-  VoteTimingContext,
+  defaultVoteTimingContextState,
+  defaultVotesContextState,
 } from "contexts";
+import {
+  computeMillisecondsUntilPhaseEnds,
+  computePhaseEndTimeMilliseconds,
+} from "helpers";
 import VotePage from "pages";
 import {
   makeMockVotes,
@@ -40,6 +44,9 @@ const Template: Story = {
   render: function Wrapper(args) {
     const mockVoteTimingContextState = {
       ...defaultVoteTimingContextState,
+      phaseEndTimeMilliseconds: computePhaseEndTimeMilliseconds(),
+      phaseEndTimeAsDate: new Date(computePhaseEndTimeMilliseconds()),
+      millisecondsUntilPhaseEnds: computeMillisecondsUntilPhaseEnds(),
       phase: args.phase ?? "commit",
       roundId: 1,
     };

--- a/stories/mocks/misc.ts
+++ b/stories/mocks/misc.ts
@@ -1,1 +1,1 @@
-export const mockDate = new Date("2023-03-28 12:00:00");
+export const date = new Date("2023-03-28 12:00:00");

--- a/stories/mocks/votes.ts
+++ b/stories/mocks/votes.ts
@@ -7,13 +7,14 @@ import {
   maybeMakePolymarketOptions,
 } from "helpers";
 import { VoteT } from "types";
+import { date } from "./misc";
 
 export const defaultMockVote = (number = 1): VoteT => {
   const decodedIdentifier = "MOCK_IDENTIFIER";
   const decodedAncillaryData = `MOCK_ANCILLARY_DATA_${number}`;
   const identifier = formatBytes32String(decodedIdentifier);
   const ancillaryData = formatBytes32String(decodedAncillaryData);
-  const timeAsDate = sub(new Date(), { days: 1 });
+  const timeAsDate = sub(date, { days: 1 });
   const timeMilliseconds = timeAsDate.getTime();
   const time = Math.round(timeAsDate.getTime() / 1000);
   const uniqueKey = makeUniqueKeyForVote(

--- a/stories/mocks/votes.ts
+++ b/stories/mocks/votes.ts
@@ -8,9 +8,7 @@ import {
 } from "helpers";
 import { VoteT } from "types";
 
-export const defaultMockVote = (
-  number = Math.floor(Math.random() * 1000)
-): VoteT => {
+export const defaultMockVote = (number = 1): VoteT => {
   const decodedIdentifier = "MOCK_IDENTIFIER";
   const decodedAncillaryData = `MOCK_ANCILLARY_DATA_${number}`;
   const identifier = formatBytes32String(decodedIdentifier);
@@ -158,15 +156,11 @@ function makeMockVoteHistory(args?: VoteHistoryMockArgsT) {
   return {
     ...mockVoteHistory,
     ...args,
-    uniqueKey: `${Math.random()}`,
-    voted: args?.voted ?? Math.random() > 0.5,
-    correctness: args?.correctness ?? Math.random() > 0.5,
-    staking: args?.staking ?? Math.random() > 0.5,
-    slashAmount:
-      args?.slashAmount ??
-      bigNumberFromFloatString(
-        `${Math.random() > 0.5 ? "-" : ""}${Math.random() * 100}`
-      ),
+    uniqueKey: `${JSON.stringify(args)}`,
+    voted: args?.voted ?? true,
+    correctness: args?.correctness ?? true,
+    staking: args?.staking ?? true,
+    slashAmount: args?.slashAmount ?? bigNumberFromFloatString("100"),
   };
 }
 


### PR DESCRIPTION
We have some story code that uses `Math.random` and `new Date`. These are different on every push to chromatic, creating false positives in the visual regression tests.

Remove these usages in favor of deterministic values.