### PR TITLE
fix: option parsing for polymarket requests

### DIFF
--- a/helpers/voting/polymarket.ts
+++ b/helpers/voting/polymarket.ts
@@ -25,7 +25,7 @@ function dynamicPolymarketOptions(
     /res_data: (p\d): (\d+\.\d+|\d+), (p\d): (\d+\.\d+|\d+), (p\d): (\d+\.\d+|\d+)/
   );
   const correspondence = decodedAncillaryData.match(
-    /Where (p\d) corresponds to ([^,]+), (p\d) to ([^,]+), (p\d) to ([^,]+)/
+    /Where (p\d) corresponds to ([^,]+), (p\d) to ([^,]+), (p\d) to ([^.,]+)/
   );
 
   if (!resData || !correspondence) return [];


### PR DESCRIPTION
## motivation
since polymarket changed ancillary data format, we need to update dynamic option parsing

## changes
 this updates the regex to account for a period where a comma used to be