### PR TITLE
feat: ensure we fetch all past votes

### DIFF
--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -1,7 +1,8 @@
 import { utils } from "ethers";
-import request, { gql } from "graphql-request";
+import { gql } from "graphql-request";
 import { formatBytes32String, makePriceRequestsByKey } from "helpers";
 import { config } from "helpers/config";
+import { fetchAllDocuments } from "helpers/util/fetchAllDocuments";
 import { PastVotesQuery, RevealedVotesByAddress } from "types";
 
 const { graphEndpoint } = config;
@@ -93,8 +94,14 @@ export async function getPastVotesV2() {
       }
     }
   `;
-  const result = await request<PastVotesQuery>(endpoint, pastVotesQuery);
-  return result?.priceRequests?.map(
+
+  const result = await fetchAllDocuments<PastVotesQuery>(
+    endpoint,
+    pastVotesQuery,
+    "priceRequests"
+  );
+
+  return result?.map(
     ({
       identifier: { id },
       time,

--- a/helpers/util/fetchAllDocuments.ts
+++ b/helpers/util/fetchAllDocuments.ts
@@ -1,0 +1,40 @@
+import request from "graphql-request";
+
+/**
+ * Thegraph can only return a maximum of 1000 documents at a time and does not support pagination features whereby the client can determine the total amount of documents in the store.
+ * This helper requests 1000 documents at a time until there are no more ensuring we don't miss any
+ * @param endpoint the endpoint for your graphql request
+ * @param query your graphql request document
+ * @param dataKey the key for the data you want. this is the root key of your graphql document
+ * @param pageSize Chunk size per request. 1000 is the max we get back from thegraph but you can customize this.
+ * @returns a flattened array of the document[dataKey] for all requests
+ */
+export async function fetchAllDocuments<
+  RequestType extends {
+    [key: string]: unknown[];
+  }
+>(
+  endpoint: string,
+  query: string,
+  dataKey: keyof RequestType,
+  pageSize = 1000
+) {
+  let allData = new Array<RequestType[keyof RequestType][number]>();
+  let skip = 0;
+  let continueFetching = true;
+
+  while (continueFetching) {
+    const variables = { skip, limit: pageSize };
+    const response = await request<RequestType>(endpoint, query, variables);
+    allData = allData.concat(response[dataKey]);
+
+    // if we get less than 1000 we know we got them all
+    if (response[dataKey].length < pageSize) {
+      continueFetching = false;
+    } else {
+      skip += pageSize;
+    }
+  }
+
+  return allData;
+}

--- a/helpers/util/fetchAllDocuments.ts
+++ b/helpers/util/fetchAllDocuments.ts
@@ -21,20 +21,15 @@ export async function fetchAllDocuments<
 ) {
   let allData = new Array<RequestType[keyof RequestType][number]>();
   let skip = 0;
-  let continueFetching = true;
+  let response: RequestType;
 
-  while (continueFetching) {
+  do {
     const variables = { skip, limit: pageSize };
-    const response = await request<RequestType>(endpoint, query, variables);
+    response = await request<RequestType>(endpoint, query, variables);
     allData = allData.concat(response[dataKey]);
-
+    skip += pageSize;
     // if we get less than 1000 we know we got them all
-    if (response[dataKey].length < pageSize) {
-      continueFetching = false;
-    } else {
-      skip += pageSize;
-    }
-  }
+  } while (!(response[dataKey].length < pageSize));
 
   return allData;
 }


### PR DESCRIPTION
## motivation

thegraph server only returns 1000 documents at a time and does not support standard PageInfo features like cursors for pagination. So we might get into a situation where we think we are fetching all documents but we're only fetching this first 1000. 

It seems unlikely that we'll ever have more than 1000 upcoming votes so I'm only implementing this logic for `pastVotes`

In this solution all we're doing is fetching 1000 at a time until we get less that 1000 then we know we've got them all. 

closes #UMA-2125