### PR TITLE
fix: use object as param to prevent accidentally using wrong values

### DIFF
--- a/components/Panel/ClaimPanel.tsx
+++ b/components/Panel/ClaimPanel.tsx
@@ -27,8 +27,14 @@ export function ClaimPanel() {
   const { isDelegate, delegatorAddress, outstandingRewards } =
     useDelegationContext();
   const { address } = useAccountDetails();
-  const { withdrawRewardsMutation } = useWithdrawRewards("claim");
-  const { withdrawAndRestakeMutation } = useWithdrawAndRestake("claim");
+  const { withdrawRewardsMutation } = useWithdrawRewards({
+    address,
+    errorOrigin: "claim",
+  });
+  const { withdrawAndRestakeMutation } = useWithdrawAndRestake({
+    address,
+    errorOrigin: "claim",
+  });
   const { isLoading: stakerDetailsIsLoading } = useStakerDetails(
     isDelegate ? delegatorAddress : address
   );

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -37,11 +37,22 @@ export function StakeUnstakePanel() {
   const { data: unstakeCoolDown } = useUnstakeCoolDown();
   const { data: stakerDetails } = useStakerDetails(address);
   const { pendingUnstake, canUnstakeTime } = stakerDetails || {};
-  const { approveMutation, isApproving } = useApprove("stake");
-  const { stakeMutation } = useStake("stake");
-  const { requestUnstakeMutation, isRequestingUnstake } =
-    useRequestUnstake("unstake");
-  const { executeUnstakeMutation } = useExecuteUnstake("unstake");
+  const { approveMutation, isApproving } = useApprove({
+    address: stakingAddress,
+    errorOrigin: "stake",
+  });
+  const { stakeMutation } = useStake({
+    address: stakingAddress,
+    errorOrigin: "stake",
+  });
+  const { requestUnstakeMutation, isRequestingUnstake } = useRequestUnstake({
+    address: stakingAddress,
+    errorOrigin: "unstake",
+  });
+  const { executeUnstakeMutation } = useExecuteUnstake({
+    address: stakingAddress,
+    errorOrigin: "unstake",
+  });
   const cooldownEnds = canUnstakeTime;
   const hasCooldownTimeRemaining = !!cooldownEnds && cooldownEnds > new Date();
   const hasPendingUnstake = pendingUnstake?.gt(0) ?? false;

--- a/contexts/DelegationContext.tsx
+++ b/contexts/DelegationContext.tsx
@@ -1,10 +1,10 @@
+import { BigNumber } from "ethers";
 import {
+  calculateOutstandingRewards,
   getAddress,
   truncateEthAddress,
   zeroAddress,
-  calculateOutstandingRewards,
 } from "helpers";
-import { BigNumber } from "ethers";
 import {
   useAcceptReceivedRequestToBeDelegate,
   useAccountDetails,
@@ -151,7 +151,7 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
     isIgnoringRequestToBeDelegate,
   } = useIgnoreReceivedRequestToBeDelegate(address);
   const { sendRequestToBeDelegateMutation, isSendingRequestToBeDelegate } =
-    useSendRequestToBeDelegate(address);
+    useSendRequestToBeDelegate({ address });
   const {
     cancelSentRequestToBeDelegateMutation,
     isCancelingSentRequestToBeDelegate,

--- a/hooks/mutations/delegation/useSendRequestToBeDelegate.ts
+++ b/hooks/mutations/delegation/useSendRequestToBeDelegate.ts
@@ -4,10 +4,13 @@ import { useHandleError } from "hooks";
 import { DelegationEventT, ErrorOriginT, StakerDetailsT } from "types";
 import { setDelegate } from "web3";
 
-export function useSendRequestToBeDelegate(
-  address: string | undefined,
-  errorOrigin?: ErrorOriginT
-) {
+export function useSendRequestToBeDelegate({
+  address,
+  errorOrigin,
+}: {
+  address: string | undefined;
+  errorOrigin?: ErrorOriginT;
+}) {
   const { onError, clearErrors } = useHandleError({ errorOrigin });
   const queryClient = useQueryClient();
 

--- a/hooks/mutations/rewards/useWithdrawAndRestake.ts
+++ b/hooks/mutations/rewards/useWithdrawAndRestake.ts
@@ -9,10 +9,13 @@ import { useHandleError, useStakerDetails } from "hooks";
 import { ErrorOriginT, RewardCalculationT, StakerDetailsT } from "types";
 import { withdrawAndRestake } from "web3";
 
-export function useWithdrawAndRestake(
-  address: string,
-  errorOrigin?: ErrorOriginT
-) {
+export function useWithdrawAndRestake({
+  address,
+  errorOrigin,
+}: {
+  address: string | undefined;
+  errorOrigin?: ErrorOriginT;
+}) {
   const queryClient = useQueryClient();
   const { data: stakerDetails } = useStakerDetails(address);
   const { outstandingRewards } = stakerDetails || {};

--- a/hooks/mutations/rewards/useWithdrawRewards.ts
+++ b/hooks/mutations/rewards/useWithdrawRewards.ts
@@ -9,10 +9,13 @@ import { useHandleError, useStakerDetails } from "hooks";
 import { ErrorOriginT, RewardCalculationT, StakerDetailsT } from "types";
 import { withdrawRewards } from "web3";
 
-export function useWithdrawRewards(
-  address: string | undefined,
-  errorOrigin?: ErrorOriginT
-) {
+export function useWithdrawRewards({
+  address,
+  errorOrigin,
+}: {
+  address: string | undefined;
+  errorOrigin?: ErrorOriginT;
+}) {
   const queryClient = useQueryClient();
   const { data: stakerDetails } = useStakerDetails(address);
   const { outstandingRewards } = stakerDetails || {};

--- a/hooks/mutations/staking/useApprove.ts
+++ b/hooks/mutations/staking/useApprove.ts
@@ -5,10 +5,13 @@ import { useHandleError } from "hooks";
 import { ErrorOriginT } from "types";
 import { approve } from "web3";
 
-export function useApprove(
-  address: string | undefined,
-  errorOrigin?: ErrorOriginT
-) {
+export function useApprove({
+  address,
+  errorOrigin,
+}: {
+  address: string | undefined;
+  errorOrigin?: ErrorOriginT;
+}) {
   const queryClient = useQueryClient();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 

--- a/hooks/mutations/staking/useExecuteUnstake.ts
+++ b/hooks/mutations/staking/useExecuteUnstake.ts
@@ -14,10 +14,13 @@ function max(a: BigNumber, b: BigNumber) {
   return b;
 }
 
-export function useExecuteUnstake(
-  address: string | undefined,
-  errorOrigin?: ErrorOriginT
-) {
+export function useExecuteUnstake({
+  address,
+  errorOrigin,
+}: {
+  address: string | undefined;
+  errorOrigin?: ErrorOriginT;
+}) {
   const queryClient = useQueryClient();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 

--- a/hooks/mutations/staking/useRequestUnstake.ts
+++ b/hooks/mutations/staking/useRequestUnstake.ts
@@ -10,10 +10,13 @@ import { useHandleError } from "hooks";
 import { ErrorOriginT, StakerDetailsT } from "types";
 import { requestUnstake } from "web3";
 
-export function useRequestUnstake(
-  address: string | undefined,
-  errorOrigin?: ErrorOriginT
-) {
+export function useRequestUnstake({
+  address,
+  errorOrigin,
+}: {
+  address: string | undefined;
+  errorOrigin?: ErrorOriginT;
+}) {
   const queryClient = useQueryClient();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 

--- a/hooks/mutations/staking/useStake.ts
+++ b/hooks/mutations/staking/useStake.ts
@@ -5,10 +5,13 @@ import { useHandleError } from "hooks";
 import { ErrorOriginT } from "types";
 import { stake } from "web3";
 
-export function useStake(
-  address: string | undefined,
-  errorOrigin?: ErrorOriginT
-) {
+export function useStake({
+  address,
+  errorOrigin,
+}: {
+  address: string | undefined;
+  errorOrigin?: ErrorOriginT;
+}) {
   const queryClient = useQueryClient();
   const { onError, clearErrors } = useHandleError({ errorOrigin });
 


### PR DESCRIPTION
Some of our mutations had an optional param for `errorOrigin`. We then updated those mutations to also take the `address` to use as the first param. But because the second param was optional, and the address is just a string, typescript did not flag any errors in the places where we called the mutations with the string of the `errorOrigin` instead of the string of the `address`. So essentially we were trying to use the string "claim" or the string "stake" as the address.

I've updated these mutations to take object arguments instead, so that this ambiguity cannot happen in future.