### PR TITLE
improve: remove redundant context getters and memoize the values

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Wallet } from "components";
 import {
   green,
@@ -19,13 +18,19 @@ import NextLink from "next/link";
 import Bell from "public/assets/icons/bell.svg";
 import Time from "public/assets/icons/time-with-inner-circle.svg";
 import Logo from "public/assets/logo.svg";
+import { useEffect } from "react";
 import styled, { CSSProperties } from "styled-components";
 import Menu from "/public/assets/icons/menu.svg";
 
 export function Header() {
   const { openPanel } = usePanelContext();
-  const { getDelegationStatus, getDelegationDataLoading, getDelegatorAddress } =
-    useDelegationContext();
+  const {
+    delegatorAddress,
+    isDelegate,
+    isDelegatePending,
+    isDelegator,
+    getDelegationDataLoading,
+  } = useDelegationContext();
 
   // theres a feature now to set the override address for various contexts. This allows us to query data based
   // on an arbitrary address, in all cases though this is based on the delegate/ delegator relationship. if we
@@ -34,11 +39,9 @@ export function Header() {
     useStakingContext();
   const { setAddressOverride: setUserContextAddress } = useUserContext();
   const { setAddressOverride: setVotesAddressOverride } = useVotesContext();
-  const delegationStatus = getDelegationStatus();
-  const delegatorAddress = getDelegatorAddress();
 
   useEffect(() => {
-    if (delegationStatus === "delegate") {
+    if (isDelegate) {
       const address = delegatorAddress;
       // these contexts have special logic to allow certain queries based on a different address, in this case
       // its the delegator address, so we can get things like stake/unstake balance, vote history and other data.
@@ -52,23 +55,17 @@ export function Header() {
       setVotesAddressOverride(undefined);
     }
   }, [
-    delegationStatus,
     delegatorAddress,
+    isDelegate,
     setUserContextAddress,
     setStakingAddressOverride,
     setVotesAddressOverride,
   ]);
 
-  const status = getDelegationStatus();
   const showDelegationNotification =
     !getDelegationDataLoading() &&
-    (status === "delegate" ||
-      status === "delegate-pending" ||
-      status === "delegator");
+    (isDelegate || isDelegatePending || isDelegator);
   const showV1RewardsNotification = v1Rewards?.totalRewards.gt(0);
-  const isDelegate = status === "delegate";
-  const isDelegator = status === "delegator";
-  const isDelegatePending = status === "delegate-pending";
 
   const delegationNotificationStyle = {
     "--color": isDelegate || isDelegator ? green : red500,

--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -25,9 +25,7 @@ export function HowItWorks() {
   } = useStakingContext();
   const { countWrongVotes, countCorrectVotes, apr, userDataFetching } =
     useUserContext();
-  const { getDelegationStatus, getDelegatorAddress } = useDelegationContext();
-  const isDelegate = getDelegationStatus() === "delegate";
-  const delegatorAddress = getDelegatorAddress();
+  const { isDelegate, delegatorAddress } = useDelegationContext();
 
   function openStakeUnstakePanel() {
     openPanel("stake");

--- a/components/Panel/ClaimPanel.tsx
+++ b/components/Panel/ClaimPanel.tsx
@@ -23,13 +23,12 @@ const minimumAmountClaimable = parseEtherSafe(".01");
 
 export function ClaimPanel() {
   const { votingWriter } = useContractsContext();
-  const { getDelegationStatus } = useDelegationContext();
+  const { isDelegate } = useDelegationContext();
   const { withdrawRewardsMutation, isWithdrawingRewards } =
     useWithdrawRewards("claim");
   const { withdrawAndRestakeMutation, isWithdrawingAndRestaking } =
     useWithdrawAndRestake("claim");
   const { outstandingRewards, getStakingDataFetching } = useStakingContext();
-  const isDelegate = getDelegationStatus() === "delegate";
 
   function withdrawRewards() {
     if (!outstandingRewards || !votingWriter) return;

--- a/components/Panel/DelegationPanel.tsx
+++ b/components/Panel/DelegationPanel.tsx
@@ -6,6 +6,7 @@ import {
 } from "components";
 import { mobileAndUnder } from "constant";
 import { getAddress, isAddress, truncateEthAddress } from "helpers";
+import { config } from "helpers/config";
 import {
   useDelegationContext,
   useErrorContext,
@@ -22,7 +23,6 @@ import styled, { css } from "styled-components";
 import { PanelFooter } from "./PanelFooter";
 import { PanelTitle } from "./PanelTitle";
 import { PanelSectionText, PanelSectionTitle, PanelWrapper } from "./styles";
-import { config } from "helpers/config";
 
 export function DelegationPanel() {
   const { closePanel } = usePanelContext();
@@ -30,34 +30,25 @@ export function DelegationPanel() {
   const { addErrorMessage, clearErrorMessages } = useErrorContext("delegation");
   const [delegateAddressToAdd, setDelegateAddressToAdd] = useState("");
   const {
-    getDelegationStatus,
+    isNoDelegation,
+    isDelegatorPending,
     sendRequestToBeDelegate,
-    getPendingSentRequestsToBeDelegate,
+    pendingSentRequestsToBeDelegate,
     getDelegationDataFetching,
   } = useDelegationContext();
 
-  const delegationStatus = getDelegationStatus();
-
   useEffect(() => {
     // only show this panel when the user has not yet entered a delegation relationship, or the user has requested another wallet to be their delegate wallet
-    if (
-      !(
-        delegationStatus === "no-delegation" ||
-        delegationStatus === "delegator-pending"
-      )
-    ) {
+    if (!(isNoDelegation || isDelegatorPending)) {
       closePanel();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [delegationStatus]);
-
-  const pendingRequests = getPendingSentRequestsToBeDelegate();
+  }, [closePanel, isDelegatorPending, isNoDelegation]);
 
   // only allow user to add a delegate wallet if they are neither a delegator nor a delegate
-  const showAddDelegateInput = delegationStatus === "no-delegation";
+  const showAddDelegateInput = isNoDelegation;
 
   const showPendingRequests =
-    delegationStatus === "delegator-pending" && pendingRequests.length > 0;
+    isDelegatorPending && pendingSentRequestsToBeDelegate.length > 0;
 
   function onAddDelegateWallet() {
     if (!address) return;
@@ -155,31 +146,35 @@ export function DelegationPanel() {
               </AddDelegateInputWrapper>
             )}
             {showPendingRequests &&
-              pendingRequests.map(({ delegate, transactionHash }) => (
-                <PendingRequestWrapper key={transactionHash}>
-                  <AddressWrapper>
-                    <IconWrapper>
-                      <PendingRequestIcon />
-                    </IconWrapper>
-                    <PendingRequestDetailsWrapper>
-                      <PendingRequestText>
-                        Request sent to {truncateEthAddress(delegate)}
-                      </PendingRequestText>
-                      <PendingRequestText>
-                        Waiting for approval.
-                      </PendingRequestText>
-                      <PendingRequestText>
-                        <Link
-                          href={config.makeTransactionHashLink(transactionHash)}
-                          target="_blank"
-                        >
-                          View Transaction
-                        </Link>
-                      </PendingRequestText>
-                    </PendingRequestDetailsWrapper>
-                  </AddressWrapper>
-                </PendingRequestWrapper>
-              ))}
+              pendingSentRequestsToBeDelegate.map(
+                ({ delegate, transactionHash }) => (
+                  <PendingRequestWrapper key={transactionHash}>
+                    <AddressWrapper>
+                      <IconWrapper>
+                        <PendingRequestIcon />
+                      </IconWrapper>
+                      <PendingRequestDetailsWrapper>
+                        <PendingRequestText>
+                          Request sent to {truncateEthAddress(delegate)}
+                        </PendingRequestText>
+                        <PendingRequestText>
+                          Waiting for approval.
+                        </PendingRequestText>
+                        <PendingRequestText>
+                          <Link
+                            href={config.makeTransactionHashLink(
+                              transactionHash
+                            )}
+                            target="_blank"
+                          >
+                            View Transaction
+                          </Link>
+                        </PendingRequestText>
+                      </PendingRequestDetailsWrapper>
+                    </AddressWrapper>
+                  </PendingRequestWrapper>
+                )
+              )}
           </>
         )}
         <PanelErrorBanner errorOrigin="delegation" />

--- a/components/Panel/MenuPanel/MenuPanel.tsx
+++ b/components/Panel/MenuPanel/MenuPanel.tsx
@@ -16,11 +16,14 @@ export function MenuPanel() {
   const { setSigner, setProvider } = useWalletContext();
   const { address, connectedWallet, walletIcon } = useUserContext();
   const {
-    getDelegationStatus,
-    getDelegateAddress,
-    getDelegatorAddress,
-    getPendingSentRequestsToBeDelegate,
-    getPendingReceivedRequestsToBeDelegate,
+    isDelegate,
+    isDelegatePending,
+    isDelegator,
+    isDelegatorPending,
+    delegateAddress,
+    delegatorAddress,
+    pendingSentRequestsToBeDelegate,
+    pendingReceivedRequestsToBeDelegate,
   } = useDelegationContext();
 
   const links = [
@@ -58,13 +61,6 @@ export function MenuPanel() {
     ? links
     : links.filter((link) => link.href !== "/wallet-settings");
 
-  const status = getDelegationStatus();
-
-  const isDelegator = status === "delegator";
-  const isDelegate = status === "delegate";
-  const isDelegatorPending = status === "delegator-pending";
-  const isDelegatePending = status === "delegate-pending";
-
   const walletTitle = isDelegator
     ? "Delegator Wallet"
     : isDelegate
@@ -73,14 +69,12 @@ export function MenuPanel() {
 
   const showOtherWallet = isDelegator || isDelegate;
   const otherWalletTitle = isDelegator ? "Delegate Wallet" : "Delegator Wallet";
-  const otherWalletAddress = isDelegator
-    ? getDelegateAddress()
-    : getDelegatorAddress();
+  const otherWalletAddress = isDelegator ? delegateAddress : delegatorAddress;
 
   const showPending = isDelegatorPending || isDelegatePending;
   const pendingRequests = isDelegatorPending
-    ? getPendingSentRequestsToBeDelegate()
-    : getPendingReceivedRequestsToBeDelegate();
+    ? pendingSentRequestsToBeDelegate
+    : pendingReceivedRequestsToBeDelegate;
   const pendingRequestLinkText = isDelegatorPending
     ? "Sent request"
     : "Received request";

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -31,7 +31,7 @@ export function StakeUnstakePanel() {
     getStakingDataFetching,
     unstakeCoolDown,
   } = useStakingContext();
-  const { getDelegationStatus } = useDelegationContext();
+  const { isDelegate } = useDelegationContext();
   const { approveMutation, isApproving } = useApprove("stake");
   const { stakeMutation, isStaking } = useStake("stake");
   const { requestUnstakeMutation, isRequestingUnstake } =
@@ -41,7 +41,6 @@ export function StakeUnstakePanel() {
   const cooldownEnds = canUnstakeTime;
   const hasCooldownTimeRemaining = !!cooldownEnds && cooldownEnds > new Date();
   const hasPendingUnstake = pendingUnstake?.gt(0) ?? false;
-  const isDelegate = getDelegationStatus() === "delegate";
   const isReadyToUnstake =
     !isDelegate && !hasCooldownTimeRemaining && hasPendingUnstake;
   const showCooldownTimer =

--- a/components/VoteList/VoteListItem.tsx
+++ b/components/VoteList/VoteListItem.tsx
@@ -42,7 +42,8 @@ export interface Props {
   activityStatus: ActivityStatusT;
   moreDetailsAction: () => void;
   isFetching: boolean;
-  delegationStatus?: string;
+  isDelegate: boolean;
+  isDelegator: boolean;
   setDirty?: (dirty: boolean) => void;
   isDirty?: boolean;
 }
@@ -57,7 +58,8 @@ export function VoteListItem({
   isFetching,
   setDirty,
   isDirty = false,
-  delegationStatus,
+  isDelegate,
+  isDelegator,
 }: Props) {
   const { width } = useWindowSize();
   const [isCustomInput, setIsCustomInput] = useState(false);
@@ -218,9 +220,9 @@ export function VoteListItem({
     if (phase === "commit") {
       if (!hasSigningKey) return "Requires signature";
       if (isCommitted && !decryptedVote) {
-        if (delegationStatus === "delegator") {
+        if (isDelegator) {
           return "Committed by Delegate";
-        } else if (delegationStatus === "delegate") {
+        } else if (isDelegate) {
           return "Committed by Delegator";
         } else {
           return "Decrypt Error";
@@ -231,13 +233,13 @@ export function VoteListItem({
       if (!isCommitted) return "Not committed";
       if (!hasSigningKey) return "Requires signature";
       if (!decryptedVote || !canReveal) {
-        if (delegationStatus === "delegator") {
+        if (isDelegator) {
           if (isRevealed) {
             return "Delegate revealed";
           } else {
             return "Delegate must reveal";
           }
-        } else if (delegationStatus === "delegate") {
+        } else if (isDelegate) {
           if (isRevealed) {
             return "Delegator revealed";
           } else {

--- a/components/VoteTimeline/VoteTimeline.tsx
+++ b/components/VoteTimeline/VoteTimeline.tsx
@@ -7,21 +7,19 @@ import { RevealPhase } from "./RevealPhase";
 
 export function VoteTimeline() {
   const { phase, millisecondsUntilPhaseEnds } = useVoteTimingContext();
-  const { getActivityStatus } = useVotesContext();
+  const { activityStatus } = useVotesContext();
 
-  const status = getActivityStatus();
-
-  if (status === "past") return null;
+  if (activityStatus === "past") return null;
 
   return (
     <>
-      {status === "upcoming" && (
+      {activityStatus === "upcoming" && (
         <NextRoundStartsIn
           phase={phase}
           timeRemaining={millisecondsUntilPhaseEnds}
         />
       )}
-      {status === "active" && (
+      {activityStatus === "active" && (
         <Wrapper>
           <CommitPhase
             phase={phase}

--- a/components/Votes/ActiveVotes.tsx
+++ b/components/Votes/ActiveVotes.tsx
@@ -48,7 +48,7 @@ export function ActiveVotes() {
     useWalletContext();
   const { votingWriter } = useContractsContext();
   const { stakedBalance } = useStakingContext();
-  const { getDelegationStatus, getDelegatorAddress } = useDelegationContext();
+  const { isDelegate, isDelegator, delegatorAddress } = useDelegationContext();
   const { openPanel } = usePanelContext();
   const [{ connecting: isConnectingWallet }, connect] = useConnectWallet();
   const { commitVotesMutation, isCommittingVotes } = useCommitVotes();
@@ -61,10 +61,6 @@ export function ActiveVotes() {
   function isDirty(): boolean {
     return dirtyInputs.some((x) => x);
   }
-
-  const isDelegate = getDelegationStatus() === "delegate";
-  const isDelegator = getDelegationStatus() === "delegator";
-  const delegatorAddress = isDelegate ? getDelegatorAddress() : undefined;
 
   const actionStatus = calculateActionStatus();
   type ActionStatus = {
@@ -310,7 +306,8 @@ export function ActiveVotes() {
               activityStatus="active"
               moreDetailsAction={() => openPanel("vote", vote)}
               key={vote.uniqueKey}
-              delegationStatus={getDelegationStatus()}
+              isDelegate={isDelegate}
+              isDelegator={isDelegator}
               isDirty={dirtyInputs[index]}
               setDirty={(dirty: boolean) => {
                 setDirtyInput((inputs) => {

--- a/components/Votes/PastVotes.tsx
+++ b/components/Votes/PastVotes.tsx
@@ -1,5 +1,10 @@
 import { Button, VoteList, VoteListItem, VoteTableHeadings } from "components";
-import { usePanelContext, useVoteTimingContext, useVotesContext } from "hooks";
+import {
+  useDelegationContext,
+  usePanelContext,
+  useVoteTimingContext,
+  useVotesContext,
+} from "hooks";
 import { CSSProperties } from "react";
 import {
   ButtonInnerWrapper,
@@ -12,6 +17,7 @@ export function PastVotes() {
   const { pastVoteList, getUserDependentIsFetching } = useVotesContext();
   const { phase } = useVoteTimingContext();
   const { openPanel } = usePanelContext();
+  const { isDelegate, isDelegator } = useDelegationContext();
 
   return (
     <>
@@ -32,6 +38,8 @@ export function PastVotes() {
               activityStatus="past"
               moreDetailsAction={() => openPanel("vote", vote)}
               key={vote.uniqueKey}
+              isDelegate={isDelegate}
+              isDelegator={isDelegator}
               isFetching={getUserDependentIsFetching()}
             />
           ))}

--- a/components/Votes/UpcomingVotes.tsx
+++ b/components/Votes/UpcomingVotes.tsx
@@ -23,7 +23,7 @@ export function UpcomingVotes() {
   const voteList = voteListsByActivityStatus.upcoming;
   const { phase } = useVoteTimingContext();
   const { openPanel } = usePanelContext();
-  const { getDelegationStatus } = useDelegationContext();
+  const { isDelegate, isDelegator } = useDelegationContext();
   const { showPagination, entriesToShow, ...paginationProps } =
     usePagination(voteList);
 
@@ -41,7 +41,8 @@ export function UpcomingVotes() {
               activityStatus="upcoming"
               moreDetailsAction={() => openPanel("vote", vote)}
               key={vote.uniqueKey}
-              delegationStatus={getDelegationStatus()}
+              isDelegate={isDelegate}
+              isDelegator={isDelegator}
               isFetching={getUserDependentIsFetching()}
             />
           ))}

--- a/components/Votes/UpcomingVotes.tsx
+++ b/components/Votes/UpcomingVotes.tsx
@@ -15,18 +15,22 @@ import {
 import { Divider, PaginationWrapper, Title, VotesTableWrapper } from "./style";
 
 export function UpcomingVotes() {
-  const { upcomingVoteList, getActivityStatus, getUserDependentIsFetching } =
-    useVotesContext();
+  const {
+    activityStatus,
+    voteListsByActivityStatus,
+    getUserDependentIsFetching,
+  } = useVotesContext();
+  const voteList = voteListsByActivityStatus.upcoming;
   const { phase } = useVoteTimingContext();
   const { openPanel } = usePanelContext();
   const { getDelegationStatus } = useDelegationContext();
   const { showPagination, entriesToShow, ...paginationProps } =
-    usePagination(upcomingVoteList);
+    usePagination(voteList);
 
   return (
     <>
       <Title>Upcoming votes:</Title>
-      {getActivityStatus() === "upcoming" && <VoteTimeline />}
+      {activityStatus === "upcoming" && <VoteTimeline />}
       <VotesTableWrapper>
         <VoteList
           headings={<VoteTableHeadings activityStatus="upcoming" />}

--- a/components/Votes/UpcomingVotes.tsx
+++ b/components/Votes/UpcomingVotes.tsx
@@ -15,17 +15,13 @@ import {
 import { Divider, PaginationWrapper, Title, VotesTableWrapper } from "./style";
 
 export function UpcomingVotes() {
-  const {
-    activityStatus,
-    voteListsByActivityStatus,
-    getUserDependentIsFetching,
-  } = useVotesContext();
-  const voteList = voteListsByActivityStatus.upcoming;
+  const { upcomingVoteList, activityStatus, getUserDependentIsFetching } =
+    useVotesContext();
   const { phase } = useVoteTimingContext();
   const { openPanel } = usePanelContext();
   const { isDelegate, isDelegator } = useDelegationContext();
   const { showPagination, entriesToShow, ...paginationProps } =
-    usePagination(voteList);
+    usePagination(upcomingVoteList);
 
   return (
     <>

--- a/components/pages/PastVotes.tsx
+++ b/components/pages/PastVotes.tsx
@@ -10,7 +10,12 @@ import {
   VoteTableHeadings,
   usePagination,
 } from "components";
-import { usePanelContext, useVoteTimingContext, useVotesContext } from "hooks";
+import {
+  useDelegationContext,
+  usePanelContext,
+  useVoteTimingContext,
+  useVotesContext,
+} from "hooks";
 import styled from "styled-components";
 import { LoadingSpinnerWrapper } from "./styles";
 
@@ -20,6 +25,7 @@ export function PastVotes() {
     getUserIndependentIsLoading,
     getUserDependentIsFetching,
   } = useVotesContext();
+  const { isDelegate, isDelegator } = useDelegationContext();
   const { phase } = useVoteTimingContext();
   const { openPanel } = usePanelContext();
   const { showPagination, entriesToShow, ...paginationProps } =
@@ -48,6 +54,8 @@ export function PastVotes() {
                       activityStatus="past"
                       moreDetailsAction={() => openPanel("vote", vote)}
                       key={vote.uniqueKey}
+                      isDelegate={isDelegate}
+                      isDelegator={isDelegator}
                       isFetching={getUserDependentIsFetching()}
                     />
                   ))}

--- a/components/pages/UpcomingVotes.tsx
+++ b/components/pages/UpcomingVotes.tsx
@@ -11,7 +11,12 @@ import {
   VoteTableHeadings,
   usePagination,
 } from "components";
-import { usePanelContext, useVoteTimingContext, useVotesContext } from "hooks";
+import {
+  useDelegationContext,
+  usePanelContext,
+  useVoteTimingContext,
+  useVotesContext,
+} from "hooks";
 import Image from "next/image";
 import noVotesIndicator from "public/assets/no-votes-indicator.png";
 import styled from "styled-components";
@@ -23,6 +28,7 @@ export function UpcomingVotes() {
     getUserIndependentIsLoading,
     getUserDependentIsFetching,
   } = useVotesContext();
+  const { isDelegate, isDelegator } = useDelegationContext();
   const { phase, millisecondsUntilPhaseEnds } = useVoteTimingContext();
   const { openPanel } = usePanelContext();
   const { showPagination, entriesToShow, ...paginationProps } =
@@ -59,6 +65,8 @@ export function UpcomingVotes() {
                           activityStatus="upcoming"
                           moreDetailsAction={() => openPanel("vote", vote)}
                           key={vote.uniqueKey}
+                          isDelegate={isDelegate}
+                          isDelegator={isDelegator}
                           isFetching={getUserDependentIsFetching()}
                         />
                       ))}

--- a/components/pages/WalletSettings/IsDelegate.tsx
+++ b/components/pages/WalletSettings/IsDelegate.tsx
@@ -5,11 +5,11 @@ import { PendingRequests } from "./PendingRequests";
 
 export function IsDelegate({ hasPending }: { hasPending?: boolean }) {
   const {
-    getDelegatorAddress,
+    delegatorAddress,
     acceptReceivedRequestToBeDelegate,
     ignoreReceivedRequestToBeDelegate,
     terminateRelationshipWithDelegator,
-    getPendingReceivedRequestsToBeDelegate,
+    pendingReceivedRequestsToBeDelegate,
   } = useDelegationContext();
 
   return (
@@ -18,14 +18,14 @@ export function IsDelegate({ hasPending }: { hasPending?: boolean }) {
       {hasPending ? (
         <PendingRequests
           requestType="delegate"
-          pendingRequests={getPendingReceivedRequestsToBeDelegate()}
+          pendingRequests={pendingReceivedRequestsToBeDelegate}
           acceptReceivedRequestToBeDelegate={acceptReceivedRequestToBeDelegate}
           ignoreReceivedRequestToBeDelegate={ignoreReceivedRequestToBeDelegate}
         />
       ) : (
         <OtherWallet
           status="delegator"
-          address={getDelegatorAddress()}
+          address={delegatorAddress}
           remove={terminateRelationshipWithDelegator}
         />
       )}

--- a/components/pages/WalletSettings/IsDelegator.tsx
+++ b/components/pages/WalletSettings/IsDelegator.tsx
@@ -5,8 +5,8 @@ import { PendingRequests } from "./PendingRequests";
 
 export function IsDelegator({ hasPending }: { hasPending?: boolean }) {
   const {
-    getDelegateAddress,
-    getPendingSentRequestsToBeDelegate,
+    delegateAddress,
+    pendingSentRequestsToBeDelegate,
     cancelSentRequestToBeDelegate,
     terminateRelationshipWithDelegate,
   } = useDelegationContext();
@@ -17,13 +17,13 @@ export function IsDelegator({ hasPending }: { hasPending?: boolean }) {
       {hasPending ? (
         <PendingRequests
           requestType="delegator"
-          pendingRequests={getPendingSentRequestsToBeDelegate()}
+          pendingRequests={pendingSentRequestsToBeDelegate}
           cancelSentRequestToBeDelegate={cancelSentRequestToBeDelegate}
         />
       ) : (
         <OtherWallet
           status="delegate"
-          address={getDelegateAddress()}
+          address={delegateAddress}
           remove={terminateRelationshipWithDelegate}
         />
       )}

--- a/components/pages/WalletSettings/OtherWallet.tsx
+++ b/components/pages/WalletSettings/OtherWallet.tsx
@@ -22,11 +22,11 @@ export function OtherWallet({
   remove: (address: string) => void;
 }) {
   if (!address) return null;
+  const isDelegate = status === "delegate";
 
-  const text =
-    status === "delegate"
-      ? "A delegate is a wallet that has been chosen to vote on behalf of another party. If acting as a delegate, a delegate can no longer vote for themselves. Delegates can commit & reveal votes on behalf of a delegator, as well as claim and stake reward tokens. A delegate cannot unstake tokens for a delegator. A delegate can only be a delegate for a single delegator."
-      : "A delegator is a wallet that has chosen to delegate its voting power to another party. Delegators can only delegate to one address at a time.";
+  const text = isDelegate
+    ? "A delegate is a wallet that has been chosen to vote on behalf of another party. If acting as a delegate, a delegate can no longer vote for themselves. Delegates can commit & reveal votes on behalf of a delegator, as well as claim and stake reward tokens. A delegate cannot unstake tokens for a delegator. A delegate can only be a delegate for a single delegator."
+    : "A delegator is a wallet that has chosen to delegate its voting power to another party. Delegators can only delegate to one address at a time.";
 
   return (
     <>

--- a/components/pages/WalletSettings/Wallets.tsx
+++ b/components/pages/WalletSettings/Wallets.tsx
@@ -6,21 +6,23 @@ import { NoDelegation } from "./NoDelegation";
 import { NoWalletConnected } from "./NoWalletConnected";
 
 export function Wallets() {
-  const { getDelegationStatus } = useDelegationContext();
-  const delegationStatus = getDelegationStatus();
+  const {
+    isNoWalletConnected,
+    isNoDelegation,
+    isDelegate,
+    isDelegator,
+    isDelegatePending,
+    isDelegatorPending,
+  } = useDelegationContext();
 
   return (
     <Wrapper>
-      {delegationStatus === "no-wallet-connected" && <NoWalletConnected />}
-      {delegationStatus === "no-delegation" && <NoDelegation />}
-      {delegationStatus === "delegator" && <IsDelegator />}
-      {delegationStatus === "delegate" && <IsDelegate />}
-      {delegationStatus === "delegator-pending" && (
-        <IsDelegator hasPending={true} />
-      )}
-      {delegationStatus === "delegate-pending" && (
-        <IsDelegate hasPending={true} />
-      )}
+      {isNoWalletConnected && <NoWalletConnected />}
+      {isNoDelegation && <NoDelegation />}
+      {isDelegator && <IsDelegator />}
+      {isDelegate && <IsDelegate />}
+      {isDelegatorPending && <IsDelegator hasPending={true} />}
+      {isDelegatePending && <IsDelegate hasPending={true} />}
     </Wrapper>
   );
 }

--- a/contexts/ContractsContext.tsx
+++ b/contexts/ContractsContext.tsx
@@ -3,7 +3,7 @@ import {
   VotingTokenEthers,
   VotingV2Ethers,
 } from "@uma/contracts-frontend";
-import { createContext, ReactNode, useState } from "react";
+import { ReactNode, createContext, useMemo, useState } from "react";
 import {
   createVotingContractInstance,
   createVotingTokenContractInstance,
@@ -46,18 +46,21 @@ export function ContractsProvider({ children }: { children: ReactNode }) {
     undefined
   );
 
+  const value = useMemo(
+    () => ({
+      voting: defaultVoting,
+      votingToken: defaultVotingToken,
+      votingV1: defaultVotingV1,
+      setVotingWriter,
+      votingWriter,
+      setVotingTokenWriter,
+      votingTokenWriter,
+    }),
+    [votingTokenWriter, votingWriter]
+  );
+
   return (
-    <ContractsContext.Provider
-      value={{
-        voting: defaultVoting,
-        votingToken: defaultVotingToken,
-        votingV1: defaultVotingV1,
-        setVotingWriter,
-        votingWriter,
-        setVotingTokenWriter,
-        votingTokenWriter,
-      }}
-    >
+    <ContractsContext.Provider value={value}>
       {children}
     </ContractsContext.Provider>
   );

--- a/contexts/DelegationContext.tsx
+++ b/contexts/DelegationContext.tsx
@@ -18,7 +18,7 @@ import {
   useUserContext,
   useVoterFromDelegate,
 } from "hooks";
-import { ReactNode, createContext } from "react";
+import { ReactNode, createContext, useCallback, useMemo } from "react";
 import { DelegationEventT, DelegationStatusT } from "types";
 export interface DelegationContextState {
   delegationStatus: DelegationStatusT;
@@ -153,41 +153,75 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   const hasPendingSentRequestsToBeDelegate =
     getHasPendingSentRequestsToBeDelegate();
 
-  function getDelegationDataLoading() {
-    return (
-      receivedRequestsToBeDelegateLoading ||
-      sentRequestsToBeDelegateLoading ||
-      delegatorSetEventsForDelegateLoading ||
-      voterFromDelegateLoading ||
-      delegateToStakerLoading ||
-      delegatorSetEventsForDelegatorLoading ||
-      ignoredRequestToBeDelegateAddressesLoading ||
-      isIgnoringRequestToBeDelegate ||
-      isSendingRequestToBeDelegate ||
-      isCancelingSentRequestToBeDelegate ||
-      isAcceptingReceivedRequestToBeDelegate ||
-      isTerminatingRelationshipWithDelegate ||
-      isTerminatingRelationshipWithDelegator
-    );
-  }
+  const getDelegationDataLoading = useCallback(
+    function () {
+      return (
+        receivedRequestsToBeDelegateLoading ||
+        sentRequestsToBeDelegateLoading ||
+        delegatorSetEventsForDelegateLoading ||
+        voterFromDelegateLoading ||
+        delegateToStakerLoading ||
+        delegatorSetEventsForDelegatorLoading ||
+        ignoredRequestToBeDelegateAddressesLoading ||
+        isIgnoringRequestToBeDelegate ||
+        isSendingRequestToBeDelegate ||
+        isCancelingSentRequestToBeDelegate ||
+        isAcceptingReceivedRequestToBeDelegate ||
+        isTerminatingRelationshipWithDelegate ||
+        isTerminatingRelationshipWithDelegator
+      );
+    },
+    [
+      delegateToStakerLoading,
+      delegatorSetEventsForDelegateLoading,
+      delegatorSetEventsForDelegatorLoading,
+      ignoredRequestToBeDelegateAddressesLoading,
+      isAcceptingReceivedRequestToBeDelegate,
+      isCancelingSentRequestToBeDelegate,
+      isIgnoringRequestToBeDelegate,
+      isSendingRequestToBeDelegate,
+      isTerminatingRelationshipWithDelegate,
+      isTerminatingRelationshipWithDelegator,
+      receivedRequestsToBeDelegateLoading,
+      sentRequestsToBeDelegateLoading,
+      voterFromDelegateLoading,
+    ]
+  );
 
-  function getDelegationDataFetching() {
-    return (
-      receivedRequestsToBeDelegateFetching ||
-      sentRequestsToBeDelegateFetching ||
-      delegatorSetEventsForDelegateFetching ||
-      voterFromDelegateFetching ||
-      delegateToStakerFetching ||
-      delegatorSetEventsForDelegatorFetching ||
-      ignoredRequestToBeDelegateAddressesFetching ||
-      isIgnoringRequestToBeDelegate ||
-      isSendingRequestToBeDelegate ||
-      isCancelingSentRequestToBeDelegate ||
-      isAcceptingReceivedRequestToBeDelegate ||
-      isTerminatingRelationshipWithDelegate ||
-      isTerminatingRelationshipWithDelegator
-    );
-  }
+  const getDelegationDataFetching = useCallback(
+    function () {
+      return (
+        receivedRequestsToBeDelegateFetching ||
+        sentRequestsToBeDelegateFetching ||
+        delegatorSetEventsForDelegateFetching ||
+        voterFromDelegateFetching ||
+        delegateToStakerFetching ||
+        delegatorSetEventsForDelegatorFetching ||
+        ignoredRequestToBeDelegateAddressesFetching ||
+        isIgnoringRequestToBeDelegate ||
+        isSendingRequestToBeDelegate ||
+        isCancelingSentRequestToBeDelegate ||
+        isAcceptingReceivedRequestToBeDelegate ||
+        isTerminatingRelationshipWithDelegate ||
+        isTerminatingRelationshipWithDelegator
+      );
+    },
+    [
+      delegateToStakerFetching,
+      delegatorSetEventsForDelegateFetching,
+      delegatorSetEventsForDelegatorFetching,
+      ignoredRequestToBeDelegateAddressesFetching,
+      isAcceptingReceivedRequestToBeDelegate,
+      isCancelingSentRequestToBeDelegate,
+      isIgnoringRequestToBeDelegate,
+      isSendingRequestToBeDelegate,
+      isTerminatingRelationshipWithDelegate,
+      isTerminatingRelationshipWithDelegator,
+      receivedRequestsToBeDelegateFetching,
+      sentRequestsToBeDelegateFetching,
+      voterFromDelegateFetching,
+    ]
+  );
 
   function getDelegateAddress() {
     if (isDelegator) return delegate;
@@ -290,119 +324,162 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
     );
   }
 
-  function sendRequestToBeDelegate(delegateAddress: string) {
-    if (!votingWriter) return;
-    sendRequestToBeDelegateMutation(
-      {
+  const sendRequestToBeDelegate = useCallback(
+    function sendRequestToBeDelegate(delegateAddress: string) {
+      if (!votingWriter) return;
+      sendRequestToBeDelegateMutation(
+        {
+          voting: votingWriter,
+          delegateAddress,
+          notificationMessages: {
+            pending: `Requesting ${truncateEthAddress(
+              delegateAddress
+            )} to be your delegate...`,
+            success: `Successfully requested ${truncateEthAddress(
+              delegateAddress
+            )} to be your delegate`,
+            error: `Failed to request ${truncateEthAddress(
+              delegateAddress
+            )} to be your delegate`,
+          },
+        },
+        {
+          onSuccess: () => {
+            closePanel();
+          },
+        }
+      );
+    },
+    [closePanel, sendRequestToBeDelegateMutation, votingWriter]
+  );
+
+  const cancelSentRequestToBeDelegate = useCallback(
+    function cancelSentRequestToBeDelegate() {
+      if (!votingWriter) return;
+      cancelSentRequestToBeDelegateMutation({
         voting: votingWriter,
-        delegateAddress,
         notificationMessages: {
-          pending: `Requesting ${truncateEthAddress(
-            delegateAddress
-          )} to be your delegate...`,
-          success: `Successfully requested ${truncateEthAddress(
-            delegateAddress
-          )} to be your delegate`,
-          error: `Failed to request ${truncateEthAddress(
-            delegateAddress
-          )} to be your delegate`,
+          pending: "Cancelling request to delegate...",
+          success: "Successfully cancelled request to delegate",
+          error: "Failed to cancel request to delegate",
         },
-      },
-      {
-        onSuccess: () => {
-          closePanel();
-        },
-      }
-    );
-  }
+      });
+    },
+    [cancelSentRequestToBeDelegateMutation, votingWriter]
+  );
 
-  function cancelSentRequestToBeDelegate() {
-    if (!votingWriter) return;
-    cancelSentRequestToBeDelegateMutation({
-      voting: votingWriter,
-      notificationMessages: {
-        pending: "Cancelling request to delegate...",
-        success: "Successfully cancelled request to delegate",
-        error: "Failed to cancel request to delegate",
-      },
-    });
-  }
-
-  function acceptReceivedRequestToBeDelegate(delegatorAddress: string) {
-    if (!votingWriter) return;
-    acceptReceivedRequestToBeDelegateMutation({
-      voting: votingWriter,
-      delegatorAddress,
-      notificationMessages: {
-        pending: `Accepting request to be delegate from ${truncateEthAddress(
-          delegatorAddress
-        )}...`,
-        success: `Successfully accepted request to be delegate from ${truncateEthAddress(
-          delegatorAddress
-        )}`,
-        error: `Failed to accept request to be delegate from ${truncateEthAddress(
-          delegatorAddress
-        )}`,
-      },
-    });
-  }
-
-  function ignoreReceivedRequestToBeDelegate(delegatorAddress: string) {
-    ignoreReceivedRequestToBeDelegateMutation({
-      userAddress: address,
-      delegatorAddress,
-    });
-  }
-
-  function terminateRelationshipWithDelegator() {
-    if (!votingWriter) return;
-    terminateRelationshipWithDelegatorMutation({
-      voting: votingWriter,
-      notificationMessages: {
-        pending: "Removing delegator...",
-        success: "Successfully removed delegator",
-        error: "Failed to remove delegator",
-      },
-    });
-  }
-
-  function terminateRelationshipWithDelegate() {
-    if (!votingWriter) return;
-    terminateRelationshipWithDelegateMutation({
-      voting: votingWriter,
-      notificationMessages: {
-        pending: "Removing delegate...",
-        success: "Successfully removed delegate",
-        error: "Failed to remove delegate",
-      },
-    });
-  }
-  return (
-    <DelegationContext.Provider
-      value={{
-        delegationStatus,
-        isNoWalletConnected,
-        isNoDelegation,
-        isDelegatePending,
-        isDelegatorPending,
-        isDelegate,
-        isDelegator,
+  const acceptReceivedRequestToBeDelegate = useCallback(
+    function acceptReceivedRequestToBeDelegate(delegatorAddress: string) {
+      if (!votingWriter) return;
+      acceptReceivedRequestToBeDelegateMutation({
+        voting: votingWriter,
         delegatorAddress,
-        delegateAddress,
-        pendingReceivedRequestsToBeDelegate,
-        pendingSentRequestsToBeDelegate,
-        hasPendingSentRequestsToBeDelegate,
-        hasPendingReceivedRequestsToBeDelegate,
-        sendRequestToBeDelegate,
-        terminateRelationshipWithDelegate,
-        terminateRelationshipWithDelegator,
-        acceptReceivedRequestToBeDelegate,
-        ignoreReceivedRequestToBeDelegate,
-        cancelSentRequestToBeDelegate,
-        getDelegationDataLoading,
-        getDelegationDataFetching,
-      }}
-    >
+        notificationMessages: {
+          pending: `Accepting request to be delegate from ${truncateEthAddress(
+            delegatorAddress
+          )}...`,
+          success: `Successfully accepted request to be delegate from ${truncateEthAddress(
+            delegatorAddress
+          )}`,
+          error: `Failed to accept request to be delegate from ${truncateEthAddress(
+            delegatorAddress
+          )}`,
+        },
+      });
+    },
+    [acceptReceivedRequestToBeDelegateMutation, votingWriter]
+  );
+
+  const ignoreReceivedRequestToBeDelegate = useCallback(
+    function (delegatorAddress: string) {
+      ignoreReceivedRequestToBeDelegateMutation({
+        userAddress: address,
+        delegatorAddress,
+      });
+    },
+    [address, ignoreReceivedRequestToBeDelegateMutation]
+  );
+
+  const terminateRelationshipWithDelegator = useCallback(
+    function () {
+      if (!votingWriter) return;
+      terminateRelationshipWithDelegatorMutation({
+        voting: votingWriter,
+        notificationMessages: {
+          pending: "Removing delegator...",
+          success: "Successfully removed delegator",
+          error: "Failed to remove delegator",
+        },
+      });
+    },
+    [terminateRelationshipWithDelegatorMutation, votingWriter]
+  );
+
+  const terminateRelationshipWithDelegate = useCallback(
+    function () {
+      if (!votingWriter) return;
+      terminateRelationshipWithDelegateMutation({
+        voting: votingWriter,
+        notificationMessages: {
+          pending: "Removing delegate...",
+          success: "Successfully removed delegate",
+          error: "Failed to remove delegate",
+        },
+      });
+    },
+    [terminateRelationshipWithDelegateMutation, votingWriter]
+  );
+
+  const value = useMemo(
+    () => ({
+      delegationStatus,
+      isNoWalletConnected,
+      isNoDelegation,
+      isDelegatePending,
+      isDelegatorPending,
+      isDelegate,
+      isDelegator,
+      delegatorAddress,
+      delegateAddress,
+      pendingReceivedRequestsToBeDelegate,
+      pendingSentRequestsToBeDelegate,
+      hasPendingSentRequestsToBeDelegate,
+      hasPendingReceivedRequestsToBeDelegate,
+      sendRequestToBeDelegate,
+      terminateRelationshipWithDelegate,
+      terminateRelationshipWithDelegator,
+      acceptReceivedRequestToBeDelegate,
+      ignoreReceivedRequestToBeDelegate,
+      cancelSentRequestToBeDelegate,
+      getDelegationDataLoading,
+      getDelegationDataFetching,
+    }),
+    [
+      acceptReceivedRequestToBeDelegate,
+      cancelSentRequestToBeDelegate,
+      delegateAddress,
+      delegationStatus,
+      delegatorAddress,
+      getDelegationDataFetching,
+      getDelegationDataLoading,
+      hasPendingReceivedRequestsToBeDelegate,
+      hasPendingSentRequestsToBeDelegate,
+      ignoreReceivedRequestToBeDelegate,
+      isDelegate,
+      isDelegatePending,
+      isDelegator,
+      isDelegatorPending,
+      isNoDelegation,
+      isNoWalletConnected,
+      pendingReceivedRequestsToBeDelegate,
+      pendingSentRequestsToBeDelegate,
+      sendRequestToBeDelegate,
+      terminateRelationshipWithDelegate,
+      terminateRelationshipWithDelegator,
+    ]
+  );
+  return (
+    <DelegationContext.Provider value={value}>
       {children}
     </DelegationContext.Provider>
   );

--- a/contexts/DelegationContext.tsx
+++ b/contexts/DelegationContext.tsx
@@ -23,7 +23,7 @@ import { DelegationEventT, DelegationStatusT } from "types";
 export interface DelegationContextState {
   delegationStatus: DelegationStatusT;
   isNoWalletConnected: boolean;
-  isNoDelegate: boolean;
+  isNoDelegation: boolean;
   isDelegate: boolean;
   isDelegator: boolean;
   isDelegatePending: boolean;
@@ -47,7 +47,7 @@ export interface DelegationContextState {
 export const defaultDelegationContextState: DelegationContextState = {
   delegationStatus: "no-wallet-connected",
   isNoWalletConnected: true,
-  isNoDelegate: false,
+  isNoDelegation: false,
   isDelegatePending: false,
   isDelegatorPending: false,
   isDelegate: false,
@@ -138,7 +138,7 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   const { closePanel } = usePanelContext();
   const delegationStatus = getDelegationStatus();
   const isNoWalletConnected = delegationStatus === "no-wallet-connected";
-  const isNoDelegate = delegationStatus === "no-delegation";
+  const isNoDelegation = delegationStatus === "no-delegation";
   const isDelegatePending = delegationStatus === "delegate-pending";
   const isDelegatorPending = delegationStatus === "delegator-pending";
   const isDelegate = delegationStatus === "delegate";
@@ -190,16 +190,14 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   }
 
   function getDelegateAddress() {
-    const status = getDelegationStatus();
-    if (status === "delegator") return delegate;
-    if (status === "delegate") return address;
+    if (isDelegator) return delegate;
+    if (isDelegate) return address;
     return zeroAddress;
   }
 
   function getDelegatorAddress() {
-    const status = getDelegationStatus();
-    if (status === "delegator") return address;
-    if (status === "delegate") return voterFromDelegate;
+    if (isDelegator) return address;
+    if (isDelegate) return voterFromDelegate;
     return zeroAddress;
   }
 
@@ -384,7 +382,7 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
       value={{
         delegationStatus,
         isNoWalletConnected,
-        isNoDelegate,
+        isNoDelegation,
         isDelegatePending,
         isDelegatorPending,
         isDelegate,

--- a/contexts/DelegationContext.tsx
+++ b/contexts/DelegationContext.tsx
@@ -153,75 +153,69 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   const hasPendingSentRequestsToBeDelegate =
     getHasPendingSentRequestsToBeDelegate();
 
-  const getDelegationDataLoading = useCallback(
-    function () {
-      return (
-        receivedRequestsToBeDelegateLoading ||
-        sentRequestsToBeDelegateLoading ||
-        delegatorSetEventsForDelegateLoading ||
-        voterFromDelegateLoading ||
-        delegateToStakerLoading ||
-        delegatorSetEventsForDelegatorLoading ||
-        ignoredRequestToBeDelegateAddressesLoading ||
-        isIgnoringRequestToBeDelegate ||
-        isSendingRequestToBeDelegate ||
-        isCancelingSentRequestToBeDelegate ||
-        isAcceptingReceivedRequestToBeDelegate ||
-        isTerminatingRelationshipWithDelegate ||
-        isTerminatingRelationshipWithDelegator
-      );
-    },
-    [
-      delegateToStakerLoading,
-      delegatorSetEventsForDelegateLoading,
-      delegatorSetEventsForDelegatorLoading,
-      ignoredRequestToBeDelegateAddressesLoading,
-      isAcceptingReceivedRequestToBeDelegate,
-      isCancelingSentRequestToBeDelegate,
-      isIgnoringRequestToBeDelegate,
-      isSendingRequestToBeDelegate,
-      isTerminatingRelationshipWithDelegate,
-      isTerminatingRelationshipWithDelegator,
-      receivedRequestsToBeDelegateLoading,
-      sentRequestsToBeDelegateLoading,
-      voterFromDelegateLoading,
-    ]
-  );
+  const getDelegationDataLoading = useCallback(() => {
+    return (
+      receivedRequestsToBeDelegateLoading ||
+      sentRequestsToBeDelegateLoading ||
+      delegatorSetEventsForDelegateLoading ||
+      voterFromDelegateLoading ||
+      delegateToStakerLoading ||
+      delegatorSetEventsForDelegatorLoading ||
+      ignoredRequestToBeDelegateAddressesLoading ||
+      isIgnoringRequestToBeDelegate ||
+      isSendingRequestToBeDelegate ||
+      isCancelingSentRequestToBeDelegate ||
+      isAcceptingReceivedRequestToBeDelegate ||
+      isTerminatingRelationshipWithDelegate ||
+      isTerminatingRelationshipWithDelegator
+    );
+  }, [
+    delegateToStakerLoading,
+    delegatorSetEventsForDelegateLoading,
+    delegatorSetEventsForDelegatorLoading,
+    ignoredRequestToBeDelegateAddressesLoading,
+    isAcceptingReceivedRequestToBeDelegate,
+    isCancelingSentRequestToBeDelegate,
+    isIgnoringRequestToBeDelegate,
+    isSendingRequestToBeDelegate,
+    isTerminatingRelationshipWithDelegate,
+    isTerminatingRelationshipWithDelegator,
+    receivedRequestsToBeDelegateLoading,
+    sentRequestsToBeDelegateLoading,
+    voterFromDelegateLoading,
+  ]);
 
-  const getDelegationDataFetching = useCallback(
-    function () {
-      return (
-        receivedRequestsToBeDelegateFetching ||
-        sentRequestsToBeDelegateFetching ||
-        delegatorSetEventsForDelegateFetching ||
-        voterFromDelegateFetching ||
-        delegateToStakerFetching ||
-        delegatorSetEventsForDelegatorFetching ||
-        ignoredRequestToBeDelegateAddressesFetching ||
-        isIgnoringRequestToBeDelegate ||
-        isSendingRequestToBeDelegate ||
-        isCancelingSentRequestToBeDelegate ||
-        isAcceptingReceivedRequestToBeDelegate ||
-        isTerminatingRelationshipWithDelegate ||
-        isTerminatingRelationshipWithDelegator
-      );
-    },
-    [
-      delegateToStakerFetching,
-      delegatorSetEventsForDelegateFetching,
-      delegatorSetEventsForDelegatorFetching,
-      ignoredRequestToBeDelegateAddressesFetching,
-      isAcceptingReceivedRequestToBeDelegate,
-      isCancelingSentRequestToBeDelegate,
-      isIgnoringRequestToBeDelegate,
-      isSendingRequestToBeDelegate,
-      isTerminatingRelationshipWithDelegate,
-      isTerminatingRelationshipWithDelegator,
-      receivedRequestsToBeDelegateFetching,
-      sentRequestsToBeDelegateFetching,
-      voterFromDelegateFetching,
-    ]
-  );
+  const getDelegationDataFetching = useCallback(() => {
+    return (
+      receivedRequestsToBeDelegateFetching ||
+      sentRequestsToBeDelegateFetching ||
+      delegatorSetEventsForDelegateFetching ||
+      voterFromDelegateFetching ||
+      delegateToStakerFetching ||
+      delegatorSetEventsForDelegatorFetching ||
+      ignoredRequestToBeDelegateAddressesFetching ||
+      isIgnoringRequestToBeDelegate ||
+      isSendingRequestToBeDelegate ||
+      isCancelingSentRequestToBeDelegate ||
+      isAcceptingReceivedRequestToBeDelegate ||
+      isTerminatingRelationshipWithDelegate ||
+      isTerminatingRelationshipWithDelegator
+    );
+  }, [
+    delegateToStakerFetching,
+    delegatorSetEventsForDelegateFetching,
+    delegatorSetEventsForDelegatorFetching,
+    ignoredRequestToBeDelegateAddressesFetching,
+    isAcceptingReceivedRequestToBeDelegate,
+    isCancelingSentRequestToBeDelegate,
+    isIgnoringRequestToBeDelegate,
+    isSendingRequestToBeDelegate,
+    isTerminatingRelationshipWithDelegate,
+    isTerminatingRelationshipWithDelegator,
+    receivedRequestsToBeDelegateFetching,
+    sentRequestsToBeDelegateFetching,
+    voterFromDelegateFetching,
+  ]);
 
   function getDelegateAddress() {
     if (isDelegator) return delegate;
@@ -400,35 +394,29 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
     [address, ignoreReceivedRequestToBeDelegateMutation]
   );
 
-  const terminateRelationshipWithDelegator = useCallback(
-    function () {
-      if (!votingWriter) return;
-      terminateRelationshipWithDelegatorMutation({
-        voting: votingWriter,
-        notificationMessages: {
-          pending: "Removing delegator...",
-          success: "Successfully removed delegator",
-          error: "Failed to remove delegator",
-        },
-      });
-    },
-    [terminateRelationshipWithDelegatorMutation, votingWriter]
-  );
+  const terminateRelationshipWithDelegator = useCallback(() => {
+    if (!votingWriter) return;
+    terminateRelationshipWithDelegatorMutation({
+      voting: votingWriter,
+      notificationMessages: {
+        pending: "Removing delegator...",
+        success: "Successfully removed delegator",
+        error: "Failed to remove delegator",
+      },
+    });
+  }, [terminateRelationshipWithDelegatorMutation, votingWriter]);
 
-  const terminateRelationshipWithDelegate = useCallback(
-    function () {
-      if (!votingWriter) return;
-      terminateRelationshipWithDelegateMutation({
-        voting: votingWriter,
-        notificationMessages: {
-          pending: "Removing delegate...",
-          success: "Successfully removed delegate",
-          error: "Failed to remove delegate",
-        },
-      });
-    },
-    [terminateRelationshipWithDelegateMutation, votingWriter]
-  );
+  const terminateRelationshipWithDelegate = useCallback(() => {
+    if (!votingWriter) return;
+    terminateRelationshipWithDelegateMutation({
+      voting: votingWriter,
+      notificationMessages: {
+        pending: "Removing delegate...",
+        success: "Successfully removed delegate",
+        error: "Failed to remove delegate",
+      },
+    });
+  }, [terminateRelationshipWithDelegateMutation, votingWriter]);
 
   const value = useMemo(
     () => ({

--- a/contexts/DelegationContext.tsx
+++ b/contexts/DelegationContext.tsx
@@ -136,6 +136,13 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
     data: { delegate },
   } = useStakerDetails();
   const { closePanel } = usePanelContext();
+  const pendingReceivedRequestsToBeDelegate =
+    getPendingReceivedRequestsToBeDelegate();
+  const hasPendingReceivedRequestsToBeDelegate =
+    pendingReceivedRequestsToBeDelegate.length > 0;
+  const pendingSentRequestsToBeDelegate = getPendingSentRequestsToBeDelegate();
+  const hasPendingSentRequestsToBeDelegate =
+    getHasPendingSentRequestsToBeDelegate();
   const delegationStatus = getDelegationStatus();
   const isNoWalletConnected = delegationStatus === "no-wallet-connected";
   const isNoDelegation = delegationStatus === "no-delegation";
@@ -145,13 +152,6 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   const isDelegator = delegationStatus === "delegator";
   const delegatorAddress = isDelegate ? getDelegatorAddress() : undefined;
   const delegateAddress = getDelegateAddress();
-  const pendingReceivedRequestsToBeDelegate =
-    getPendingReceivedRequestsToBeDelegate();
-  const hasPendingReceivedRequestsToBeDelegate =
-    pendingReceivedRequestsToBeDelegate.length > 0;
-  const pendingSentRequestsToBeDelegate = getPendingSentRequestsToBeDelegate();
-  const hasPendingSentRequestsToBeDelegate =
-    getHasPendingSentRequestsToBeDelegate();
 
   const getDelegationDataLoading = useCallback(() => {
     return (

--- a/contexts/DelegationContext.tsx
+++ b/contexts/DelegationContext.tsx
@@ -21,6 +21,10 @@ import {
 import { createContext, ReactNode } from "react";
 import { DelegationEventT, DelegationStatusT } from "types";
 export interface DelegationContextState {
+  delegationStatus: DelegationStatusT;
+  isDelegate: boolean;
+  isDelegator: boolean;
+  delegatorAddress: string | undefined;
   getDelegationStatus: () => DelegationStatusT;
   getPendingReceivedRequestsToBeDelegate: () => DelegationEventT[];
   getHasPendingReceivedRequestsToBeDelegate: () => boolean;
@@ -39,6 +43,10 @@ export interface DelegationContextState {
 }
 
 export const defaultDelegationContextState: DelegationContextState = {
+  delegationStatus: "no-wallet-connected",
+  isDelegate: false,
+  isDelegator: false,
+  delegatorAddress: undefined,
   getDelegationStatus: () => "no-wallet-connected",
   getPendingReceivedRequestsToBeDelegate: () => [],
   getHasPendingReceivedRequestsToBeDelegate: () => false,
@@ -124,6 +132,10 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
     data: { delegate },
   } = useStakerDetails();
   const { closePanel } = usePanelContext();
+  const delegationStatus = getDelegationStatus();
+  const isDelegate = delegationStatus === "delegate";
+  const isDelegator = delegationStatus === "delegator";
+  const delegatorAddress = isDelegate ? getDelegatorAddress() : undefined;
 
   function getDelegationDataLoading() {
     return (
@@ -358,6 +370,10 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   return (
     <DelegationContext.Provider
       value={{
+        delegationStatus,
+        isDelegate,
+        isDelegator,
+        delegatorAddress,
         getDelegationStatus,
         getDelegateAddress,
         getDelegatorAddress,

--- a/contexts/ErrorContext.tsx
+++ b/contexts/ErrorContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useState } from "react";
+import { createContext, ReactNode, useMemo, useState } from "react";
 import { ErrorOriginT } from "types";
 
 type ErrorMessagesT = Record<ErrorOriginT, string[]>;
@@ -61,16 +61,17 @@ export function ErrorProvider({ children }: { children: ReactNode }) {
     }));
   }
 
+  const value = useMemo(
+    () => ({
+      errorMessages,
+      addErrorMessage,
+      removeErrorMessage,
+      clearErrorMessages,
+    }),
+    [errorMessages]
+  );
+
   return (
-    <ErrorContext.Provider
-      value={{
-        errorMessages,
-        addErrorMessage,
-        removeErrorMessage,
-        clearErrorMessages,
-      }}
-    >
-      {children}
-    </ErrorContext.Provider>
+    <ErrorContext.Provider value={value}>{children}</ErrorContext.Provider>
   );
 }

--- a/contexts/NotificationsContext.tsx
+++ b/contexts/NotificationsContext.tsx
@@ -1,5 +1,5 @@
 import { events } from "helpers";
-import { createContext, ReactNode, useEffect, useState } from "react";
+import { createContext, ReactNode, useEffect, useMemo, useState } from "react";
 import {
   NotificationT,
   PendingNotificationT,
@@ -97,14 +97,17 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     setNotifications((prev) => ({ ...prev, [id]: undefined }));
   }
 
+  const value = useMemo(
+    () => ({
+      notifications,
+      removeNotification,
+      clearNotifications,
+    }),
+    [notifications]
+  );
+
   return (
-    <NotificationsContext.Provider
-      value={{
-        notifications,
-        removeNotification,
-        clearNotifications,
-      }}
-    >
+    <NotificationsContext.Provider value={value}>
       {children}
     </NotificationsContext.Provider>
   );

--- a/contexts/StakingContext.tsx
+++ b/contexts/StakingContext.tsx
@@ -12,7 +12,13 @@ import {
   useV1Rewards,
 } from "hooks";
 import { useIsOldDesignatedVotingAccount } from "hooks/queries/rewards/useIsOldDesignatedVotingAccount";
-import { createContext, ReactNode, useState } from "react";
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 import { OldDesignatedVotingAccountT, V1RewardsT } from "types";
 
 export interface StakingContextState {
@@ -124,7 +130,7 @@ export function StakingProvider({ children }: { children: ReactNode }) {
     setOutstandingRewards(calculatedOutstandingRewards);
   }
 
-  function getStakingDataLoading() {
+  const getStakingDataLoading = useCallback(() => {
     if (!address) return false;
 
     return (
@@ -135,9 +141,17 @@ export function StakingProvider({ children }: { children: ReactNode }) {
       unstakeCoolDownLoading ||
       rewardsCalculationInputsLoading
     );
-  }
+  }, [
+    address,
+    rewardsCalculationInputsLoading,
+    stakedBalanceLoading,
+    stakerDetailsLoading,
+    tokenAllowanceLoading,
+    unstakeCoolDownLoading,
+    unstakedBalanceLoading,
+  ]);
 
-  function getStakingDataFetching() {
+  const getStakingDataFetching = useCallback(() => {
     if (!address) return false;
 
     return (
@@ -148,30 +162,53 @@ export function StakingProvider({ children }: { children: ReactNode }) {
       unstakeCoolDownFetching ||
       rewardsCalculationInputsFetching
     );
-  }
+  }, [
+    address,
+    rewardsCalculationInputsFetching,
+    stakedBalanceFetching,
+    stakerDetailsFetching,
+    tokenAllowanceFetching,
+    unstakeCoolDownFetching,
+    unstakedBalanceFetching,
+  ]);
 
   const hasStaked = stakedBalance?.gt(0) ?? false;
 
+  const value = useMemo(
+    () => ({
+      hasStaked,
+      stakedBalance,
+      unstakedBalance,
+      pendingUnstake,
+      updateTime,
+      unstakeCoolDown,
+      outstandingRewards,
+      tokenAllowance,
+      canUnstakeTime,
+      v1Rewards,
+      oldDesignatedVotingAccount,
+      getStakingDataLoading,
+      getStakingDataFetching,
+      setAddressOverride,
+    }),
+    [
+      canUnstakeTime,
+      getStakingDataFetching,
+      getStakingDataLoading,
+      hasStaked,
+      oldDesignatedVotingAccount,
+      outstandingRewards,
+      pendingUnstake,
+      stakedBalance,
+      tokenAllowance,
+      unstakeCoolDown,
+      unstakedBalance,
+      updateTime,
+      v1Rewards,
+    ]
+  );
+
   return (
-    <StakingContext.Provider
-      value={{
-        hasStaked,
-        stakedBalance,
-        unstakedBalance,
-        pendingUnstake,
-        updateTime,
-        unstakeCoolDown,
-        outstandingRewards,
-        tokenAllowance,
-        canUnstakeTime,
-        v1Rewards,
-        oldDesignatedVotingAccount,
-        getStakingDataLoading,
-        getStakingDataFetching,
-        setAddressOverride,
-      }}
-    >
-      {children}
-    </StakingContext.Provider>
+    <StakingContext.Provider value={value}>{children}</StakingContext.Provider>
   );
 }

--- a/contexts/StakingContext.tsx
+++ b/contexts/StakingContext.tsx
@@ -16,6 +16,7 @@ import { createContext, ReactNode, useState } from "react";
 import { OldDesignatedVotingAccountT, V1RewardsT } from "types";
 
 export interface StakingContextState {
+  hasStaked: boolean;
   stakedBalance: BigNumber | undefined;
   unstakedBalance: BigNumber | undefined;
   pendingUnstake: BigNumber | undefined;
@@ -32,6 +33,7 @@ export interface StakingContextState {
 }
 
 export const defaultStakingContextState: StakingContextState = {
+  hasStaked: false,
   stakedBalance: undefined,
   unstakedBalance: undefined,
   pendingUnstake: undefined,
@@ -148,9 +150,12 @@ export function StakingProvider({ children }: { children: ReactNode }) {
     );
   }
 
+  const hasStaked = stakedBalance?.gt(0) ?? false;
+
   return (
     <StakingContext.Provider
       value={{
+        hasStaked,
         stakedBalance,
         unstakedBalance,
         pendingUnstake,

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -1,14 +1,14 @@
 import { WalletState } from "@web3-onboard/core";
 import { Account } from "@web3-onboard/core/dist/types";
 import { BigNumber } from "ethers";
+import { config } from "helpers/config";
 import {
   useAccountDetails,
   useUserVotingAndStakingDetails,
   useWalletContext,
 } from "hooks";
-import { createContext, ReactNode, useState } from "react";
-import { VoteHistoryByKeyT, SigningKey } from "types";
-import { config } from "helpers/config";
+import { ReactNode, createContext, useMemo, useState } from "react";
+import { SigningKey, VoteHistoryByKeyT } from "types";
 
 export interface UserContextState {
   connectedWallet: WalletState | undefined;
@@ -84,31 +84,48 @@ export function UserProvider({ children }: { children: ReactNode }) {
   const signingKey = signingKeys[address];
   const correctChainConnected = connectedChainId === config.chainId;
 
-  return (
-    <UserContext.Provider
-      value={{
-        connectedWallet,
-        account,
-        address,
-        truncatedAddress,
-        walletIcon,
-        apr,
-        countReveals,
-        countNoVotes,
-        countWrongVotes,
-        countCorrectVotes,
-        cumulativeCalculatedSlash,
-        cumulativeCalculatedSlashPercentage,
-        voteHistoryByKey,
-        userDataLoading,
-        userDataFetching,
-        signingKey,
-        hasSigningKey: !!signingKey,
-        correctChainConnected,
-        setAddressOverride,
-      }}
-    >
-      {children}
-    </UserContext.Provider>
+  const value = useMemo(
+    () => ({
+      connectedWallet,
+      account,
+      address,
+      truncatedAddress,
+      walletIcon,
+      apr,
+      countReveals,
+      countNoVotes,
+      countWrongVotes,
+      countCorrectVotes,
+      cumulativeCalculatedSlash,
+      cumulativeCalculatedSlashPercentage,
+      voteHistoryByKey,
+      userDataLoading,
+      userDataFetching,
+      signingKey,
+      hasSigningKey: !!signingKey,
+      correctChainConnected,
+      setAddressOverride,
+    }),
+    [
+      account,
+      address,
+      apr,
+      connectedWallet,
+      correctChainConnected,
+      countCorrectVotes,
+      countNoVotes,
+      countReveals,
+      countWrongVotes,
+      cumulativeCalculatedSlash,
+      cumulativeCalculatedSlashPercentage,
+      signingKey,
+      truncatedAddress,
+      userDataFetching,
+      userDataLoading,
+      voteHistoryByKey,
+      walletIcon,
+    ]
   );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
 }

--- a/contexts/VoteTimingContext.tsx
+++ b/contexts/VoteTimingContext.tsx
@@ -4,7 +4,7 @@ import {
   computeRoundId,
   getPhase,
 } from "helpers";
-import { createContext, ReactNode, useState } from "react";
+import { ReactNode, createContext, useMemo, useState } from "react";
 
 export interface VoteTimingContextState {
   isCommit: boolean;
@@ -55,23 +55,34 @@ export function VoteTimingProvider({ children }: { children: ReactNode }) {
   const isCommit = phase === "commit";
   const isReveal = phase === "reveal";
 
+  const value = useMemo(
+    () => ({
+      isCommit,
+      isReveal,
+      roundId,
+      setRoundId,
+      phase,
+      setPhase,
+      phaseEndTimeMilliseconds,
+      setPhaseEndTimeMilliseconds,
+      phaseEndTimeAsDate,
+      setPhaseEndTimeAsDate,
+      millisecondsUntilPhaseEnds,
+      setMillisecondsUntilPhaseEnds,
+    }),
+    [
+      isCommit,
+      isReveal,
+      millisecondsUntilPhaseEnds,
+      phase,
+      phaseEndTimeAsDate,
+      phaseEndTimeMilliseconds,
+      roundId,
+    ]
+  );
+
   return (
-    <VoteTimingContext.Provider
-      value={{
-        isCommit,
-        isReveal,
-        roundId,
-        setRoundId,
-        phase,
-        setPhase,
-        phaseEndTimeMilliseconds,
-        setPhaseEndTimeMilliseconds,
-        phaseEndTimeAsDate,
-        setPhaseEndTimeAsDate,
-        millisecondsUntilPhaseEnds,
-        setMillisecondsUntilPhaseEnds,
-      }}
-    >
+    <VoteTimingContext.Provider value={value}>
       {children}
     </VoteTimingContext.Provider>
   );

--- a/contexts/VoteTimingContext.tsx
+++ b/contexts/VoteTimingContext.tsx
@@ -7,6 +7,8 @@ import {
 import { createContext, ReactNode, useState } from "react";
 
 export interface VoteTimingContextState {
+  isCommit: boolean;
+  isReveal: boolean;
   roundId: number;
   setRoundId: (roundId: number) => void;
   phase: "commit" | "reveal";
@@ -20,6 +22,8 @@ export interface VoteTimingContextState {
 }
 
 export const defaultVoteTimingContextState: VoteTimingContextState = {
+  isCommit: false,
+  isReveal: false,
   roundId: computeRoundId(),
   setRoundId: () => null,
   phase: getPhase(),
@@ -48,10 +52,14 @@ export function VoteTimingProvider({ children }: { children: ReactNode }) {
   const [millisecondsUntilPhaseEnds, setMillisecondsUntilPhaseEnds] = useState(
     defaultVoteTimingContextState.millisecondsUntilPhaseEnds
   );
+  const isCommit = phase === "commit";
+  const isReveal = phase === "reveal";
 
   return (
     <VoteTimingContext.Provider
       value={{
+        isCommit,
+        isReveal,
         roundId,
         setRoundId,
         phase,

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -56,7 +56,6 @@ export interface VotesContextState {
   encryptedVotes: EncryptedVotesByKeyT;
   decryptedVotes: DecryptedVotesByKeyT | undefined;
   contentfulData: ContentfulDataByKeyT;
-  getActivityStatus: () => ActivityStatusT;
   getUserDependentIsLoading: () => boolean;
   getUserIndependentIsLoading: () => boolean;
   getIsLoading: () => boolean;
@@ -92,7 +91,6 @@ export const defaultVotesContextState: VotesContextState = {
   encryptedVotes: {},
   decryptedVotes: {},
   contentfulData: {},
-  getActivityStatus: () => "past",
   getUserDependentIsLoading: () => false,
   getUserIndependentIsLoading: () => false,
   getIsLoading: () => false,
@@ -347,7 +345,6 @@ export function VotesProvider({ children }: { children: ReactNode }) {
         encryptedVotes,
         decryptedVotes,
         contentfulData,
-        getActivityStatus,
         getUserDependentIsLoading,
         getUserIndependentIsLoading,
         getIsLoading,

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -35,6 +35,13 @@ import {
 } from "types";
 
 export interface VotesContextState {
+  voteListsByActivityStatus: Record<ActivityStatusT, VoteT[]>;
+  hasPreviouslyCommittedAll: boolean;
+  votesToReveal: VoteT[];
+  activityStatus: ActivityStatusT;
+  isActive: boolean;
+  isUpcoming: boolean;
+  isPast: boolean;
   hasActiveVotes: boolean | undefined;
   activeVotesByKey: PriceRequestByKeyT;
   activeVoteList: VoteT[];
@@ -60,6 +67,17 @@ export interface VotesContextState {
 }
 
 export const defaultVotesContextState: VotesContextState = {
+  voteListsByActivityStatus: {
+    active: [],
+    upcoming: [],
+    past: [],
+  },
+  hasPreviouslyCommittedAll: false,
+  votesToReveal: [],
+  activityStatus: "past",
+  isActive: false,
+  isUpcoming: false,
+  isPast: false,
   hasActiveVotes: undefined,
   activeVotesByKey: {},
   activeVoteList: [],
@@ -288,9 +306,33 @@ export function VotesProvider({ children }: { children: ReactNode }) {
   const pastVoteList = getVotesWithData(pastVotesByKey, decryptedVotes);
   const pastVotesV2List = pastVoteList.filter((vote) => !vote.isV1);
 
+  const activityStatus = getActivityStatus();
+  const isActive = activityStatus === "active";
+  const isUpcoming = activityStatus === "upcoming";
+  const isPast = activityStatus === "past";
+  const votesToReveal = activeVoteList.filter(
+    ({ isCommitted, decryptedVote, isRevealed, canReveal }) =>
+      isCommitted && !!decryptedVote && isRevealed === false && canReveal
+  );
+  const voteListsByActivityStatus = {
+    active: activeVoteList,
+    upcoming: upcomingVoteList,
+    past: pastVoteList,
+  };
+  const hasPreviouslyCommittedAll =
+    activeVoteList.filter(({ decryptedVote }) => decryptedVote).length ===
+    activeVoteList.length;
+
   return (
     <VotesContext.Provider
       value={{
+        hasPreviouslyCommittedAll,
+        voteListsByActivityStatus,
+        votesToReveal,
+        activityStatus,
+        isActive,
+        isUpcoming,
+        isPast,
         hasActiveVotes,
         activeVotesByKey,
         activeVoteList,

--- a/contexts/WalletContext.tsx
+++ b/contexts/WalletContext.tsx
@@ -4,7 +4,13 @@ import { ethers } from "ethers";
 import { getSavedSigningKeys, initOnboard } from "helpers";
 import { config } from "helpers/config";
 import { useSign } from "hooks";
-import { createContext, ReactNode, useState } from "react";
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 import { SigningKeys } from "types";
 
 export interface WalletContextState {
@@ -60,11 +66,13 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     signer,
     setSigningKeys
   );
-  function setCorrectChain() {
+
+  const setCorrectChain = useCallback(() => {
     setChain({ chainId: config.onboardConfig.id }).catch((err) =>
       console.error("Error Setting Chain:", err)
     );
-  }
+  }, [setChain]);
+
   const connectedChainId = connectedChain
     ? parseInt(connectedChain.id)
     : undefined;
@@ -73,26 +81,38 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     ? connectedChainId !== parseInt(config.onboardConfig.id)
     : false;
 
+  const value = useMemo(
+    () => ({
+      isWrongChain,
+      onboard,
+      setOnboard,
+      provider,
+      setProvider,
+      signer,
+      setSigner,
+      signingKeys,
+      setSigningKeys,
+      sign,
+      isSigning,
+      connectedChainId,
+      setCorrectChain,
+      isSettingChain,
+    }),
+    [
+      connectedChainId,
+      isSettingChain,
+      isSigning,
+      isWrongChain,
+      onboard,
+      provider,
+      setCorrectChain,
+      sign,
+      signer,
+      signingKeys,
+    ]
+  );
+
   return (
-    <WalletContext.Provider
-      value={{
-        isWrongChain,
-        onboard,
-        setOnboard,
-        provider,
-        setProvider,
-        signer,
-        setSigner,
-        signingKeys,
-        setSigningKeys,
-        sign,
-        isSigning,
-        connectedChainId,
-        setCorrectChain,
-        isSettingChain,
-      }}
-    >
-      {children}
-    </WalletContext.Provider>
+    <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
   );
 }

--- a/hooks/queries/delegation/useCommittedVotesForDelegator.ts
+++ b/hooks/queries/delegation/useCommittedVotesForDelegator.ts
@@ -15,12 +15,9 @@ export function useCommittedVotesForDelegator() {
   const { address } = useUserContext();
   const { isWrongChain } = useWalletContext();
   const { voting } = useContractsContext();
-  const { getDelegationStatus, getDelegatorAddress } = useDelegationContext();
+  const { delegatorAddress, isDelegate } = useDelegationContext();
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
-
-  const status = getDelegationStatus();
-  const delegatorAddress = getDelegatorAddress();
 
   const queryResult = useQuery(
     [committedVotesForDelegatorKey, address, delegatorAddress, roundId],
@@ -29,12 +26,8 @@ export function useCommittedVotesForDelegator() {
         ? getCommittedVotes(voting, delegatorAddress, roundId)
         : {},
     {
-      refetchInterval: status === "delegate" ? oneMinute : false,
-      enabled:
-        !!address &&
-        !isWrongChain &&
-        !!delegatorAddress &&
-        status === "delegate",
+      refetchInterval: isDelegate ? oneMinute : false,
+      enabled: !!address && !isWrongChain && !!delegatorAddress && isDelegate,
       initialData: {},
       onError,
     }

--- a/stories/BaseComponents/navigation/Header.stories.tsx
+++ b/stories/BaseComponents/navigation/Header.stories.tsx
@@ -22,7 +22,7 @@ export default {
     (Story, { args }) => {
       const mockDelegationContextState: DelegationContextState = {
         ...defaultDelegationContextState,
-        getDelegationStatus: () => args.delegationStatus ?? "no-delegation",
+        delegationStatus: args.delegationStatus ?? "no-delegation",
       };
 
       return (

--- a/stories/BaseComponents/navigation/Panel.stories.tsx
+++ b/stories/BaseComponents/navigation/Panel.stories.tsx
@@ -149,13 +149,12 @@ const votesDecorator: Decorator<Props> = (Story, { args }) => {
 const delegationDecorator: Decorator<Props> = (Story, { args }) => {
   const mockDelegationContextState: DelegationContextState = {
     ...defaultDelegationContextState,
-    getDelegationStatus: () => args.delegationStatus ?? "no-delegation",
-    getPendingSentRequestsToBeDelegate: () =>
-      args.pendingSentRequestsToBeDelegate ?? [],
-    getPendingReceivedRequestsToBeDelegate: () =>
+    delegationStatus: args.delegationStatus ?? "no-delegation",
+    pendingSentRequestsToBeDelegate: args.pendingSentRequestsToBeDelegate ?? [],
+    pendingReceivedRequestsToBeDelegate:
       args.pendingReceivedRequestsToBeDelegate ?? [],
-    getDelegateAddress: () => args.delegateAddress ?? zeroAddress,
-    getDelegatorAddress: () => args.delegatorAddress ?? zeroAddress,
+    delegateAddress: args.delegateAddress ?? zeroAddress,
+    delegatorAddress: args.delegatorAddress ?? zeroAddress,
   };
 
   return (

--- a/stories/Pages/VotePage/VotePage.stories.tsx
+++ b/stories/Pages/VotePage/VotePage.stories.tsx
@@ -56,7 +56,7 @@ const Template: Story = {
       activeVoteList: args.activeVotes ?? [],
       upcomingVoteList: args.upcomingVotes ?? [],
       pastVoteList: args.pastVotes ?? [],
-      getActivityStatus: () => args.activityStatus ?? "past",
+      activityStatus: args.activityStatus ?? "past",
     };
 
     return (


### PR DESCRIPTION
### Motivation

When we use an object as the `value` prop of a react context, that object is recreated on every render. This has performance implications. From the [react docs](https://react.dev/reference/react/useContext#optimizing-re-renders-when-passing-objects-and-functions):

"Whenever MyApp re-renders (for example, on a route update), this will be a different object pointing at a different function, so React will also have to re-render all components deep in the tree that call useContext(AuthContext)."

Here's a codesandbox showing this problem:

https://codesandbox.io/s/jj611c?file=/App.js&utm_medium=sandpack

The solution is to wrap the `value` in a call to `useMemo`.

I've implemented that solution here where applicable, including memoizing the dependencies of those values as well.

I also cleaned up the values returned by the contexts to make them more useful and remove redundant recalculation of derived values.

### Changes

* Memoize context values
* Remove redundant getter functions
* Add helper values that can be used instead of getter functions