### PR TITLE
fix: use og graph to determine if is og vote

### DIFF
--- a/helpers/voting/optimisticGovernor.ts
+++ b/helpers/voting/optimisticGovernor.ts
@@ -1,9 +1,2 @@
-export function checkIfIsOptimisticGovernor(decodedAncillaryData: string) {
-  return (
-    decodedAncillaryData.includes("assertionId:") &&
-    decodedAncillaryData.includes("ooAsserter:")
-  );
-}
-
 export const getOptimisticGovernorTitle = (explanation?: string) =>
   `oSnap Request ${explanation ?? ""}`;

--- a/hooks/queries/votes/useOptimisticGovernorData.ts
+++ b/hooks/queries/votes/useOptimisticGovernorData.ts
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { checkIfIsOptimisticGovernor } from "helpers";
 import { MainnetOrGoerli } from "types";
 
 import { useSetChain } from "@web3-onboard/react";
@@ -78,16 +77,12 @@ export function useOptimisticGovernorData(decodedAncillaryData: string) {
   const { isWrongChain } = useWalletContext();
   const { onError } = useHandleError({ isDataFetching: true });
 
-  const isOptimisticGovernorVote =
-    checkIfIsOptimisticGovernor(decodedAncillaryData);
-
   const [_, assertionId, ooAsserter] =
     decodedAncillaryData.match(
       /assertionId:([a-f0-9]+),ooAsserter:([a-f0-9]+)/
     ) || [];
 
-  const shouldFetch =
-    isOptimisticGovernorVote && !isWrongChain && assertionId != null;
+  const shouldFetch = !isWrongChain && assertionId != null;
 
   const queryResult = useQuery({
     queryKey: [assertionId, ooAsserter, connectedChain?.id],
@@ -99,9 +94,10 @@ export function useOptimisticGovernorData(decodedAncillaryData: string) {
     enabled: shouldFetch,
     onError,
   });
+  const isOptimisticGovernorVote = !!queryResult?.data?.proposal;
 
   const ipfsData = useIpfs<SnapshotData>(
-    queryResult?.data?.proposal.explanationText
+    queryResult?.data?.proposal?.explanationText
   );
 
   return {


### PR DESCRIPTION
## motivation
Non osnap assertion votes are causing app to crash

## changes
This uses the subgraph to determine if something is a og vote, rather than the ancillary data