### PR TITLE
fix: parse yes_no query options

### DIFF
--- a/helpers/voting/getVoteMetaData.ts
+++ b/helpers/voting/getVoteMetaData.ts
@@ -130,12 +130,18 @@ export function getVoteMetaData(
     const description = identifierDetails.summary;
     const umipOrUppUrl = identifierDetails.umipLink.url;
     const umipOrUppNumber = identifierDetails.umipLink.number;
+
+    const isYesNoQuery = decodedIdentifier === "YES_OR_NO_QUERY";
+    const options = isYesNoQuery
+      ? maybeMakePolymarketOptions(decodedAncillaryData)
+      : undefined;
+
     return {
       title,
       description,
       umipOrUppLink: maybeMakeUmipOrUppLink(umipOrUppNumber, umipOrUppUrl),
       umipOrUppNumber,
-      options: undefined,
+      options,
       origin: "UMA",
       isGovernance: false,
       discordLink,


### PR DESCRIPTION
## motivation
non polymarket yes or no query not showing drop down options for voting

## changes
this attempts to parse options from ancillary data in polymarket style, but not attribute it to a polymarket vote