### PR TITLE
fix: migrate to graph studio

### DIFF
--- a/helpers/config.ts
+++ b/helpers/config.ts
@@ -14,6 +14,7 @@ const Env = ss.object({
   NEXT_PUBLIC_ONBOARD_API_KEY: ss.string(),
   NEXT_PUBLIC_CURRENT_ENV: ss.string(),
   NEXT_PUBLIC_WALLET_CONNECT: ss.string(),
+  NEXT_PUBLIC_GRAPH_STUDIO_API_KEY: ss.string(),
   // optional envs
   NEXT_PUBLIC_CONTENTFUL_SPACE_ID: ss.optional(ss.string()),
   NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN: ss.optional(ss.string()),
@@ -70,6 +71,8 @@ export const env = ss.create(
     NEXT_PUBLIC_PHASE_LENGTH: process.env.NEXT_PUBLIC_PHASE_LENGTH,
     NEXT_PUBLIC_MAILCHIMP_URL: process.env.NEXT_PUBLIC_MAILCHIMP_URL,
     NEXT_PUBLIC_MAILCHIMP_TAGS: process.env.NEXT_PUBLIC_MAILCHIMP_TAGS,
+    NEXT_PUBLIC_GRAPH_STUDIO_API_KEY:
+      process.env.NEXT_PUBLIC_GRAPH_STUDIO_API_KEY,
     NEXT_PUBLIC_PROVIDER_V3_1: process.env.NEXT_PUBLIC_PROVIDER_V3_1,
     NEXT_PUBLIC_PROVIDER_V3_137: process.env.NEXT_PUBLIC_PROVIDER_V3_137,
     NEXT_PUBLIC_PROVIDER_V3_288: process.env.NEXT_PUBLIC_PROVIDER_V3_288,
@@ -95,6 +98,7 @@ const AppConfig = ss.object({
   deployBlock: ss.number(),
   chainId: ss.number(),
   walletConnectProjectId: ss.string(),
+  graphStudioApiKey: ss.string(),
   graphEndpointV1: ss.optional(ss.string()),
   graphEndpoint: ss.optional(ss.string()),
   contentfulSpace: ss.optional(ss.string()),
@@ -150,6 +154,7 @@ export const appConfig = ss.create(
     phaseLength: Number(env.NEXT_PUBLIC_PHASE_LENGTH || 86400),
     mailchimpUrl: env.NEXT_PUBLIC_MAILCHIMP_URL,
     mailchimpTags: env.NEXT_PUBLIC_MAILCHIMP_TAGS,
+    graphStudioApiKey: env.NEXT_PUBLIC_GRAPH_STUDIO_API_KEY,
     oov3ProviderUrl1: process.env.NEXT_PUBLIC_PROVIDER_V3_1,
     oov3ProviderUrl137: process.env.NEXT_PUBLIC_PROVIDER_V3_137,
     oov3ProviderUrl288: process.env.NEXT_PUBLIC_PROVIDER_V3_288,

--- a/hooks/queries/votes/useOptimisticGovernorData.ts
+++ b/hooks/queries/votes/useOptimisticGovernorData.ts
@@ -3,6 +3,7 @@ import { MainnetOrL1Testnet } from "types";
 
 import { useSetChain } from "@web3-onboard/react";
 import request, { gql } from "graphql-request";
+import { appConfig } from "helpers";
 import { useWalletContext } from "hooks/contexts/useWalletContext";
 import { useHandleError } from "hooks/helpers/useHandleError";
 import { useIpfs } from "./useIpfs";
@@ -57,20 +58,20 @@ export async function getProposalData(
   let endpoint: string;
   switch (chainId) {
     case 1:
-      endpoint =
-        "https://api.thegraph.com/subgraphs/name/umaprotocol/mainnet-optimistic-governor";
+      endpoint = `https://gateway-arbitrum.network.thegraph.com/api/${appConfig.graphStudioApiKey}/subgraphs/id/DQpwhiRSPQJEuc8y6ZBGsFfNpfwFQ8NjmjLmfv8kBkLu`;
       break;
     case 5:
       endpoint =
+        // TODO: Consider removing as hosted service is deprecated and Studio does not support Goerli.
         "https://api.thegraph.com/subgraphs/name/umaprotocol/goerli-optimistic-governor";
       break;
     case 11155111:
       endpoint =
-        "https://api.thegraph.com/subgraphs/name/reinis-frp/sepolia-optimistic-governor";
+        // TODO: update to production endpoint once it is indexed.
+        "https://api.studio.thegraph.com/query/1057/sepolia-optimistic-governor/version/latest";
       break;
     default:
-      endpoint =
-        "https://api.thegraph.com/subgraphs/name/umaprotocol/mainnet-optimistic-governor";
+      endpoint = `https://gateway-arbitrum.network.thegraph.com/api/${appConfig.graphStudioApiKey}/subgraphs/id/DQpwhiRSPQJEuc8y6ZBGsFfNpfwFQ8NjmjLmfv8kBkLu`;
       break;
   }
   const proposalQuery = gql`


### PR DESCRIPTION
With the deprecation of hosted subgraph service we need to migrate to Subgraph Studio

Fixes: https://linear.app/uma/issue/UMA-2640/subgraph-studio-in-voter-dapp