### PR TITLE
fix: add "." to polymarket dropdown regex

### DIFF
--- a/helpers/voting/polymarket.ts
+++ b/helpers/voting/polymarket.ts
@@ -25,7 +25,7 @@ function dynamicPolymarketOptions(
     /res_data: (p\d): (\d+\.\d+|\d+), (p\d): (\d+\.\d+|\d+), (p\d): (\d+\.\d+|\d+)/
   );
   const correspondence = decodedAncillaryData.match(
-    /Where (p\d) corresponds to ([^,]+), (p\d) to ([^,]+), (p\d) to ([^,]+)/
+    /Where (p\d) corresponds to ([^,]+), (p\d) to ([^,]+), (p\d) to ([^.,]+)/
   );
 
   if (!resData || !correspondence) return [];


### PR DESCRIPTION
Polymarket changed their ancillary data. We need to update the parsing regex to allow this.