### PR TITLE
fix: return empty when no address

### DIFF
--- a/web3/queries/delegation/getDelegateToStaker.ts
+++ b/web3/queries/delegation/getDelegateToStaker.ts
@@ -1,8 +1,10 @@
 import { VotingV2Ethers } from "@uma/contracts-frontend";
+import { zeroAddress } from "helpers";
 
 export function getDelegateToStaker(
   voting: VotingV2Ethers,
   delegateAddress: string
 ) {
+  if (!delegateAddress) return zeroAddress;
   return voting.delegateToStaker(delegateAddress);
 }

--- a/web3/queries/rewards/getOutstandingRewards.ts
+++ b/web3/queries/rewards/getOutstandingRewards.ts
@@ -1,9 +1,11 @@
 import { VotingV2Ethers } from "@uma/contracts-frontend";
+import { BigNumber } from "ethers";
 
 export async function getOutstandingRewards(
   votingContract: VotingV2Ethers,
   address: string
 ) {
+  if (!address) return BigNumber.from(0);
   const result = await votingContract.functions.outstandingRewards(address);
   return result?.[0];
 }

--- a/web3/queries/votes/getEncryptedVotes.ts
+++ b/web3/queries/votes/getEncryptedVotes.ts
@@ -8,6 +8,7 @@ export async function getEncryptedVotes(
   address: string | undefined,
   findRoundId?: number
 ) {
+  if (!address) return {};
   const v1Filter = votingV1Contract.filters.EncryptedVote(address);
   const v1Result = await votingV1Contract.queryFilter(v1Filter);
 


### PR DESCRIPTION
We did not include cases for when there is no address in two of our queries. 

For the encrypted votes query, this caused us to query all of the encrypted vote events instead of just for a specific address. We did not notice this error when we tested on goerli because the events we were looking for were still present. This was an error on mainnet because the query returned more than 10000 events, which causes infura to throw an error.