### PR TITLE
improve: change ownership pronoun

### DIFF
--- a/components/HowItWorks/HowItWorks.tsx
+++ b/components/HowItWorks/HowItWorks.tsx
@@ -108,7 +108,7 @@ export function HowItWorks() {
                   {formatNumberForDisplay(stakedBalance)}
                 </Loader>
               </Strong>{" "}
-              {isDelegate ? "of their" : "of your"}{" "}
+              {isDelegate ? "of its" : "of your"}{" "}
               <Strong>
                 <Loader
                   isLoading={


### PR DESCRIPTION
When talking about something that belongs to a single person or thing, I believe we'd want to use "its" to show possession. 

I.e. Your delegator is staking X of their Y UMA tokens.

In the above example, _their_ refers to _Your delegator_, and since there's only one delegator, it should be _its_.

