### PR TITLE
improve: commify uma large displays of tokens in vote results

### DIFF
--- a/components/Panel/VotePanel/Result.tsx
+++ b/components/Panel/VotePanel/Result.tsx
@@ -6,7 +6,11 @@ import {
   Tooltip,
 } from "components";
 import { mobileAndUnder, isEarlyVote } from "constant";
-import { formatVoteStringWithPrecision, truncateDecimals } from "helpers";
+import {
+  formatVoteStringWithPrecision,
+  truncateDecimals,
+  commify,
+} from "helpers";
 import { usePanelWidth } from "hooks";
 import Portion from "public/assets/icons/portion.svg";
 import Voting from "public/assets/icons/voting.svg";
@@ -81,7 +85,7 @@ export function Result({
                 <LegendItemData>
                   <LegendItemLabel label={label} />
                   <Strong>{(percent * 100).toFixed(2)}%</Strong> (
-                  {value ? truncateDecimals(value, 2) : 0})
+                  {value ? commify(truncateDecimals(value, 2)) : 0})
                 </LegendItemData>
               </LegendItem>
             ))}
@@ -107,7 +111,7 @@ export function Result({
           <span>Total tokens that voted</span>
           <Strong>
             {totalTokensVotedWith
-              ? truncateDecimals(totalTokensVotedWith, 2)
+              ? commify(truncateDecimals(totalTokensVotedWith, 2))
               : 0}
           </Strong>
         </ParticipationItem>


### PR DESCRIPTION
## motivation
sometimes it's interesting to follow the voter numbers to gauge approx votes revealed vs. remaining, but my brain short circuits when I try to parse long numbers without a separator.
ethers has a helper called [commify()](https://docs.ethers.org/v5/single-page/#/v5/api/utils/display-logic/-%23-utils-commify) to do this automagically - could that be an easy way to format it?What's the reason for the improvement?

## changes
commify the 2 places where we display this in vote results