### PR TITLE
fix: disable staking max button with no wallet connected

### DIFF
--- a/components/Panel/StakeUnstakePanel/Stake.tsx
+++ b/components/Panel/StakeUnstakePanel/Stake.tsx
@@ -20,6 +20,7 @@ interface Props {
   approve: (approveAmount: string) => void;
   isApproving: boolean;
   stake: (stakeAmount: string, resetStakeAmount: () => void) => void;
+  isWalletConnected: boolean;
 }
 export function Stake({
   tokenAllowance,
@@ -29,6 +30,7 @@ export function Stake({
   unstakeCoolDown,
   isDelegate,
   isApproving,
+  isWalletConnected,
 }: Props) {
   const [inputAmount, setInputAmount] = useState("");
   const [disclaimerChecked, setDisclaimerChecked] = useState(false);
@@ -60,6 +62,10 @@ export function Stake({
       parseEtherSafe(inputAmount).eq(0) ||
       (unstakedBalance ? parseEtherSafe(inputAmount).gt(unstakedBalance) : true)
     );
+  }
+
+  function isInputDisabled() {
+    return !isWalletConnected;
   }
 
   function onApprove() {
@@ -103,6 +109,7 @@ export function Stake({
               onInput={setInputAmount}
               onMax={onMax}
               allowNegative={false}
+              disabled={isInputDisabled()}
             />
           </AmountInputWrapper>
           <CheckboxWrapper>
@@ -110,6 +117,7 @@ export function Stake({
               label={disclaimer}
               checked={disclaimerChecked}
               onChange={(e) => setDisclaimerChecked(e.target.checked)}
+              disabled={isInputDisabled()}
             />
           </CheckboxWrapper>
           <Button

--- a/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
+++ b/components/Panel/StakeUnstakePanel/StakeUnstakePanel.tsx
@@ -107,6 +107,7 @@ export function StakeUnstakePanel() {
           stake={stake}
           unstakeCoolDown={unstakeCoolDown}
           isDelegate={isDelegate}
+          isWalletConnected={!!address}
         />
       ),
     },


### PR DESCRIPTION
## motivation
when wallet not connected, there was a way to enable the stake button by messing with the input box. this leads to errors on the app.

## changes
this makes sure we know to disable the staking inputbox and other buttons when no wallet is connected. 

![image](https://github.com/UMAprotocol/voter-dapp-v2/assets/4429761/ede39cb6-4679-440e-8f7d-7c440a2d7629)
