### PR TITLE
fix: make user re-select their vote when a vote rolls

### DIFF
--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -18,6 +18,7 @@ import {
   useRevealedVotes,
   useUpcomingVotes,
   useUserVotingAndStakingDetails,
+  useVoteTimingContext,
 } from "hooks";
 import { ReactNode, createContext, useMemo } from "react";
 import {
@@ -107,6 +108,7 @@ export const VotesContext = createContext<VotesContextState>(
 );
 
 export function VotesProvider({ children }: { children: ReactNode }) {
+  const { roundId } = useVoteTimingContext();
   const { address: userAddress } = useAccountDetails();
   const { isDelegate, delegatorAddress } = useDelegationContext();
   const userOrDelegatorAddress = isDelegate ? delegatorAddress : userAddress;
@@ -136,7 +138,7 @@ export function VotesProvider({ children }: { children: ReactNode }) {
     // if we are a delegate we need to override to our delegators address
   } = useRevealedVotes(userOrDelegatorAddress);
   const { data: encryptedVotes, isLoading: encryptedVotesIsLoading } =
-    useEncryptedVotes(userAddress);
+    useEncryptedVotes(userAddress, roundId);
   const { data: decryptedVotes, isLoading: decryptedVotesIsLoading } =
     useDecryptedVotes(userAddress, encryptedVotes);
   const { data: activeVoteResultsByKey } = useActiveVoteResults();

--- a/web3/queries/votes/getEncryptedVotes.ts
+++ b/web3/queries/votes/getEncryptedVotes.ts
@@ -10,7 +10,7 @@ export async function getEncryptedVotes(
 ) {
   if (!address) return {};
 
-  const v2Filter = votingContract.filters.EncryptedVote(address);
+  const v2Filter = votingContract.filters.EncryptedVote(address, findRoundId);
   const v2Result = await votingContract.queryFilter(v2Filter);
 
   const v2EventData = v2Result


### PR DESCRIPTION
There is a bug where the app does not recognize that a rolled vote is a new vote. it repopulates the form field with the user's encrypted vote from the previous round. 

We want the vote to be treated as a new vote. In my opinion it does not make sense to automatically assume that the user wants to vote the same as the previous time for a rolled vote anyway, since by the nature of a rolled vote it is likely that the user has changed their mind. At the very least they should consider their new vote before committing.

To fix this behavior we should filter encrypted votes by round id.