### PR TITLE
feat: add multiple choice query parsing

### DIFF
--- a/constant/voting/earlyRequestMagicNumber.ts
+++ b/constant/voting/earlyRequestMagicNumber.ts
@@ -3,6 +3,11 @@ export const earlyRequestMagicNumber =
 export const earlyRequestMagicNumberWei =
   "-57896044618658097711785492504343953926634992332820282019728792003956564819968";
 
+export const answerNotPossible =
+  "57896044618658097711785492504343953926634992332820282019728.792003956564819967";
+export const answerNotPossibleWei =
+  "57896044618658097711785492504343953926634992332820282019728792003956564819967";
+
 export function isEarlyVote(value: string | undefined):boolean{
   if(value === undefined) return false
   return [earlyRequestMagicNumber, earlyRequestMagicNumberWei].includes(value)


### PR DESCRIPTION
## motivation
we added the mutliple choice query identifier but its not yet supported in voter dapp

## changes
this copies over parser from oracle dapp, with a couple modifications
- adds a too early response for magic number
- modfies logic for the format voterdapp expects

before
![image](https://github.com/UMAprotocol/voter-dapp-v2/assets/4429761/f8612640-d668-497b-8541-cfce71c4511f)
![image](https://github.com/UMAprotocol/voter-dapp-v2/assets/4429761/80587e41-a67c-462e-afeb-165c21e73c81)

after
![image](https://github.com/UMAprotocol/voter-dapp-v2/assets/4429761/42a7b8db-aec4-45fc-8577-394d9d233ca6)
![image](https://github.com/UMAprotocol/voter-dapp-v2/assets/4429761/4bf617e8-5803-4972-aa90-354527d0dba8)
