### PR TITLE
improve: improve osnap vote rendering

### DIFF
--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -24,7 +24,7 @@ import Time from "public/assets/icons/time-with-inner-circle.svg";
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import styled from "styled-components";
-import { VoteT } from "types";
+import { VoteT, SupportedChainIds, OracleTypeT } from "types";
 import { PanelSectionTitle } from "../styles";
 import { ChainIcon } from "./ChainIcon";
 import { OoTypeIcon } from "./OoTypeIcon";
@@ -43,12 +43,12 @@ export function Details({
   augmentedData,
   assertionChildChainId,
   assertionAsserter,
-  claim,
-}: VoteT & { claim: string | undefined }) {
+}: VoteT) {
   const [showDecodedAdminTransactions, setShowDecodedAdminTransactions] =
     useState(false);
   const [showRawAncillaryData, setShowRawAncillaryData] = useState(false);
   const [showRawClaimData, setShowRawClaimData] = useState(false);
+  const claim = augmentedData?.optimisticOracleV3Data?.claim;
   const isClaim = !!claim;
   const showAncillaryData = !isClaim;
   function toggleShowDecodedAdminTransactions() {
@@ -101,7 +101,9 @@ export function Details({
     augmentedData.originatingOracleType
       ? makeTransactionHashLink(
           `${
-            supportedChains[augmentedData.originatingChainId]
+            supportedChains[
+              augmentedData.originatingChainId as SupportedChainIds
+            ]
           } ${getOracleTypeDisplayName(
             augmentedData.originatingOracleType
           )} Request`,
@@ -116,8 +118,16 @@ export function Details({
     <Wrapper>
       <SectionWrapper>
         <RequestInfoIcons>
-          <ChainIcon chainId={augmentedData?.originatingChainId} />
-          <OoTypeIcon ooType={augmentedData?.originatingOracleType} />
+          <ChainIcon
+            chainId={
+              augmentedData?.originatingChainId as SupportedChainIds | undefined
+            }
+          />
+          <OoTypeIcon
+            ooType={
+              augmentedData?.originatingOracleType as OracleTypeT | undefined
+            }
+          />
         </RequestInfoIcons>
         <PanelSectionTitle>
           <IconWrapper>

--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from "components";
 import { decodeHexString } from "helpers";
-import { useAssertionClaim, useVoteDiscussion } from "hooks";
+import { useVoteDiscussion } from "hooks";
 import { VoteT } from "types";
 import { PanelFooter } from "../PanelFooter";
 import { PanelTitle } from "../PanelTitle";
@@ -24,8 +24,7 @@ export function VotePanel({ content }: Props) {
     results,
     isGovernance,
     options,
-    assertionChildChainId,
-    assertionId,
+    augmentedData,
   } = content;
 
   const { data: discussion, isFetching: discussionLoading } = useVoteDiscussion(
@@ -34,8 +33,7 @@ export function VotePanel({ content }: Props) {
       time,
     }
   );
-
-  const { data: claim } = useAssertionClaim(assertionChildChainId, assertionId);
+  const claim = augmentedData?.optimisticOracleV3Data?.claim;
 
   const titleOrClaimOrIdentifier = claim
     ? decodeHexString(claim)
@@ -52,7 +50,7 @@ export function VotePanel({ content }: Props) {
     const tabs = [
       {
         title: "Details",
-        content: <Details {...content} claim={claim} />,
+        content: <Details {...content} />,
       },
       {
         title: "Discussion",

--- a/helpers/voting/getVoteMetaData.ts
+++ b/helpers/voting/getVoteMetaData.ts
@@ -21,9 +21,10 @@ export function getVoteMetaData(
   decodedAncillaryData: string,
   umipDataFromContentful: ContentfulDataT | undefined
 ): VoteMetaDataT {
-  const isAssertion = ["assertionId:", "ooAsserter:", "childChainId:"].every(
-    (lookup) => decodedAncillaryData.includes(lookup)
+  const isAssertion = ["assertionId:", "ooAsserter:"].every((lookup) =>
+    decodedAncillaryData.includes(lookup)
   );
+
   if (isAssertion) {
     const assertionData = parseAssertionAncillaryData(decodedAncillaryData);
     const description = makeAssertionDescription(assertionData);

--- a/pages/api/augment-request.ts
+++ b/pages/api/augment-request.ts
@@ -79,7 +79,7 @@ function constructOoUiLink(
   const subDomain = Number(chainId) === 5 ? "testnet." : "";
   return `https://${subDomain}oracle.uma.xyz/request?transactionHash=${txHash}&chainId=${chainId}&oracleType=${castOracleNameForOOUi(
     oracleType
-  )}`;
+  )}&eventIndex=`;
 }
 
 function castOracleNameForOOUi(oracleType: string): string {

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -258,19 +258,13 @@ export type AugmentedVoteDataResponseT = ss.Infer<
 >;
 
 export type VoteAugmentedDataT = {
-  augmentedData: AugmentedVoteDataT | undefined;
+  augmentedData: AugmentedVoteDataResponseT | undefined;
 };
 
-export type AugmentedVoteDataT = {
-  l1RequestTxHash: string;
-  uniqueKey: UniqueKeyT;
-  ooRequestUrl: string | undefined;
-  originatingChainTxHash: string | undefined;
-  originatingChainId: SupportedChainIds | undefined;
-  originatingOracleType: OracleTypeT | undefined;
-};
-
-export type AugmentedVoteDataByKeyT = Record<UniqueKeyT, AugmentedVoteDataT>;
+export type AugmentedVoteDataByKeyT = Record<
+  UniqueKeyT,
+  AugmentedVoteDataResponseT
+>;
 
 export type TransactionHashT = string;
 

--- a/web3/queries/votes/getAugmentedVoteData.ts
+++ b/web3/queries/votes/getAugmentedVoteData.ts
@@ -1,7 +1,7 @@
 import * as ss from "superstruct";
 import {
-  AugmentedVoteDataByKeyT,
   AugmentedVoteDataResponseT,
+  AugmentedVoteDataByKeyT,
   PriceRequestByKeyT,
 } from "types";
 import { config } from "helpers/config";


### PR DESCRIPTION
## motivation
we arent correctly detecting osnap assertions, and not showing relevant data

## changes
1. this makes it so we correctly detect assertions ( we were looking for a string that doesnt exist on these osnap assertions )
2. we decode the claim now in details
3. we have the correct options, previously the options were missing, so votes should be woking

with more time we need to fix showing the correct title, and parsing the claim data similar to OO.