### PR TITLE
feat: improve wording around commited/revealed votes

### DIFF
--- a/components/Panel/VotePanel/Result.tsx
+++ b/components/Panel/VotePanel/Result.tsx
@@ -65,6 +65,11 @@ export function Result({
     return findVoteInOptions(value);
   }
 
+  const revealPercentage = (
+    (totalTokensVotedWith / totalTokensCommitted) *
+    100
+  ).toFixed(2);
+
   return (
     <Wrapper>
       <PanelSectionTitle>
@@ -112,7 +117,7 @@ export function Result({
           <Strong>{uniqueRevealAddresses}</Strong>
         </ParticipationItem>
         <ParticipationItem>
-          <span>Total tokens that commited</span>
+          <span>Total tokens that committed</span>
           <Strong>
             {totalTokensCommitted
               ? commify(truncateDecimals(totalTokensCommitted, 2))
@@ -122,6 +127,7 @@ export function Result({
         <ParticipationItem>
           <span>Total tokens that revealed</span>
           <Strong>
+            <Span>(%{revealPercentage})</Span>
             {totalTokensVotedWith
               ? commify(truncateDecimals(totalTokensVotedWith, 2))
               : 0}
@@ -143,6 +149,11 @@ function LegendItemLabel({ label }: { label: string }) {
   }
   return <LegendItemLabelWrapper>{label}</LegendItemLabelWrapper>;
 }
+
+const Span = styled.span`
+  color: var(--red-500);
+  margin-inline: 1em;
+`;
 
 const Wrapper = styled.div`
   margin-top: 20px;

--- a/components/Panel/VotePanel/Result.tsx
+++ b/components/Panel/VotePanel/Result.tsx
@@ -65,11 +65,6 @@ export function Result({
     return findVoteInOptions(value);
   }
 
-  const revealPercentage = (
-    (totalTokensVotedWith / totalTokensCommitted) *
-    100
-  ).toFixed(2);
-
   return (
     <Wrapper>
       <PanelSectionTitle>
@@ -124,15 +119,23 @@ export function Result({
               : 0}
           </Strong>
         </ParticipationItem>
-        <ParticipationItem>
-          <span>Total tokens that revealed</span>
-          <Strong>
-            <Span>(%{revealPercentage})</Span>
-            {totalTokensVotedWith
-              ? commify(truncateDecimals(totalTokensVotedWith, 2))
-              : 0}
-          </Strong>
-        </ParticipationItem>
+        {totalTokensCommitted && (
+          <ParticipationItem>
+            <span>Total tokens that revealed</span>
+            <Strong>
+              <Span>
+                (%
+                {((totalTokensVotedWith / totalTokensCommitted) * 100).toFixed(
+                  2
+                )}
+                )
+              </Span>
+              {totalTokensVotedWith
+                ? commify(truncateDecimals(totalTokensVotedWith, 2))
+                : 0}
+            </Strong>
+          </ParticipationItem>
+        )}
       </SectionWrapper>
       <PanelErrorBanner errorOrigin="vote" />
     </Wrapper>

--- a/components/Panel/VotePanel/Result.tsx
+++ b/components/Panel/VotePanel/Result.tsx
@@ -34,8 +34,12 @@ export function Result({
 
   if (!participation || !results) return null;
 
-  const { uniqueCommitAddresses, uniqueRevealAddresses, totalTokensVotedWith } =
-    participation;
+  const {
+    uniqueCommitAddresses,
+    uniqueRevealAddresses,
+    totalTokensVotedWith,
+    totalTokensCommitted,
+  } = participation;
 
   const resultsWithLabels = results.map(({ vote, tokensVotedWith }) => {
     const formatted = formatVoteStringWithPrecision(vote, decodedIdentifier);
@@ -106,6 +110,14 @@ export function Result({
         <ParticipationItem>
           <span>Unique reveal addresses</span>
           <Strong>{uniqueRevealAddresses}</Strong>
+        </ParticipationItem>
+        <ParticipationItem>
+          <span>Total tokens that commited</span>
+          <Strong>
+            {totalTokensCommitted
+              ? commify(truncateDecimals(totalTokensCommitted, 2))
+              : 0}
+          </Strong>
         </ParticipationItem>
         <ParticipationItem>
           <span>Total tokens that revealed</span>

--- a/graph/queries/getActiveVoteResults.ts
+++ b/graph/queries/getActiveVoteResults.ts
@@ -42,6 +42,9 @@ export async function getActiveVoteResults(): Promise<
           }
           committedVotes {
             id
+            voter {
+              voterStake
+            }
           }
           revealedVotes {
             id
@@ -54,6 +57,7 @@ export async function getActiveVoteResults(): Promise<
       }
     }
   `;
+
   const result = await request<PastVotesQuery>(endpoint, pastVotesQuery);
   return makePriceRequestsByKey(
     result?.priceRequests?.map(
@@ -68,10 +72,16 @@ export async function getActiveVoteResults(): Promise<
         const identifier = formatBytes32String(id);
         const correctVote = price;
         const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
+        // no counter field in entity so we must do this calculation client side
+        const totalTokensCommitted = latestRound.committedVotes
+          .map((v) => Number(v.voter.voterStake))
+          .reduce((acc, curr) => acc + curr, 0);
+
         const participation = {
           uniqueCommitAddresses: latestRound.committedVotes.length,
           uniqueRevealAddresses: latestRound.revealedVotes.length,
           totalTokensVotedWith,
+          totalTokensCommitted,
         };
         const results = latestRound.groups.map(
           ({ price, totalVoteAmount }) => ({

--- a/graph/queries/getActiveVoteResults.ts
+++ b/graph/queries/getActiveVoteResults.ts
@@ -72,10 +72,17 @@ export async function getActiveVoteResults(): Promise<
         const identifier = formatBytes32String(id);
         const correctVote = price;
         const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
+
+        // for v1 this data is missing so we need to dynamically check this
+        const hasVoterStakeDetails = latestRound.committedVotes.some(
+          (v) => v.voter?.voterStake
+        );
         // no counter field in subgraph entity so we must do this calculation client side
-        const totalTokensCommitted = latestRound.committedVotes
-          .map((v) => Number(v.voter.voterStake))
-          .reduce((acc, curr) => acc + curr, 0);
+        const totalTokensCommitted = hasVoterStakeDetails
+          ? latestRound.committedVotes
+              .map((v) => Number(v?.voter?.voterStake))
+              .reduce((acc, curr) => acc + curr, 0)
+          : undefined;
 
         const participation = {
           uniqueCommitAddresses: latestRound.committedVotes.length,

--- a/graph/queries/getActiveVoteResults.ts
+++ b/graph/queries/getActiveVoteResults.ts
@@ -72,7 +72,7 @@ export async function getActiveVoteResults(): Promise<
         const identifier = formatBytes32String(id);
         const correctVote = price;
         const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
-        // no counter field in entity so we must do this calculation client side
+        // no counter field in subgraph entity so we must do this calculation client side
         const totalTokensCommitted = latestRound.committedVotes
           .map((v) => Number(v.voter.voterStake))
           .reduce((acc, curr) => acc + curr, 0);
@@ -83,6 +83,7 @@ export async function getActiveVoteResults(): Promise<
           totalTokensVotedWith,
           totalTokensCommitted,
         };
+
         const results = latestRound.groups.map(
           ({ price, totalVoteAmount }) => ({
             vote: price,

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -84,6 +84,9 @@ export async function getPastVotesV2() {
           }
           committedVotes {
             id
+            voter {
+              voterStake
+            }
           }
           revealedVotes {
             id
@@ -115,10 +118,16 @@ export async function getPastVotesV2() {
       const identifier = formatBytes32String(id);
       const correctVote = price;
       const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
+      // no counter field in subgraph entity so we must do this calculation client side
+      const totalTokensCommitted = latestRound.committedVotes
+        .map((v) => Number(v.voter.voterStake))
+        .reduce((acc, curr) => acc + curr, 0);
+
       const participation = {
         uniqueCommitAddresses: latestRound.committedVotes.length,
         uniqueRevealAddresses: latestRound.revealedVotes.length,
         totalTokensVotedWith,
+        totalTokensCommitted,
       };
       const results = latestRound.groups.map(({ price, totalVoteAmount }) => ({
         vote: price,

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -25,16 +25,11 @@ export async function getPastVotesV1() {
       const identifier = formatBytes32String(id);
       const correctVote = price;
       const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
-      // no counter field in subgraph entity so we must do this calculation client side
-      const totalTokensCommitted = latestRound.committedVotes
-        .map((v) => Number(v.voter.voterStake))
-        .reduce((acc, curr) => acc + curr, 0);
 
       const participation = {
         uniqueCommitAddresses: committedVotes.length,
         uniqueRevealAddresses: revealedVotes.length,
         totalTokensVotedWith,
-        totalTokensCommitted,
       };
 
       const results = latestRound.groups.map(({ price, totalVoteAmount }) => ({
@@ -124,10 +119,17 @@ export async function getPastVotesV2() {
       const identifier = formatBytes32String(id);
       const correctVote = price;
       const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
+
+      // for v1 this data is missing so we need to dynamically check this
+      const hasVoterStakeDetails = latestRound.committedVotes.some(
+        (v) => v.voter?.voterStake
+      );
       // no counter field in subgraph entity so we must do this calculation client side
-      const totalTokensCommitted = latestRound.committedVotes
-        .map((v) => Number(v.voter.voterStake))
-        .reduce((acc, curr) => acc + curr, 0);
+      const totalTokensCommitted = hasVoterStakeDetails
+        ? latestRound.committedVotes
+            .map((v) => Number(v?.voter?.voterStake))
+            .reduce((acc, curr) => acc + curr, 0)
+        : undefined;
 
       const participation = {
         uniqueCommitAddresses: latestRound.committedVotes.length,

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -25,10 +25,16 @@ export async function getPastVotesV1() {
       const identifier = formatBytes32String(id);
       const correctVote = price;
       const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
+      // no counter field in subgraph entity so we must do this calculation client side
+      const totalTokensCommitted = latestRound.committedVotes
+        .map((v) => Number(v.voter.voterStake))
+        .reduce((acc, curr) => acc + curr, 0);
+
       const participation = {
         uniqueCommitAddresses: committedVotes.length,
         uniqueRevealAddresses: revealedVotes.length,
         totalTokensVotedWith,
+        totalTokensCommitted,
       };
 
       const results = latestRound.groups.map(({ price, totalVoteAmount }) => ({

--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -61,6 +61,8 @@ function formatPriceRequest(
       priceRequest?.participation?.uniqueRevealAddresses || 0,
     totalTokensVotedWith:
       priceRequest?.participation?.totalTokensVotedWith || 0,
+    totalTokensCommitted:
+      priceRequest?.participation?.totalTokensCommitted || 0,
   };
   const results = priceRequest.results;
   const uniqueKey = makeUniqueKeyForVote(

--- a/stories/BaseComponents/navigation/Panel.stories.tsx
+++ b/stories/BaseComponents/navigation/Panel.stories.tsx
@@ -241,6 +241,7 @@ export const VotePanelWithResults: Story = {
         uniqueCommitAddresses: 100,
         uniqueRevealAddresses: 100,
         totalTokensVotedWith: 800000000.123,
+        totalTokensCommitted: 690000000.123,
       },
       results: [
         {

--- a/types/queries.ts
+++ b/types/queries.ts
@@ -15,7 +15,7 @@ export type PastVotesQuery = {
       }[];
       committedVotes: {
         id: string;
-        voter: {
+        voter?: {
           voterStake: string;
         };
       }[];

--- a/types/queries.ts
+++ b/types/queries.ts
@@ -15,6 +15,9 @@ export type PastVotesQuery = {
       }[];
       committedVotes: {
         id: string;
+        voter: {
+          voterStake: string;
+        };
       }[];
       revealedVotes: {
         id: string;

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -40,6 +40,7 @@ export type ParticipationT = {
   uniqueCommitAddresses: number;
   uniqueRevealAddresses: number;
   totalTokensVotedWith: number;
+  totalTokensCommitted: number;
 };
 
 export type VoteParticipationT = {

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -40,7 +40,7 @@ export type ParticipationT = {
   uniqueCommitAddresses: number;
   uniqueRevealAddresses: number;
   totalTokensVotedWith: number;
-  totalTokensCommitted: number;
+  totalTokensCommitted?: number;
 };
 
 export type VoteParticipationT = {


### PR DESCRIPTION
## motivation

Some users have noticed it is a bit unclear how many users have committed or revealed since the UI previously only shows amount of **votes**. 
Now we show how many tokens committed and revealed. we also show the percentage of users that revealed.

## screenshots

![Screenshot 2024-07-11 at 16 23 51](https://github.com/UMAprotocol/voter-dapp-v2/assets/51655063/6a8c92b5-a401-4cff-9715-9ef9fdc184e2)
