### PR TITLE
fix: use latest round

### DIFF
--- a/graph/queries/getActiveVoteResults.ts
+++ b/graph/queries/getActiveVoteResults.ts
@@ -40,16 +40,16 @@ export async function getActiveVoteResults(): Promise<
             price
             totalVoteAmount
           }
-        }
-        committedVotes {
-          id
-        }
-        revealedVotes {
-          id
-          voter {
-            address
+          committedVotes {
+            id
           }
-          price
+          revealedVotes {
+            id
+            voter {
+              address
+            }
+            price
+          }
         }
       }
     }
@@ -64,15 +64,13 @@ export async function getActiveVoteResults(): Promise<
         ancillaryData,
         resolvedPriceRequestIndex,
         latestRound,
-        committedVotes,
-        revealedVotes,
       }) => {
         const identifier = formatBytes32String(id);
         const correctVote = price;
         const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
         const participation = {
-          uniqueCommitAddresses: committedVotes.length,
-          uniqueRevealAddresses: revealedVotes.length,
+          uniqueCommitAddresses: latestRound.committedVotes.length,
+          uniqueRevealAddresses: latestRound.revealedVotes.length,
           totalTokensVotedWith,
         };
         const results = latestRound.groups.map(
@@ -82,10 +80,13 @@ export async function getActiveVoteResults(): Promise<
           })
         );
         const init: RevealedVotesByAddress = {};
-        const revealedVoteByAddress = revealedVotes.reduce((result, vote) => {
-          result[utils.getAddress(vote.voter.address)] = vote.price;
-          return result;
-        }, init);
+        const revealedVoteByAddress = latestRound.revealedVotes.reduce(
+          (result, vote) => {
+            result[utils.getAddress(vote.voter.address)] = vote.price;
+            return result;
+          },
+          init
+        );
         return {
           identifier,
           time: Number(time),

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -79,16 +79,16 @@ export async function getPastVotesV2() {
             price
             totalVoteAmount
           }
-        }
-        committedVotes {
-          id
-        }
-        revealedVotes {
-          id
-          voter {
-            address
+          committedVotes {
+            id
           }
-          price
+          revealedVotes {
+            id
+            voter {
+              address
+            }
+            price
+          }
         }
       }
     }
@@ -102,15 +102,13 @@ export async function getPastVotesV2() {
       ancillaryData,
       resolvedPriceRequestIndex,
       latestRound,
-      committedVotes,
-      revealedVotes,
     }) => {
       const identifier = formatBytes32String(id);
       const correctVote = price;
       const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
       const participation = {
-        uniqueCommitAddresses: committedVotes.length,
-        uniqueRevealAddresses: revealedVotes.length,
+        uniqueCommitAddresses: latestRound.committedVotes.length,
+        uniqueRevealAddresses: latestRound.revealedVotes.length,
         totalTokensVotedWith,
       };
       const results = latestRound.groups.map(({ price, totalVoteAmount }) => ({
@@ -118,7 +116,7 @@ export async function getPastVotesV2() {
         tokensVotedWith: Number(totalVoteAmount),
       }));
       const init: RevealedVotesByAddress = {};
-      const revealedVoteByAddress = revealedVotes.reduce((result, vote) => {
+      const revealedVoteByAddress = latestRound.revealedVotes.reduce((result, vote) => {
         result[utils.getAddress(vote.voter.address)] = vote.price;
         return result;
       }, init);

--- a/types/queries.ts
+++ b/types/queries.ts
@@ -13,17 +13,17 @@ export type PastVotesQuery = {
         price: string;
         totalVoteAmount: string;
       }[];
+      committedVotes: {
+        id: string;
+      }[];
+      revealedVotes: {
+        id: string;
+        voter: {
+          address: string;
+        };
+        price: string;
+      }[];
     };
-    committedVotes: {
-      id: string;
-    }[];
-    revealedVotes: {
-      id: string;
-      voter: {
-        address: string;
-      };
-      price: string;
-    }[];
   }[];
 };
 


### PR DESCRIPTION
Changes proposed in this PR:

Use committedVotes and revealedVotes from latestRound instead of from the priceRequests entity to handle rolled price requests.