### PR TITLE
reset outstanding rewards if no delegate wallet connected

### DIFF
--- a/contexts/DelegationContext.tsx
+++ b/contexts/DelegationContext.tsx
@@ -416,9 +416,12 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
 
   useInterval(() => {
     updateOutstandingRewards();
-  }, 100);
+  }, 1000);
 
   function updateOutstandingRewards() {
+    if (isNoWalletConnected || isNoDelegation) {
+      setOutstandingRewards(BigNumber.from(0));
+    }
     if (rewardCalculationInputs === undefined) return;
     if (stakerAddressStakerDetails === undefined) return;
     if (stakerAddressStakedBalance === undefined) return;


### PR DESCRIPTION
## To test

1. Connect delegate wallet, should have some outstanding rewards
2. Disconnect wallet => outstanding rewards should read `0`
3. Connect delegate wallet again (outstanding rewards should appear again) then switch to non-delegate wallet, outstanding rewards should now read `0`
