### PR TITLE
fix: discord evidence rationale link

### DIFF
--- a/pages/api/discord-thread.ts
+++ b/pages/api/discord-thread.ts
@@ -98,7 +98,7 @@ async function fetchDiscordThread(
   // it to the associated threadId.
   const timeToThread: { [key: string]: string } = {};
   threadMsg.forEach((message) => {
-    const time = extractValidateTimestamp(message.content);
+    const time = extractValidateTimestamp(message.thread.name);
     if (time) timeToThread[time.toString()] = message.thread.id;
   });
   // Associate the threadId with each timestamp provided in the payload.

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -282,7 +282,7 @@ export type RawDiscordMessageT = {
     avatar: string;
   };
   timestamp: string;
-  thread: { id: string };
+  thread: { id: string; name: string };
   attachments: {
     id: string;
     filename: string;


### PR DESCRIPTION
Changes proposed in this PR:
- Fix the link to the discord threads by using the `message.thread.name` instead of `message.content`. 
  - Explanation: In some cases when editing the thread title after creation, `message.content` returned by discord API still returns the old title but `message.thread.name` is up to date. That's why we always need to use `message.thread.name`