### PR TITLE
fix: decrypting v1 vote errors

### DIFF
--- a/hooks/queries/votes/useDecryptedVotes.ts
+++ b/hooks/queries/votes/useDecryptedVotes.ts
@@ -41,18 +41,25 @@ async function decryptVotes(
   for await (const [uniqueKey, encryptedVote] of Object.entries(
     encryptedVotes
   )) {
-    let decryptedVote: DecryptedVoteT;
+    try {
+      let decryptedVote: DecryptedVoteT;
 
-    if (encryptedVote && privateKey) {
-      const decryptedVoteString = await decryptMessage(
-        privateKey,
-        encryptedVote
-      );
-      decryptedVote = JSON.parse(decryptedVoteString) as DecryptedVoteT;
+      if (encryptedVote && privateKey) {
+        const decryptedVoteString = await decryptMessage(
+          privateKey,
+          encryptedVote
+        );
+        decryptedVote = JSON.parse(decryptedVoteString) as DecryptedVoteT;
 
-      if (decryptedVote) {
-        decryptedVotes[uniqueKey] = decryptedVote;
+        if (decryptedVote) {
+          decryptedVotes[uniqueKey] = decryptedVote;
+        }
       }
+    } catch (err) {
+      console.warn("Failed Decoding encrypted vote:", err, {
+        uniqueKey,
+        encryptedVote,
+      });
     }
   }
 

--- a/web3/queries/votes/getEncryptedVotes.ts
+++ b/web3/queries/votes/getEncryptedVotes.ts
@@ -9,29 +9,16 @@ export async function getEncryptedVotes(
   findRoundId?: number
 ) {
   if (!address) return {};
-  const v1Filter = votingV1Contract.filters.EncryptedVote(address);
-  const v1Result = await votingV1Contract.queryFilter(v1Filter);
 
   const v2Filter = votingContract.filters.EncryptedVote(address);
   const v2Result = await votingContract.queryFilter(v2Filter);
 
-  const v1EventData = v1Result?.map(({ args }) => args);
   const v2EventData = v2Result
     ?.map(({ args }) => args)
     .filter(({ roundId }) => (findRoundId ? roundId === findRoundId : true));
 
   const encryptedVotes: EncryptedVotesByKeyT = {};
-  // disable v1 events if a round id is specified, this means we are only looking for current rounds
-  if (findRoundId === undefined) {
-    v1EventData?.forEach(
-      ({ encryptedVote, identifier, time, ancillaryData }) => {
-        const decodedIdentifier = decodeHexString(identifier);
-        encryptedVotes[
-          makeUniqueKeyForVote(decodedIdentifier, time, ancillaryData)
-        ] = encryptedVote;
-      }
-    );
-  }
+
   v2EventData?.forEach(({ encryptedVote, identifier, time, ancillaryData }) => {
     const decodedIdentifier = decodeHexString(identifier);
     encryptedVotes[


### PR DESCRIPTION
## motivation
we are seeing some console errors during decryption every time we launch master branch

## changes
these errors look due to tryign to decrypt v1 votes, which isnt necessary since all the data is bundled with the app. we remove this logic, as well as turn the decryption error into a warning, so to not prevent the entire list of votes from being decrypted if there are some failures. 