### PR TITLE
clamp lines to 2 in vote list titles

### DIFF
--- a/components/VoteList/VoteList.tsx
+++ b/components/VoteList/VoteList.tsx
@@ -19,7 +19,7 @@ export function VoteList({ data, activityStatus }: Props) {
 
   if (isTabletAndUnder)
     return (
-      <div className="grid gap-1">
+      <div className="flex flex-col gap-1">
         {data.map((item) => (
           <VoteListItem key={item.vote.uniqueKey} {...item} />
         ))}

--- a/components/VoteList/VoteListItem.tsx
+++ b/components/VoteList/VoteListItem.tsx
@@ -51,7 +51,7 @@ export function VoteListItem(props: VoteListItemProps) {
     useOptimisticGovernorData(props.vote.decodedAncillaryData);
 
   const optimisticGovernorTitle = isOptimisticGovernorVote
-    ? getOptimisticGovernorTitle(explanationText).slice(0, 50) + "..."
+    ? getOptimisticGovernorTitle(explanationText)
     : "";
 
   const voteOrigin = isOptimisticGovernorVote ? "OSnap" : origin;

--- a/components/VoteList/VoteListItem.tsx
+++ b/components/VoteList/VoteListItem.tsx
@@ -59,12 +59,12 @@ export function VoteListItem(props: VoteListItemProps) {
   return (
     <div
       style={style}
-      className="grid h-auto w-full items-start gap-[12px] rounded bg-white p-3"
+      className="flex h-auto w-full max-w-full flex-col items-start gap-[12px] rounded bg-white p-3"
     >
       <div className="w-full rounded-l">
         <div className="align-center flex border-b-[--border-color] pb-1">
-          <div>
-            <h3 className="mb-1 text-lg font-semibold">
+          <div className="w-full">
+            <h3 className="mb-1 line-clamp-2 w-full break-words text-lg font-semibold">
               {optimisticGovernorTitle || titleText}
             </h3>
             <div className="flex gap-2 align-baseline">

--- a/components/VoteList/VoteTableRow.tsx
+++ b/components/VoteList/VoteTableRow.tsx
@@ -74,11 +74,11 @@ export function VoteTableRow(props: VoteListItemProps) {
 
   return (
     <tr
-      className="group h-[80px] cursor-pointer rounded bg-white"
+      className="group min-h-[80px] cursor-pointer rounded bg-white"
       style={style}
       onClick={moreDetailsAction}
     >
-      <td className="rounded-l px-[--cell-padding]">
+      <td className="rounded-l p-[--cell-padding]">
         <div className="flex items-center gap-[--cell-padding]">
           <div className="min-w-[--title-icon-size]">
             <div className="w-[--title-icon-size]">
@@ -92,7 +92,7 @@ export function VoteTableRow(props: VoteListItemProps) {
             </div>
           </div>
           <div>
-            <h3 className="max-w-[500px] overflow-hidden text-ellipsis text-lg font-semibold transition duration-300 group-hover:text-red-500">
+            <h3 className="line-clamp-2 max-w-[500px] text-lg font-semibold transition duration-300 group-hover:text-red-500">
               {optimisticGovernorTitle || titleText}
             </h3>
             <div className="flex gap-2 align-baseline">

--- a/components/VoteList/VoteTableRow.tsx
+++ b/components/VoteList/VoteTableRow.tsx
@@ -92,7 +92,7 @@ export function VoteTableRow(props: VoteListItemProps) {
             </div>
           </div>
           <div>
-            <h3 className="line-clamp-2 max-w-[500px] text-lg font-semibold transition duration-300 group-hover:text-red-500">
+            <h3 className="line-clamp-2 max-w-[500px] break-words text-lg font-semibold transition duration-300 group-hover:text-red-500">
               {optimisticGovernorTitle || titleText}
             </h3>
             <div className="flex gap-2 align-baseline">


### PR DESCRIPTION
## motivation

We want to use CSS to truncate text if it spans more than 2 lines. We think 2 lines is more than enough space for a title, but in the rare case that it is larger we don't want to break the layout.

## screenshots

![Screenshot 2024-01-29 at 18 29 55](https://github.com/UMAprotocol/voter-dapp-v2/assets/51655063/525736b1-1e82-4404-9782-75d4c6c4fe51)

closes UMA-2311
