### PR TITLE
improve: allow howitworks values to show as they load

### DIFF
--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -93,7 +93,7 @@ export function HowItWorks() {
                 "You are staking"
               )}{" "}
               <Strong>
-                {isLoading() ? (
+                {stakedBalance === undefined ? (
                   <LoadingSkeleton width={50} />
                 ) : (
                   formatNumberForDisplay(stakedBalance)
@@ -126,7 +126,8 @@ export function HowItWorks() {
             <>
               You have voted in{" "}
               <Strong>
-                {isLoading() ? (
+                {countCorrectVotes === undefined ||
+                countWrongVotes === undefined ? (
                   <LoadingSkeleton width={50} />
                 ) : (
                   formatNumberForDisplay(getTotalVotes(), { decimals: 0 })
@@ -136,7 +137,7 @@ export function HowItWorks() {
               {getTotalVotes()?.eq(BigNumber.from(parseEther("1"))) ? "" : "s"},
               and are earning{" "}
               <Strong>
-                {isLoading() ? (
+                {apr === undefined ? (
                   <LoadingSkeleton width={50} />
                 ) : (
                   formatNumberForDisplay(apr, { decimals: 1 })
@@ -161,7 +162,7 @@ export function HowItWorks() {
             <>
               Your unclaimed UMA rewards:{" "}
               <Strong>
-                {isLoading() ? (
+                {outstandingRewards === undefined ? (
                   <LoadingSkeleton width={50} />
                 ) : (
                   formatNumberForDisplay(outstandingRewards, { decimals: 3 })


### PR DESCRIPTION
## motivation
how it works values can take a long time to load

## changes
we we only displaying any values once all values were available, this would block showing values which may have loaded already, but were blocked from showing until everything loaded.  this changes it so that the values are displayed only when their direct depenencies are loaded. 