### PR TITLE
correctly coerce to boolean when filtering rpcUrls

### DIFF
--- a/web3/contracts/createOOV3ContractInstances.ts
+++ b/web3/contracts/createOOV3ContractInstances.ts
@@ -74,7 +74,7 @@ export const contractDetails = [
 
 export function createOOV3ContractInstances() {
   const instances = contractDetails
-    .filter(({ providerUrl }) => new Boolean(providerUrl))
+    .filter(({ providerUrl }) => Boolean(providerUrl))
     .map(({ chainId, providerUrl, address }) => {
       const provider = new ethers.providers.JsonRpcProvider(providerUrl);
       return {


### PR DESCRIPTION
## Motivation

The app was not correctly filtering out config items where the rpc URL is undefined and the ethers will attempt to connect to `localhost:8545` if none is provided, hence the errors in console.

The fix is pretty simple, we were not coercing the value to a boolean, we were creating a Boolean _object_ which will always be truthy.