### PR TITLE
improve: upgrade react query and add linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:@tanstack/eslint-plugin-query/recommended",
     "prettier"
   ],
   "plugins": ["@typescript-eslint", "prettier"],
@@ -22,6 +23,8 @@
         "varsIgnorePattern": "^_",
         "caughtErrorsIgnorePattern": "^_"
       }
-    ]
+    ],
+    "@tanstack/query/exhaustive-deps": "off",
+    "@tanstack/query/prefer-query-object-syntax": "warn"
   }
 }

--- a/hooks/helpers/useSign.ts
+++ b/hooks/helpers/useSign.ts
@@ -7,7 +7,8 @@ export function useSign(
   signer: ethers.Signer | null | undefined,
   setSigningKeys: (signingKeys: SigningKeys) => void
 ) {
-  return useMutation(async () => (signer ? sign(signer) : {}), {
+  return useMutation({
+    mutationFn: async () => (signer ? sign(signer) : {}),
     onError: (error) => console.error("Error signing:", error),
     onSuccess: setSigningKeys,
   });

--- a/hooks/mutations/delegation/useAcceptReceivedRequestToBeDelegate.ts
+++ b/hooks/mutations/delegation/useAcceptReceivedRequestToBeDelegate.ts
@@ -8,7 +8,8 @@ export function useAcceptReceivedRequestToBeDelegate() {
   const { onError, clearErrors } = useHandleError();
   const queryClient = useQueryClient();
 
-  const { mutate, isLoading } = useMutation(setDelegator, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: setDelegator,
     onError,
     onSuccess: (_data, { delegatorAddress }) => {
       clearErrors();

--- a/hooks/mutations/delegation/useCancelSentRequestToBeDelegate.ts
+++ b/hooks/mutations/delegation/useCancelSentRequestToBeDelegate.ts
@@ -9,7 +9,8 @@ export function useCancelSentRequestToBeDelegate() {
   const { onError, clearErrors } = useHandleError();
   const queryClient = useQueryClient();
 
-  const { mutate, isLoading } = useMutation(removeDelegate, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: removeDelegate,
     onError,
     onSuccess: () => {
       clearErrors();

--- a/hooks/mutations/delegation/useIgnoreReceivedRequestToBeDelegate.ts
+++ b/hooks/mutations/delegation/useIgnoreReceivedRequestToBeDelegate.ts
@@ -8,7 +8,8 @@ export function useIgnoreReceivedRequestToBeDelegate() {
   const { onError, clearErrors } = useHandleError();
   const queryClient = useQueryClient();
 
-  const { mutate, isLoading } = useMutation(ignoreReceivedRequestToBeDelegate, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: ignoreReceivedRequestToBeDelegate,
     onError,
     onSuccess: (_data, { delegatorAddress }) => {
       clearErrors();

--- a/hooks/mutations/delegation/useSendRequestToBeDelegate.ts
+++ b/hooks/mutations/delegation/useSendRequestToBeDelegate.ts
@@ -9,7 +9,8 @@ export function useSendRequestToBeDelegate(errorOrigin?: ErrorOriginT) {
   const { onError, clearErrors } = useHandleError({ errorOrigin });
   const queryClient = useQueryClient();
 
-  const { mutate, isLoading } = useMutation(setDelegate, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: setDelegate,
     onError,
     onSuccess: ({ transactionHash }, { delegateAddress }) => {
       clearErrors();

--- a/hooks/mutations/delegation/useTerminateRelationshipWithDelegate.ts
+++ b/hooks/mutations/delegation/useTerminateRelationshipWithDelegate.ts
@@ -10,7 +10,8 @@ export function useTerminateRelationshipWithDelegate() {
   const queryClient = useQueryClient();
   const { onError, clearErrors } = useHandleError();
 
-  const { mutate, isLoading } = useMutation(removeDelegate, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: removeDelegate,
     onError,
     onSuccess: () => {
       clearErrors();

--- a/hooks/mutations/delegation/useTerminateRelationshipWithDelegator.ts
+++ b/hooks/mutations/delegation/useTerminateRelationshipWithDelegator.ts
@@ -8,7 +8,8 @@ export function useTerminateRelationshipWithDelegator() {
   const queryClient = useQueryClient();
   const { onError, clearErrors } = useHandleError();
 
-  const { mutate, isLoading } = useMutation(removeDelegator, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: removeDelegator,
     onError,
     onSuccess: () => {
       clearErrors();

--- a/hooks/mutations/rewards/useWithdrawAndRestake.ts
+++ b/hooks/mutations/rewards/useWithdrawAndRestake.ts
@@ -15,7 +15,8 @@ export function useWithdrawAndRestake(errorOrigin?: ErrorOriginT) {
   const { outstandingRewards } = useStakingContext();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 
-  const { mutate, isLoading } = useMutation(withdrawAndRestake, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: withdrawAndRestake,
     onError,
     onSuccess: () => {
       clearErrors();

--- a/hooks/mutations/rewards/useWithdrawRewards.ts
+++ b/hooks/mutations/rewards/useWithdrawRewards.ts
@@ -15,7 +15,8 @@ export function useWithdrawRewards(errorOrigin?: ErrorOriginT) {
   const { outstandingRewards } = useStakingContext();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 
-  const { mutate, isLoading } = useMutation(withdrawRewards, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: withdrawRewards,
     onError,
     onSuccess: () => {
       clearErrors();

--- a/hooks/mutations/rewards/useWithdrawV1Rewards.ts
+++ b/hooks/mutations/rewards/useWithdrawV1Rewards.ts
@@ -11,7 +11,8 @@ export function useWithdrawV1Rewards(errorOrigin: ErrorOriginT) {
   const { address } = useUserContext();
   const [{ connectedChain }] = useSetChain();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
-  const { mutate, isLoading } = useMutation(withdrawV1Rewards, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: withdrawV1Rewards,
     onError,
     onSuccess: (_receipt, { totalRewards }) => {
       clearErrors();

--- a/hooks/mutations/staking/useApprove.ts
+++ b/hooks/mutations/staking/useApprove.ts
@@ -10,7 +10,8 @@ export function useApprove(errorOrigin?: ErrorOriginT) {
   const { address } = useAccountDetails();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 
-  const { mutate, isLoading } = useMutation(approve, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: approve,
     onError,
     onSuccess: (_data, { approveAmount }) => {
       clearErrors();

--- a/hooks/mutations/staking/useExecuteUnstake.ts
+++ b/hooks/mutations/staking/useExecuteUnstake.ts
@@ -19,7 +19,8 @@ export function useExecuteUnstake(errorOrigin?: ErrorOriginT) {
   const { address } = useAccountDetails();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 
-  const { mutate, isLoading } = useMutation(executeUnstake, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: executeUnstake,
     onError,
     onSuccess: (_contractReceipt, { pendingUnstake }) => {
       clearErrors();

--- a/hooks/mutations/staking/useRequestUnstake.ts
+++ b/hooks/mutations/staking/useRequestUnstake.ts
@@ -15,7 +15,8 @@ export function useRequestUnstake(errorOrigin?: ErrorOriginT) {
   const { address } = useAccountDetails();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 
-  const { mutate, isLoading } = useMutation(requestUnstake, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: requestUnstake,
     onError,
     onSuccess: (_contractReceipt, { unstakeAmount }) => {
       clearErrors();

--- a/hooks/mutations/staking/useStake.ts
+++ b/hooks/mutations/staking/useStake.ts
@@ -10,7 +10,8 @@ export function useStake(errorOrigin?: ErrorOriginT) {
   const { address } = useAccountDetails();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 
-  const { mutate, isLoading } = useMutation(stake, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: stake,
     onError,
     onSuccess: (_data, { stakeAmount }) => {
       clearErrors();

--- a/hooks/mutations/votes/useCommitVotes.ts
+++ b/hooks/mutations/votes/useCommitVotes.ts
@@ -10,7 +10,8 @@ export function useCommitVotes() {
   const { roundId } = useVoteTimingContext();
   const { onError, clearErrors } = useHandleError();
 
-  const { mutate, isLoading } = useMutation(commitVotes, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: commitVotes,
     onError,
     onSuccess: (data, { formattedVotes }) => {
       clearErrors();

--- a/hooks/mutations/votes/useRevealVotes.ts
+++ b/hooks/mutations/votes/useRevealVotes.ts
@@ -10,7 +10,8 @@ export function useRevealVotes() {
   const { roundId } = useVoteTimingContext();
   const { onError, clearErrors } = useHandleError();
 
-  const { mutate, isLoading } = useMutation(revealVotes, {
+  const { mutate, isLoading } = useMutation({
+    mutationFn: revealVotes,
     onError,
     onSuccess: (data, { votesToReveal }) => {
       clearErrors();

--- a/hooks/queries/delegation/useCommittedVotesForDelegator.ts
+++ b/hooks/queries/delegation/useCommittedVotesForDelegator.ts
@@ -19,19 +19,22 @@ export function useCommittedVotesForDelegator() {
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [committedVotesForDelegatorKey, address, delegatorAddress, roundId],
-    async (): Promise<VoteExistsByKeyT> =>
+  const queryResult = useQuery({
+    queryKey: [
+      committedVotesForDelegatorKey,
+      address,
+      delegatorAddress,
+      roundId,
+    ],
+    queryFn: async (): Promise<VoteExistsByKeyT> =>
       delegatorAddress
         ? getCommittedVotes(voting, delegatorAddress, roundId)
         : {},
-    {
-      refetchInterval: isDelegate ? oneMinute : false,
-      enabled: !!address && !isWrongChain && !!delegatorAddress && isDelegate,
-      initialData: {},
-      onError,
-    }
-  );
+    refetchInterval: isDelegate ? oneMinute : false,
+    enabled: !!address && !isWrongChain && !!delegatorAddress && isDelegate,
+    initialData: {},
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/delegation/useDelegateToStaker.ts
+++ b/hooks/queries/delegation/useDelegateToStaker.ts
@@ -19,14 +19,12 @@ export function useDelegateToStaker() {
   const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [delegateToStakerKey, address],
-    () => getDelegateToStaker(voting, delegate ?? zeroAddress),
-    {
-      enabled: !!address && !isWrongChain,
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [delegateToStakerKey, address],
+    queryFn: () => getDelegateToStaker(voting, delegate ?? zeroAddress),
+    enabled: !!address && !isWrongChain,
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/delegation/useDelegatorSetEventsForDelegate.ts
+++ b/hooks/queries/delegation/useDelegatorSetEventsForDelegate.ts
@@ -14,14 +14,12 @@ export function useDelegatorSetEventsForDelegate() {
   const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [delegatorSetEventForDelegateKey, address],
-    () => getDelegatorSetEvents(voting, address, "delegate"),
-    {
-      enabled: !!address && !isWrongChain,
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [delegatorSetEventForDelegateKey, address],
+    queryFn: () => getDelegatorSetEvents(voting, address, "delegate"),
+    enabled: !!address && !isWrongChain,
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/delegation/useDelegatorSetEventsForDelegator.ts
+++ b/hooks/queries/delegation/useDelegatorSetEventsForDelegator.ts
@@ -14,14 +14,12 @@ export function useDelegatorSetEventsForDelegator() {
   const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [delegatorSetEventsForDelegatorKey, address],
-    () => getDelegatorSetEvents(voting, address, "delegator"),
-    {
-      enabled: !!address && !isWrongChain,
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [delegatorSetEventsForDelegatorKey, address],
+    queryFn: () => getDelegatorSetEvents(voting, address, "delegator"),
+    enabled: !!address && !isWrongChain,
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/delegation/useIgnoredRequestToBeDelegateAddresses.ts
+++ b/hooks/queries/delegation/useIgnoredRequestToBeDelegateAddresses.ts
@@ -8,14 +8,12 @@ export function useIgnoredRequestToBeDelegateAddresses() {
   const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [ignoredRequestToBeDelegateAddressesKey, address],
-    () => getIgnoredRequestToBeDelegateAddresses(address),
-    {
-      enabled: !!address && !isWrongChain,
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [ignoredRequestToBeDelegateAddressesKey, address],
+    queryFn: () => getIgnoredRequestToBeDelegateAddresses(address),
+    enabled: !!address && !isWrongChain,
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/delegation/useReceivedRequestsToBeDelegate.ts
+++ b/hooks/queries/delegation/useReceivedRequestsToBeDelegate.ts
@@ -16,14 +16,12 @@ export function useReceivedRequestsToBeDelegate() {
   const { onError } = useHandleError({ isDataFetching: true });
   const newRequests = useNewReceivedRequestsToBeDelegate();
 
-  const queryResult = useQuery(
-    [receivedRequestsToBeDelegateKey, address, newRequests],
-    () => getDelegateSetEvents(voting, address, "delegate"),
-    {
-      enabled: !!address && !isWrongChain,
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [receivedRequestsToBeDelegateKey, address, newRequests],
+    queryFn: () => getDelegateSetEvents(voting, address, "delegate"),
+    enabled: !!address && !isWrongChain,
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/delegation/useSentRequestsToBeDelegate.ts
+++ b/hooks/queries/delegation/useSentRequestsToBeDelegate.ts
@@ -14,14 +14,12 @@ export function useSentRequestsToBeDelegate() {
   const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [sentRequestsToBeDelegateKey, address],
-    () => getDelegateSetEvents(voting, address, "delegator"),
-    {
-      enabled: !!address && !isWrongChain,
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [sentRequestsToBeDelegateKey, address],
+    queryFn: () => getDelegateSetEvents(voting, address, "delegator"),
+    enabled: !!address && !isWrongChain,
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/delegation/useVoterFromDelegate.ts
+++ b/hooks/queries/delegation/useVoterFromDelegate.ts
@@ -8,13 +8,11 @@ export function useVoterFromDelegate() {
   const { address } = useUserContext();
   const { isWrongChain } = useWalletContext();
 
-  const queryResult = useQuery(
-    [voterFromDelegateKey, address],
-    () => getVoterFromDelegate(voting, address),
-    {
-      enabled: !!address && !isWrongChain,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [voterFromDelegateKey, address],
+    queryFn: () => getVoterFromDelegate(voting, address),
+    enabled: !!address && !isWrongChain,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/rewards/useGlobals.ts
+++ b/hooks/queries/rewards/useGlobals.ts
@@ -4,7 +4,9 @@ import { getGlobals } from "graph";
 import { config } from "helpers/config";
 
 export function useGlobals() {
-  return useQuery(["globals"], getGlobals, {
+  return useQuery({
+    queryKey: ["globals"],
+    queryFn: getGlobals,
     refetchInterval: oneMinute,
     initialData: {
       annualPercentageReturn: 0,

--- a/hooks/queries/rewards/useRewardsCalculationInputs.ts
+++ b/hooks/queries/rewards/useRewardsCalculationInputs.ts
@@ -16,22 +16,20 @@ export function useRewardsCalculationInputs(addressOverride?: string) {
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
 
-  const queryResult = useQuery(
-    [rewardsCalculationInputsKey, address],
-    () => getRewardsCalculationInputs(voting),
-    {
-      refetchInterval: oneMinute,
-      enabled: !!address && !isWrongChain,
-      initialData: {
-        emissionRate: BigNumber.from(0),
-        rewardPerTokenStored: BigNumber.from(0),
-        cumulativeStake: BigNumber.from(0),
-        updateTime: BigNumber.from(Date.now()),
-        updateTimeSeconds: BigNumber.from(Math.floor(Date.now() / 1000)),
-      },
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [rewardsCalculationInputsKey, address],
+    queryFn: () => getRewardsCalculationInputs(voting),
+    refetchInterval: oneMinute,
+    enabled: !!address && !isWrongChain,
+    initialData: {
+      emissionRate: BigNumber.from(0),
+      rewardPerTokenStored: BigNumber.from(0),
+      cumulativeStake: BigNumber.from(0),
+      updateTime: BigNumber.from(Date.now()),
+      updateTimeSeconds: BigNumber.from(Math.floor(Date.now() / 1000)),
+    },
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/staking/useStakerDetails.ts
+++ b/hooks/queries/staking/useStakerDetails.ts
@@ -24,13 +24,11 @@ export function useStakerDetails(addressOverride?: string) {
   const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
-  return useQuery(
-    [stakerDetailsKey, address],
-    () => (address ? getStakerDetails(voting, address) : initialData),
-    {
-      enabled: !!address && !isWrongChain,
-      initialData,
-      onError,
-    }
-  );
+  return useQuery({
+    queryKey: [stakerDetailsKey, address],
+    queryFn: () => (address ? getStakerDetails(voting, address) : initialData),
+    enabled: !!address && !isWrongChain,
+    initialData,
+    onError,
+  });
 }

--- a/hooks/queries/staking/useTokenAllowance.ts
+++ b/hooks/queries/staking/useTokenAllowance.ts
@@ -15,15 +15,13 @@ export function useTokenAllowance() {
   const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [tokenAllowanceKey, address],
-    () => getTokenAllowance(votingTokenWriter!, address),
-    {
-      enabled: !!address && !isWrongChain && !!votingTokenWriter,
-      initialData: BigNumber.from(0),
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [tokenAllowanceKey, address],
+    queryFn: () => getTokenAllowance(votingTokenWriter!, address),
+    enabled: !!address && !isWrongChain && !!votingTokenWriter,
+    initialData: BigNumber.from(0),
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/staking/useUnstakedBalance.ts
+++ b/hooks/queries/staking/useUnstakedBalance.ts
@@ -18,15 +18,14 @@ export function useUnstakedBalance(addressOverride?: string) {
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
 
-  const queryResult = useQuery(
-    [unstakedBalanceKey, address],
-    () => (address ? getUnstakedBalance(votingToken, address) : initialData),
-    {
-      enabled: !!address && !isWrongChain,
-      onError,
-      initialData,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [unstakedBalanceKey, address],
+    queryFn: () =>
+      address ? getUnstakedBalance(votingToken, address) : initialData,
+    enabled: !!address && !isWrongChain,
+    onError,
+    initialData,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/user/useDesignatedVotingV1Address.ts
+++ b/hooks/queries/user/useDesignatedVotingV1Address.ts
@@ -4,14 +4,12 @@ import { useWalletContext } from "hooks";
 
 export function useDesignatedVotingV1Address(address: string) {
   const { isWrongChain } = useWalletContext();
-  return useQuery(
-    ["designatedVotingV1Address", address],
-    () => getDesignatedVotingV1Address(address),
-    {
-      enabled: !!address && !isWrongChain,
-      initialData: undefined,
-      onError: (err) =>
-        console.error("Error fetching designated voting v1 address", err),
-    }
-  );
+  return useQuery({
+    queryKey: ["designatedVotingV1Address", address],
+    queryFn: () => getDesignatedVotingV1Address(address),
+    enabled: !!address && !isWrongChain,
+    initialData: undefined,
+    onError: (err) =>
+      console.error("Error fetching designated voting v1 address", err),
+  });
 }

--- a/hooks/queries/user/useUserVotingAndStakingDetails.ts
+++ b/hooks/queries/user/useUserVotingAndStakingDetails.ts
@@ -11,25 +11,23 @@ export function useUserVotingAndStakingDetails(addressOverride?: string) {
   const { onError } = useHandleError({ isDataFetching: true });
   const address = addressOverride || defaultAddress;
 
-  const queryResult = useQuery(
-    [userDataKey, address],
-    () => getUserData(address),
-    {
-      enabled: !!address && !isWrongChain && config.graphV2Enabled,
-      refetchInterval: oneMinute,
-      initialData: {
-        apr: BigNumber.from(0),
-        countReveals: BigNumber.from(0),
-        countNoVotes: BigNumber.from(0),
-        countWrongVotes: BigNumber.from(0),
-        countCorrectVotes: BigNumber.from(0),
-        cumulativeCalculatedSlash: BigNumber.from(0),
-        cumulativeCalculatedSlashPercentage: BigNumber.from(0),
-        voteHistoryByKey: {},
-      },
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [userDataKey, address],
+    queryFn: () => getUserData(address),
+    enabled: !!address && !isWrongChain && config.graphV2Enabled,
+    refetchInterval: oneMinute,
+    initialData: {
+      apr: BigNumber.from(0),
+      countReveals: BigNumber.from(0),
+      countNoVotes: BigNumber.from(0),
+      countWrongVotes: BigNumber.from(0),
+      countCorrectVotes: BigNumber.from(0),
+      cumulativeCalculatedSlash: BigNumber.from(0),
+      cumulativeCalculatedSlashPercentage: BigNumber.from(0),
+      voteHistoryByKey: {},
+    },
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/votes/useActiveVoteResults.ts
+++ b/hooks/queries/votes/useActiveVoteResults.ts
@@ -8,16 +8,14 @@ export function useActiveVoteResults() {
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [activeVoteResultsKey, roundId],
-    () => getActiveVoteResults(),
-    {
-      enabled: config.graphV2Enabled,
-      refetchInterval: oneMinute,
-      initialData: {},
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [activeVoteResultsKey, roundId],
+    queryFn: () => getActiveVoteResults(),
+    enabled: config.graphV2Enabled,
+    refetchInterval: oneMinute,
+    initialData: {},
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/votes/useActiveVotes.ts
+++ b/hooks/queries/votes/useActiveVotes.ts
@@ -19,19 +19,17 @@ export function useActiveVotes() {
     phase === "commit" &&
     phaseLengthMilliseconds - millisecondsUntilPhaseEnds < 30 * oneSecond;
 
-  const queryResult = useQuery(
-    [activeVotesKey, roundId],
-    () => getActiveVotes(voting),
-    {
-      refetchInterval: shouldRefetch ? 1000 : false,
-      initialData: {
-        activeVotes: {},
-        hasActiveVotes: false,
-      },
-      enabled: !isWrongChain,
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [activeVotesKey, roundId],
+    queryFn: () => getActiveVotes(voting),
+    refetchInterval: shouldRefetch ? 1000 : false,
+    initialData: {
+      activeVotes: {},
+      hasActiveVotes: false,
+    },
+    enabled: !isWrongChain,
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/votes/useCommittedVotes.ts
+++ b/hooks/queries/votes/useCommittedVotes.ts
@@ -16,15 +16,13 @@ export function useCommittedVotes() {
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [committedVotesKey, address, roundId],
-    () => getCommittedVotes(voting, address, roundId),
-    {
-      enabled: !!address && !isWrongChain,
-      initialData: {},
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [committedVotesKey, address, roundId],
+    queryFn: () => getCommittedVotes(voting, address, roundId),
+    enabled: !!address && !isWrongChain,
+    initialData: {},
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/votes/useCommittedVotesByCaller.ts
+++ b/hooks/queries/votes/useCommittedVotesByCaller.ts
@@ -16,15 +16,13 @@ export function useCommittedVotesByCaller() {
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [committedVotesKeyByCaller, address, roundId],
-    () => getCommittedVotesByCaller(voting, address, roundId),
-    {
-      enabled: !!address && !isWrongChain,
-      initialData: {},
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [committedVotesKeyByCaller, address, roundId],
+    queryFn: () => getCommittedVotesByCaller(voting, address, roundId),
+    enabled: !!address && !isWrongChain,
+    initialData: {},
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/votes/useContentfulData.ts
+++ b/hooks/queries/votes/useContentfulData.ts
@@ -73,16 +73,14 @@ export function useContentfulData() {
     }
   }
 
-  const queryResult = useQuery(
-    [contentfulDataKey, activeVotes, upcomingVotes, pastVotes],
-    () => getContentfulData(adminProposalNumbersByKey),
-    {
-      refetchInterval: oneMinute,
-      enabled: !!contentfulClient,
-      initialData: {},
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [contentfulDataKey, activeVotes, upcomingVotes, pastVotes],
+    queryFn: () => getContentfulData(adminProposalNumbersByKey),
+    refetchInterval: oneMinute,
+    enabled: !!contentfulClient,
+    initialData: {},
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/votes/useDecryptedVotes.ts
+++ b/hooks/queries/votes/useDecryptedVotes.ts
@@ -19,15 +19,13 @@ export function useDecryptedVotes(roundId?: number) {
   const { data: encryptedVotes } = useEncryptedVotes(roundId);
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [decryptedVotesKey, encryptedVotes, address],
-    () => decryptVotes(signingKey?.privateKey, encryptedVotes),
-    {
-      enabled: !!address && !isWrongChain,
-      initialData: {},
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [decryptedVotesKey, encryptedVotes, address],
+    queryFn: () => decryptVotes(signingKey?.privateKey, encryptedVotes),
+    enabled: !!address && !isWrongChain,
+    initialData: {},
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/votes/useEncryptedVotes.ts
+++ b/hooks/queries/votes/useEncryptedVotes.ts
@@ -14,15 +14,13 @@ export function useEncryptedVotes(roundId?: number) {
   const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [encryptedVotesKey, address, roundId],
-    () => getEncryptedVotes(voting, votingV1, address, roundId),
-    {
-      enabled: !!address && !isWrongChain,
-      initialData: {},
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [encryptedVotesKey, address, roundId],
+    queryFn: () => getEncryptedVotes(voting, votingV1, address, roundId),
+    enabled: !!address && !isWrongChain,
+    initialData: {},
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/votes/usePastVotes.ts
+++ b/hooks/queries/votes/usePastVotes.ts
@@ -8,16 +8,14 @@ export function usePastVotes() {
   const { roundId } = useVoteTimingContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [pastVotesKey, roundId],
-    () => getPastVotesAllVersions(),
-    {
-      enabled: config.graphV1Enabled && config.graphV2Enabled,
-      refetchInterval: oneMinute,
-      initialData: {},
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [pastVotesKey, roundId],
+    queryFn: () => getPastVotesAllVersions(),
+    enabled: config.graphV1Enabled && config.graphV2Enabled,
+    refetchInterval: oneMinute,
+    initialData: {},
+    onError,
+  });
 
   return queryResult;
 }

--- a/hooks/queries/votes/useUpcomingVotes.ts
+++ b/hooks/queries/votes/useUpcomingVotes.ts
@@ -14,17 +14,15 @@ export function useUpcomingVotes() {
   const newVotesAdded = useNewVotesAdded();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const queryResult = useQuery(
-    [upcomingVotesKey, roundId, newVotesAdded],
-    () => getUpcomingVotes(voting, roundId),
-    {
-      initialData: {
-        upcomingVotes: {},
-        hasUpcomingVotes: false,
-      },
-      onError,
-    }
-  );
+  const queryResult = useQuery({
+    queryKey: [upcomingVotesKey, roundId, newVotesAdded],
+    queryFn: () => getUpcomingVotes(voting, roundId),
+    initialData: {
+      upcomingVotes: {},
+      hasUpcomingVotes: false,
+    },
+    onError,
+  });
 
   return queryResult;
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "@reach/menu-button": "^0.18.0",
     "@reach/portal": "^0.18.0",
     "@reach/tooltip": "^0.18.0",
-    "@tanstack/react-query": "^4.3.9",
-    "@tanstack/react-query-devtools": "^4.3.9",
+    "@tanstack/react-query": "^4.29.5",
+    "@tanstack/react-query-devtools": "^4.29.6",
     "@uma/contracts-frontend": "^0.4.12",
     "@web3-onboard/core": "^2.8.3",
     "@web3-onboard/gnosis": "^2.1.2",
@@ -48,7 +48,6 @@
     "usehooks-ts": "^2.9.1"
   },
   "devDependencies": {
-    "@total-typescript/ts-reset": "^0.4.2",
     "@babel/core": "^7.19.1",
     "@babel/preset-env": "^7.19.3",
     "@babel/preset-react": "^7.18.6",
@@ -62,6 +61,8 @@
     "@storybook/react": "^7.0.6",
     "@storybook/testing-library": "^0.1.0",
     "@svgr/webpack": "^6.3.1",
+    "@tanstack/eslint-plugin-query": "^4.29.4",
+    "@total-typescript/ts-reset": "^0.4.2",
     "@types/node": "18.7.18",
     "@types/react": "18.0.20",
     "@types/react-dom": "18.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4222,6 +4222,11 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tanstack/eslint-plugin-query@^4.29.4":
+  version "4.29.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/eslint-plugin-query/-/eslint-plugin-query-4.29.4.tgz#c593b3ef36c8626484806b37ee45eae2304f96b3"
+  integrity sha512-dKWigue+8KV9BaKLq5yUu4wUYCendpvEve8lc3YyD634MQJ/joK7nJXiMfAEHY5Bwnh00Y3ZTBJ6YNtAz4CbVQ==
+
 "@tanstack/match-sorter-utils@^8.7.0":
   version "8.7.6"
   resolved "https://registry.yarnpkg.com/@tanstack/match-sorter-utils/-/match-sorter-utils-8.7.6.tgz#ccf54a37447770e0cf0fe49a579c595fd2655b16"
@@ -4229,26 +4234,26 @@
   dependencies:
     remove-accents "0.4.2"
 
-"@tanstack/query-core@4.24.4":
-  version "4.24.4"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.24.4.tgz#6fe78777286fdd805ac319c7c743df4935e18ee2"
-  integrity sha512-9dqjv9eeB6VHN7lD3cLo16ZAjfjCsdXetSAD5+VyKqLUvcKTL0CklGQRJu+bWzdrS69R6Ea4UZo8obHYZnG6aA==
+"@tanstack/query-core@4.29.5":
+  version "4.29.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.29.5.tgz#a0273e88bf2fc102c4c893dc7c034127b67fd5d9"
+  integrity sha512-xXIiyQ/4r9KfaJ3k6kejqcaqFXXBTzN2aOJ5H1J6aTJE9hl/nbgAdfF6oiIu0CD5xowejJEJ6bBg8TO7BN4NuQ==
 
-"@tanstack/react-query-devtools@^4.3.9":
-  version "4.24.4"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-4.24.4.tgz#5f0bd45f929950ff2b56a1a3ed18a006780e3495"
-  integrity sha512-4mldcR99QDX8k94I+STM9gPsYF+FDAD2EQJvHtxR2HrDNegbfmY474xuW0QUZaNW/vJi09Gak6b6Vy2INWhL6w==
+"@tanstack/react-query-devtools@^4.29.6":
+  version "4.29.6"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-4.29.6.tgz#117d88d598c5d5ec323d011fb7670a9096a6ede8"
+  integrity sha512-qpYI41a69MWmrllcGiSE1KlpmnwJY/w0yKMnmp6VXn7nVy0i5TMMAT4u8D48F1Ipv/BKIDI1lqxPAvB4MqryBg==
   dependencies:
     "@tanstack/match-sorter-utils" "^8.7.0"
     superjson "^1.10.0"
     use-sync-external-store "^1.2.0"
 
-"@tanstack/react-query@^4.3.9":
-  version "4.24.4"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.24.4.tgz#79e892edac33d8aa394795390c0f79e4a8c9be4d"
-  integrity sha512-RpaS/3T/a3pHuZJbIAzAYRu+1nkp+/enr9hfRXDS/mojwx567UiMksoqW4wUFWlwIvWTXyhot2nbIipTKEg55Q==
+"@tanstack/react-query@^4.29.5":
+  version "4.29.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.29.5.tgz#3890741291f9f925933243d78bd74dfc59d64208"
+  integrity sha512-F87cibC3s3eG0Q90g2O+hqntpCrudKFnR8P24qkH9uccEhXErnJxBC/AAI4cJRV2bfMO8IeGZQYf3WyYgmSg0w==
   dependencies:
-    "@tanstack/query-core" "4.24.4"
+    "@tanstack/query-core" "4.29.5"
     use-sync-external-store "^1.2.0"
 
 "@testing-library/dom@^8.3.0":


### PR DESCRIPTION
react query has a nice eslint plugin that I was using on another branch for an upcoming PR. However, since react query v5 is going to [deprecate using the array-based arguments to `useQuery`](https://tanstack.com/query/v4/docs/react/eslint/prefer-query-object-syntax) the eslint plugin shows warnings everywhere we've used the old syntax. I've applied the automatic fix here.