### PR TITLE
feat: add vote stats during reveal

### DIFF
--- a/components/VoteList/VoteListItem.tsx
+++ b/components/VoteList/VoteListItem.tsx
@@ -195,7 +195,7 @@ export function VoteListItem({
   }
 
   function getCorrectVote() {
-    if (correctVote === undefined) return;
+    if (correctVote === undefined || correctVote === null) return;
     const formatted = formatVoteStringWithPrecision(
       correctVote,
       decodedIdentifier

--- a/constant/query/queryKeys.ts
+++ b/constant/query/queryKeys.ts
@@ -40,3 +40,4 @@ export const delegateToStakerKey = "delegateToStakerKey";
 export const ignoredRequestToBeDelegateAddressesKey =
   "ignoredRequestToBeDelegateAddressesKey";
 export const committedVotesForDelegatorKey = "committedVotesForDelegatorKey";
+export const activeVoteResultsKey = "activeVoteResultsKey";

--- a/graph/index.ts
+++ b/graph/index.ts
@@ -1,3 +1,4 @@
 export { getPastVotes, getPastVotesAllVersions } from "./queries/getPastVotes";
 export { getUserVotingAndStakingDetails as getUserData } from "./queries/getUserVotingAndStakingDetails";
 export { getGlobals } from "./queries/getGlobals";
+export { getActiveVoteResults } from "./queries/getActiveVoteResults";

--- a/graph/queries/getActiveVoteResults.ts
+++ b/graph/queries/getActiveVoteResults.ts
@@ -1,0 +1,103 @@
+import { config } from "helpers/config";
+import request, { gql } from "graphql-request";
+import { formatBytes32String, makePriceRequestsByKey } from "helpers";
+import {
+  PastVotesQuery,
+  RevealedVotesByAddress,
+  VoteParticipationT,
+  PriceRequestT,
+  VoteResultsT,
+  UniqueKeyT,
+} from "types";
+import { utils } from "ethers";
+
+const { graphEndpoint } = config;
+
+export async function getActiveVoteResults(): Promise<
+  Record<UniqueKeyT, PriceRequestT & VoteParticipationT & VoteResultsT>
+> {
+  const endpoint = graphEndpoint;
+  if (!endpoint) throw new Error("V2 subgraph is disabled");
+  const pastVotesQuery = gql`
+    {
+      priceRequests(
+        where: { isResolved: false }
+        orderBy: resolvedPriceRequestIndex
+        orderDirection: desc
+      ) {
+        identifier {
+          id
+        }
+        price
+        time
+        ancillaryData
+        resolvedPriceRequestIndex
+        isGovernance
+        rollCount
+        latestRound {
+          totalVotesRevealed
+          groups {
+            price
+            totalVoteAmount
+          }
+        }
+        committedVotes {
+          id
+        }
+        revealedVotes {
+          id
+          voter {
+            address
+          }
+          price
+        }
+      }
+    }
+  `;
+  const result = await request<PastVotesQuery>(endpoint, pastVotesQuery);
+  return makePriceRequestsByKey(
+    result?.priceRequests?.map(
+      ({
+        identifier: { id },
+        time,
+        price,
+        ancillaryData,
+        resolvedPriceRequestIndex,
+        latestRound,
+        committedVotes,
+        revealedVotes,
+      }) => {
+        const identifier = formatBytes32String(id);
+        const correctVote = price;
+        const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
+        const participation = {
+          uniqueCommitAddresses: committedVotes.length,
+          uniqueRevealAddresses: revealedVotes.length,
+          totalTokensVotedWith,
+        };
+        const results = latestRound.groups.map(
+          ({ price, totalVoteAmount }) => ({
+            vote: price,
+            tokensVotedWith: Number(totalVoteAmount),
+          })
+        );
+        const init: RevealedVotesByAddress = {};
+        const revealedVoteByAddress = revealedVotes.reduce((result, vote) => {
+          result[utils.getAddress(vote.voter.address)] = vote.price;
+          return result;
+        }, init);
+        return {
+          identifier,
+          time: Number(time),
+          correctVote,
+          ancillaryData,
+          resolvedPriceRequestIndex,
+          isV1: false,
+          participation,
+          results,
+          revealedVoteByAddress,
+        };
+      }
+    )
+  );
+}

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -68,3 +68,4 @@ export { usePastVotes } from "./queries/votes/usePastVotes";
 export { useRevealedVotes } from "./queries/votes/useRevealedVotes";
 export { useUpcomingVotes } from "./queries/votes/useUpcomingVotes";
 export { useVoteDiscussion } from "./queries/votes/useVoteDiscussion";
+export { useActiveVoteResults } from "./queries/votes/useActiveVoteResults";

--- a/hooks/queries/votes/index.ts
+++ b/hooks/queries/votes/index.ts
@@ -6,3 +6,4 @@ export { useEncryptedVotes } from "./useEncryptedVotes";
 export { usePastVotes } from "./usePastVotes";
 export { useRevealedVotes } from "./useRevealedVotes";
 export { useUpcomingVotes } from "./useUpcomingVotes";
+export { useActiveVoteResults } from "./useActiveVoteResults";

--- a/hooks/queries/votes/useActiveVoteResults.ts
+++ b/hooks/queries/votes/useActiveVoteResults.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { oneMinute, activeVoteResultsKey } from "constant";
+import { getActiveVoteResults } from "graph";
+import { useHandleError, useVoteTimingContext } from "hooks";
+import { config } from "helpers/config";
+
+export function useActiveVoteResults() {
+  const { roundId } = useVoteTimingContext();
+  const { onError } = useHandleError({ isDataFetching: true });
+
+  const queryResult = useQuery(
+    [activeVoteResultsKey, roundId],
+    () => getActiveVoteResults(),
+    {
+      enabled: config.graphV2Enabled,
+      refetchInterval: oneMinute,
+      initialData: {},
+      onError,
+    }
+  );
+
+  return queryResult;
+}


### PR DESCRIPTION
## motivation
we want to see vote information during reveal

## changes
in order to do this, we need to query the graph for active votes.  this will attach the "results" and "participation" data needed for each active request, and this data will automatically populate the results panel.  theres a known issue, that if the vote rolls the results and participation will not clear, but we dont experience rolls on mainnet, so its not a critical bug.  the graph will need to be updated to resolve this. 

![image](https://user-images.githubusercontent.com/4429761/236215224-a5b5e048-82a2-499d-8623-7728ce8d2cfb.png)
