### PR TITLE
fix: allow commas without a trailing space

### DIFF
--- a/helpers/voting/polymarket.ts
+++ b/helpers/voting/polymarket.ts
@@ -24,8 +24,9 @@ function dynamicPolymarketOptions(
   const resData = decodedAncillaryData.match(
     /res_data: (p\d): (\d+\.\d+|\d+), (p\d): (\d+\.\d+|\d+), (p\d): (\d+\.\d+|\d+)/
   );
+  // Match any character except commas that are followed by a space, we use ", " as a delimiter. This way we can allow a string like "$2,000" to be matched.
   const correspondence = decodedAncillaryData.match(
-    /Where (p\d) corresponds to ([^,]+), (p\d) to ([^,]+), (p\d) to ([^.,]+)/
+    /Where (p\d) corresponds to ((?:[^,]|,(?!\s))+), (p\d) to ((?:[^,]|,(?!\s))+), (p\d) to ([^.,]+)/
   );
 
   if (!resData || !correspondence) return [];


### PR DESCRIPTION
## Motiviation

This _corresponds_ string in a vote's ancillaryData: `Where p1 corresponds to $2,200, p2 to $1,800, p3 to unknown/50-50`,  was not getting any matches, because the values contain commas. 
 
 This change allows commas, but only if they don't have a space after them, since we want to keep those as the delimiter.