### PR TITLE
fix: load claim data through hook which is more reliable

### DIFF
--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -14,6 +14,8 @@ import {
 } from "helpers";
 import { config } from "helpers/config";
 import { useOptimisticGovernorData } from "hooks/queries/votes/useOptimisticGovernorData";
+import { useAssertionClaim } from "hooks";
+
 import AncillaryData from "public/assets/icons/ancillary-data.svg";
 import Chat from "public/assets/icons/chat.svg";
 import Chevron from "public/assets/icons/chevron.svg";
@@ -44,6 +46,7 @@ export function Details({
   augmentedData,
   assertionChildChainId,
   assertionAsserter,
+  assertionId,
 }: VoteT) {
   const [showDecodedAdminTransactions, setShowDecodedAdminTransactions] =
     useState(false);
@@ -51,7 +54,7 @@ export function Details({
   const [showRawClaimData, setShowRawClaimData] = useState(false);
   const { isOptimisticGovernorVote, explanationText, rules, ipfs } =
     useOptimisticGovernorData(decodedAncillaryData);
-  const claim = augmentedData?.optimisticOracleV3Data?.claim;
+  const { data: claim } = useAssertionClaim(assertionChildChainId, assertionId);
   const isClaim = !!claim;
   const showAncillaryData = !isClaim;
 

--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -1,7 +1,9 @@
+import removeMarkdown from "remove-markdown";
+
 import { Tabs } from "components";
 import { decodeHexString } from "helpers";
 import { getOptimisticGovernorTitle } from "helpers/voting/optimisticGovernor";
-import { useVoteDiscussion } from "hooks";
+import { useVoteDiscussion, useAssertionClaim } from "hooks";
 import { useOptimisticGovernorData } from "hooks/queries/votes/useOptimisticGovernorData";
 import { VoteT } from "types";
 import { PanelFooter } from "../PanelFooter";
@@ -26,8 +28,9 @@ export function VotePanel({ content }: Props) {
     results,
     isGovernance,
     options,
-    augmentedData,
     decodedAncillaryData,
+    assertionId,
+    assertionChildChainId,
   } = content;
 
   const { isOptimisticGovernorVote, explanationText } =
@@ -44,11 +47,11 @@ export function VotePanel({ content }: Props) {
       time,
     }
   );
-  const claim = augmentedData?.optimisticOracleV3Data?.claim;
+  const { data: claim } = useAssertionClaim(assertionChildChainId, assertionId);
 
   const titleOrClaimOrIdentifier =
     optimisticGovernorTitle ||
-    (claim ? decodeHexString(claim) : title ?? decodedIdentifier);
+    removeMarkdown(claim ? decodeHexString(claim) : title ?? decodedIdentifier);
 
   const titleToShow =
     titleOrClaimOrIdentifier.length > 100


### PR DESCRIPTION
## motivation
title and claim data is not showing up correctly for current vote

## changes
augmented data does not seem to be loading, so use the hook useAssertionClaim instead to fetch claim data. this seems to resolve the issues. 
![image](https://github.com/UMAprotocol/voter-dapp-v2/assets/4429761/e8c576a2-80b4-463c-a7f3-228b34163c0e)
