### PR TITLE
fix: use the graph for augmented data

### DIFF
--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -14,7 +14,7 @@ import {
 } from "helpers";
 import { config } from "helpers/config";
 import { useOptimisticGovernorData } from "hooks/queries/votes/useOptimisticGovernorData";
-import { useAssertionClaim } from "hooks";
+import { useAssertionClaim, useAugmentedVoteData } from "hooks";
 
 import AncillaryData from "public/assets/icons/ancillary-data.svg";
 import Chat from "public/assets/icons/chat.svg";
@@ -43,7 +43,6 @@ export function Details({
   discordLink,
   decodedAdminTransactions,
   umipOrUppLink,
-  augmentedData,
   assertionChildChainId,
   assertionAsserter,
   assertionId,
@@ -68,6 +67,13 @@ export function Details({
   function toggleShowRawClaimData() {
     setShowRawClaimData(!showRawClaimData);
   }
+
+  const augmentedDataResponse = useAugmentedVoteData({
+    time,
+    identifier: decodedIdentifier,
+    ancillaryData: ancillaryData,
+  });
+  const augmentedData = augmentedDataResponse.data;
 
   function makeOoRequestLink() {
     if (!augmentedData?.ooRequestUrl) return;

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -4,7 +4,6 @@ import {
   useAccountDetails,
   useActiveVoteResults,
   useActiveVotes,
-  useAugmentedVoteData,
   useCommittedVotes,
   useCommittedVotesByCaller,
   useCommittedVotesForDelegator,
@@ -146,7 +145,6 @@ export function VotesProvider({ children }: { children: ReactNode }) {
     userOrDelegatorAddress
   );
   const { data: decodedAdminTransactions } = useDecodedAdminTransactions();
-  const { data: augmentedData } = useAugmentedVoteData();
   const { voteHistoryByKey } = votingAndStakingDetails || {};
 
   // This function tells you if your current logged in account can reveal this vote, ie the commit was cast by your current account.
@@ -218,7 +216,6 @@ export function VotesProvider({ children }: { children: ReactNode }) {
           ? { price: pastVoteRevealed, salt: "" }
           : decryptedVotes?.[uniqueKey],
         contentfulData: contentfulData?.[uniqueKey],
-        augmentedData: augmentedData?.[uniqueKey],
         voteHistory: voteHistoryByKey?.[uniqueKey] ?? {
           uniqueKey,
           voted: false,

--- a/hooks/queries/votes/useAugmentedVoteData.ts
+++ b/hooks/queries/votes/useAugmentedVoteData.ts
@@ -1,27 +1,32 @@
+import assert from "assert";
 import { useQuery } from "@tanstack/react-query";
 import { augmentedVoteDataKey } from "constant";
 import { getAugmentedVoteData } from "web3";
-import { useActiveVotes } from "./useActiveVotes";
-import { usePastVotes } from "./usePastVotes";
-import { useUpcomingVotes } from "./useUpcomingVotes";
 
-export function useAugmentedVoteData() {
-  const { data: activeVotes } = useActiveVotes();
-  const { data: upcomingVotes } = useUpcomingVotes();
-  const { data: pastVotes } = usePastVotes();
-
-  const allVotes = { ...activeVotes, ...upcomingVotes, ...pastVotes };
-
-  const queryResult = useQuery({
+export function useAugmentedVoteData(
+  params: Partial<{
+    ancillaryData: string;
+    time: number;
+    identifier: string;
+  }>
+) {
+  return useQuery({
     queryKey: [
       augmentedVoteDataKey,
-      activeVotes,
-      upcomingVotes,
-      pastVotes,
-      allVotes,
+      params.identifier ?? "",
+      (params.time ?? 0).toString(),
+      params.ancillaryData ?? "",
     ],
-    queryFn: () => getAugmentedVoteData(allVotes),
+    queryFn: () => {
+      assert(params.identifier, "identifier missing");
+      assert(params.time, "time missing");
+      assert(params.ancillaryData, "ancillaryData missing");
+      return getAugmentedVoteData({
+        identifier: params.identifier,
+        time: params.time,
+        ancillaryData: params.ancillaryData,
+      });
+    },
+    enabled: !!params.identifier && !!params.time && !!params.identifier,
   });
-
-  return queryResult;
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@tanstack/react-query": "^4.29.5",
     "@tanstack/react-query-devtools": "^4.29.6",
     "@uma/contracts-frontend": "^0.4.20",
-    "@vercel/kv": "^2.0.0",
     "@web3-onboard/core": "^2.20.4",
     "@web3-onboard/gnosis": "^2.1.10",
     "@web3-onboard/injected-wallets": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query": "^4.29.5",
     "@tanstack/react-query-devtools": "^4.29.6",
     "@uma/contracts-frontend": "^0.4.20",
+    "@vercel/kv": "^2.0.0",
     "@web3-onboard/core": "^2.20.4",
     "@web3-onboard/gnosis": "^2.1.10",
     "@web3-onboard/injected-wallets": "^2.10.1",
@@ -103,7 +104,7 @@
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.3.2",
     "ts-node": "^10.9.1",
-    "typescript": "4.8.3",
+    "typescript": "^5.5.3",
     "url": "^0.11.0",
     "webpack": "^5.74.0"
   },

--- a/pages/api/_common.ts
+++ b/pages/api/_common.ts
@@ -4,7 +4,10 @@ import { NodeUrls, SupportedChainIds } from "types";
 import { supportedChains } from "constant";
 import * as ss from "superstruct";
 
-export const VoteSubgraphURL = ss.assert(process.env.NEXT_PUBLIC_GRAPH_ENDPOINT,ss.string());
+export const VoteSubgraphURL: string = ss.create(
+  process.env.NEXT_PUBLIC_GRAPH_ENDPOINT,
+  ss.string()
+);
 
 type GetAddressParams = Parameters<typeof getAddress>;
 

--- a/pages/api/_common.ts
+++ b/pages/api/_common.ts
@@ -4,6 +4,8 @@ import { NodeUrls, SupportedChainIds } from "types";
 import { supportedChains } from "constant";
 import * as ss from "superstruct";
 
+export const VoteSubgraphURL = ss.assert(process.env.NEXT_PUBLIC_GRAPH_ENDPOINT,ss.string());
+
 type GetAddressParams = Parameters<typeof getAddress>;
 
 type GetAbiParams = Parameters<typeof getAbi>;

--- a/pages/api/_common.ts
+++ b/pages/api/_common.ts
@@ -2,6 +2,7 @@ import { getAbi, getAddress } from "@uma/contracts-node";
 import { Contract, ethers } from "ethers";
 import { NodeUrls, SupportedChainIds } from "types";
 import { supportedChains } from "constant";
+import * as ss from "superstruct";
 
 type GetAddressParams = Parameters<typeof getAddress>;
 
@@ -65,6 +66,10 @@ export const fromBlocks: Record<string, Record<number | string, number>> = {
     11155111: 5427310,
   },
 };
+export const ChainId = ss.enums([
+  1, 5, 10, 100, 137, 288, 416, 8453, 11155111, 1116, 42161, 43114, 80001,
+  80002, 81457,
+]);
 
 export function getFromBlock(
   oracleType: string,
@@ -72,4 +77,187 @@ export function getFromBlock(
   fallbackFromBlock = 0
 ): number {
   return fromBlocks?.[oracleType]?.[chainId] || fallbackFromBlock;
+}
+
+const SubgraphConfig = ss.object({
+  source: ss.literal("gql"),
+  url: ss.string(),
+  type: ss.enums([
+    "Optimistic Oracle V1",
+    "Optimistic Oracle V2",
+    "Optimistic Oracle V3",
+    "Skinny Optimistic Oracle",
+  ]),
+  chainId: ChainId,
+});
+
+export type SubgraphConfig = ss.Infer<typeof SubgraphConfig>;
+const SubgraphConfigs = ss.array(SubgraphConfig);
+export type SubgraphConfigs = ss.Infer<typeof SubgraphConfigs>;
+const Env = ss.object({
+  SUBGRAPH_V1_1: ss.optional(ss.string()),
+  SUBGRAPH_V2_1: ss.optional(ss.string()),
+  SUBGRAPH_V3_1: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_1: ss.optional(ss.string()),
+
+  SUBGRAPH_V1_10: ss.optional(ss.string()),
+  SUBGRAPH_V2_10: ss.optional(ss.string()),
+  SUBGRAPH_V3_10: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_10: ss.optional(ss.string()),
+
+  SUBGRAPH_V1_137: ss.optional(ss.string()),
+  SUBGRAPH_V2_137: ss.optional(ss.string()),
+  SUBGRAPH_V3_137: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_137: ss.optional(ss.string()),
+
+  SUBGRAPH_V1_5: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_5: ss.optional(ss.string()),
+  SUBGRAPH_V3_5: ss.optional(ss.string()),
+  SUBGRAPH_V2_5: ss.optional(ss.string()),
+
+  SUBGRAPH_V1_1116: ss.optional(ss.string()),
+  SUBGRAPH_V2_1116: ss.optional(ss.string()),
+  SUBGRAPH_V3_1116: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_1116: ss.optional(ss.string()),
+
+  SUBGRAPH_V1_80002: ss.optional(ss.string()),
+  SUBGRAPH_V2_80002: ss.optional(ss.string()),
+  SUBGRAPH_V3_80002: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_80002: ss.optional(ss.string()),
+
+  SUBGRAPH_V1_81457: ss.optional(ss.string()),
+  SUBGRAPH_V2_81457: ss.optional(ss.string()),
+  SUBGRAPH_V3_81457: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_81457: ss.optional(ss.string()),
+
+  SUBGRAPH_V2_11155111: ss.optional(ss.string()),
+  SUBGRAPH_V3_11155111: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_11155111: ss.optional(ss.string()),
+  SUBGRAPH_V1_11155111: ss.optional(ss.string()),
+
+  SUBGRAPH_V1_288: ss.optional(ss.string()),
+  SUBGRAPH_V2_288: ss.optional(ss.string()),
+  SUBGRAPH_V3_288: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_288: ss.optional(ss.string()),
+
+  SUBGRAPH_V1_42161: ss.optional(ss.string()),
+  SUBGRAPH_V2_42161: ss.optional(ss.string()),
+  SUBGRAPH_V3_42161: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_42161: ss.optional(ss.string()),
+
+  SUBGRAPH_V2_80001: ss.optional(ss.string()),
+  SUBGRAPH_V1_80001: ss.optional(ss.string()),
+  SUBGRAPH_V3_80001: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_80001: ss.optional(ss.string()),
+
+  SUBGRAPH_V1_8453: ss.optional(ss.string()),
+  SUBGRAPH_V2_8453: ss.optional(ss.string()),
+  SUBGRAPH_V3_8453: ss.optional(ss.string()),
+  SUBGRAPH_SKINNY_8453: ss.optional(ss.string()),
+});
+export type Env = ss.Infer<typeof Env>;
+
+// every prop of next envs needs to be explicitly pulled in
+const env = ss.create(
+  {
+    SUBGRAPH_V1_1: process.env.SUBGRAPH_V1_1,
+    SUBGRAPH_V1_10: process.env.SUBGRAPH_V1_10,
+    SUBGRAPH_V1_137: process.env.SUBGRAPH_V1_137,
+    SUBGRAPH_V1_288: process.env.SUBGRAPH_V1_288,
+    SUBGRAPH_V1_1116: process.env.SUBGRAPH_V1_1116,
+    SUBGRAPH_V1_42161: process.env.SUBGRAPH_V1_42161,
+    SUBGRAPH_V1_5: process.env.SUBGRAPH_V1_5,
+    SUBGRAPH_V1_80001: process.env.SUBGRAPH_V1_80001,
+    SUBGRAPH_V1_80002: process.env.SUBGRAPH_V1_80002,
+    SUBGRAPH_V1_81457: process.env.SUBGRAPH_V1_81457,
+    SUBGRAPH_V1_11155111: process.env.SUBGRAPH_V1_11155111,
+
+    SUBGRAPH_V2_1: process.env.SUBGRAPH_V2_1,
+    SUBGRAPH_V2_10: process.env.SUBGRAPH_V2_10,
+    SUBGRAPH_V2_137: process.env.SUBGRAPH_V2_137,
+    SUBGRAPH_V2_288: process.env.SUBGRAPH_V2_288,
+    SUBGRAPH_V2_1116: process.env.SUBGRAPH_V2_1116,
+    SUBGRAPH_V2_42161: process.env.SUBGRAPH_V2_42161,
+    SUBGRAPH_V2_5: process.env.SUBGRAPH_V2_5,
+    SUBGRAPH_V2_80001: process.env.SUBGRAPH_V2_80001,
+    SUBGRAPH_V2_80002: process.env.SUBGRAPH_V2_80002,
+    SUBGRAPH_V2_81457: process.env.SUBGRAPH_V2_81457,
+    SUBGRAPH_V2_11155111: process.env.SUBGRAPH_V2_11155111,
+
+    SUBGRAPH_V3_1: process.env.SUBGRAPH_V3_1,
+    SUBGRAPH_V3_10: process.env.SUBGRAPH_V3_10,
+    SUBGRAPH_V3_137: process.env.SUBGRAPH_V3_137,
+    SUBGRAPH_V3_288: process.env.SUBGRAPH_V3_288,
+    SUBGRAPH_V3_1116: process.env.SUBGRAPH_V3_1116,
+    SUBGRAPH_V3_42161: process.env.SUBGRAPH_V3_42161,
+    SUBGRAPH_V3_5: process.env.SUBGRAPH_V3_5,
+    SUBGRAPH_V3_80001: process.env.SUBGRAPH_V3_80001,
+    SUBGRAPH_V3_80002: process.env.SUBGRAPH_V3_80002,
+    SUBGRAPH_V3_81457: process.env.SUBGRAPH_V3_81457,
+    SUBGRAPH_V3_11155111: process.env.SUBGRAPH_V3_11155111,
+
+    SUBGRAPH_SKINNY_1: process.env.SUBGRAPH_SKINNY_1,
+    SUBGRAPH_SKINNY_10: process.env.SUBGRAPH_SKINNY_10,
+    SUBGRAPH_SKINNY_137: process.env.SUBGRAPH_SKINNY_137,
+    SUBGRAPH_SKINNY_288: process.env.SUBGRAPH_SKINNY_288,
+    SUBGRAPH_SKINNY_1116: process.env.SUBGRAPH_SKINNY_1116,
+    SUBGRAPH_SKINNY_42161: process.env.SUBGRAPH_SKINNY_42161,
+    SUBGRAPH_SKINNY_5: process.env.SUBGRAPH_SKINNY_5,
+    SUBGRAPH_SKINNY_80001: process.env.SUBGRAPH_SKINNY_80001,
+    SUBGRAPH_SKINNY_80002: process.env.SUBGRAPH_SKINNY_80002,
+    SUBGRAPH_SKINNY_81457: process.env.SUBGRAPH_SKINNY_81457,
+    SUBGRAPH_SKINNY_11155111: process.env.SUBGRAPH_SKINNY_11155111,
+
+    SUBGRAPH_V1_8453: process.env.SUBGRAPH_V1_8453,
+    SUBGRAPH_V2_8453: process.env.SUBGRAPH_V2_8453,
+    SUBGRAPH_V3_8453: process.env.SUBGRAPH_V3_8453,
+    SUBGRAPH_SKINNY_8453: process.env.SUBGRAPH_SKINNY_8453,
+  },
+  Env
+);
+
+export function parseSubgraphEnv(env: Env): SubgraphConfigs {
+  const subgraphs: SubgraphConfigs = [];
+
+  for (const [key, value] of Object.entries(env)) {
+    if (!value) continue;
+    const [type, version, chainId] = key.split("_");
+    if (type === "SUBGRAPH") {
+      if (version === "SKINNY") {
+        const subgraph = {
+          source: "gql",
+          url: value,
+          type: "Skinny Optimistic Oracle",
+          chainId: parseInt(chainId),
+        };
+        if (ss.is(subgraph, SubgraphConfig)) {
+          subgraphs.push(subgraph);
+        }
+      } else {
+        const subgraph = {
+          source: "gql",
+          url: value,
+          type: `Optimistic Oracle ${version}`,
+          chainId: parseInt(chainId),
+        };
+        if (ss.is(subgraph, SubgraphConfig)) {
+          subgraphs.push(subgraph);
+        }
+      }
+    }
+  }
+  return subgraphs;
+}
+
+export const subgraphConfigs = parseSubgraphEnv(env);
+
+export function getSubgraphConfig(
+  type: string,
+  chainId: number
+): SubgraphConfig {
+  const found = subgraphConfigs.find(
+    (config) => config.chainId === chainId && config.type === type
+  );
+  if (found !== undefined) return found;
+  throw new Error(`No subgraph information found for ${type} on ${chainId}`);
 }

--- a/pages/api/augment-request-gql.ts
+++ b/pages/api/augment-request-gql.ts
@@ -3,16 +3,17 @@ import assert from "assert";
 import { NextApiRequest, NextApiResponse } from "next";
 import * as ss from "superstruct";
 import { makeUniqueKeyForVote, decodeHexString } from "helpers";
-import { isSupportedChainId, getSubgraphConfig } from "./_common";
+import {
+  isSupportedChainId,
+  getSubgraphConfig,
+  VoteSubgraphURL,
+} from "./_common";
 import { ethers } from "ethers";
 
 function encodeHexString(str: string): string {
   return ethers.utils.hexlify(ethers.utils.toUtf8Bytes(str));
 }
 const debug = !!process.env.DEBUG;
-const VoteSubgraphURL =
-  process.env.NEXT_PUBLIC_GRAPH_ENDPOINT ??
-  "https://api.thegraph.com/subgraphs/name/md0x/mainnet-voting-v2";
 
 const RequestBody = ss.object({
   ancillaryData: ss.string(),
@@ -117,7 +118,7 @@ async function voteQuery({
   try {
     const data: GqlResponse = await request(VoteSubgraphURL, query, { id });
     assert(data.priceRequest, "vote query request not found");
-    return data?.priceRequest;
+    return data.priceRequest;
   } catch (error) {
     if (debug) console.error("vote fetch error:", error);
     throw error;
@@ -317,9 +318,9 @@ async function oov2Query({
     if (data.optimisticPriceRequests.length > 1) {
       optimisticPriceRequest = data.optimisticPriceRequests.find((req) => {
         if (req.eventBased) {
-          return req.proposalTimestamp === time;
+          return Number(req.proposalTimestamp) === time;
         } else {
-          return req.time === time;
+          return Number(req.time) === time;
         }
       });
     } else {

--- a/pages/api/augment-request-gql.ts
+++ b/pages/api/augment-request-gql.ts
@@ -1,0 +1,408 @@
+import request, { gql } from "graphql-request";
+import assert from "assert";
+import { NextApiRequest, NextApiResponse } from "next";
+import * as ss from "superstruct";
+import { makeUniqueKeyForVote, decodeHexString } from "helpers";
+import { isSupportedChainId, getSubgraphConfig } from "./_common";
+
+const debug = !!process.env.DEBUG;
+const VoteSubgraphURL =
+  process.env.NEXT_PUBLIC_GRAPH_ENDPOINT ??
+  "https://api.thegraph.com/subgraphs/name/md0x/mainnet-voting-v2";
+
+const RequestBody = ss.object({
+  ancillaryData: ss.string(),
+  time: ss.number(),
+  identifier: ss.string(),
+});
+
+type RequestBody = ss.Infer<typeof RequestBody>;
+
+type OracleQueryParams = RequestBody & { chainId: number };
+
+export const ResponseBody = ss.object({
+  uniqueKey: ss.string(),
+  time: ss.number(),
+  identifier: ss.string(),
+  l1RequestTxHash: ss.optional(ss.string()),
+  ooRequestUrl: ss.optional(ss.string()),
+  originatingChainTxHash: ss.optional(ss.string()),
+  originatingChainId: ss.optional(ss.number()),
+  originatingOracleType: ss.optional(ss.string()),
+  optimisticOracleV3Data: ss.optional(
+    ss.object({
+      assertionId: ss.optional(ss.string()),
+      domainId: ss.optional(ss.string()),
+      claim: ss.optional(ss.string()),
+      asserter: ss.optional(ss.string()),
+      callbackRecipient: ss.optional(ss.string()),
+      escalationManager: ss.optional(ss.string()),
+      expirationTime: ss.optional(ss.number()),
+      caller: ss.optional(ss.string()),
+    })
+  ),
+});
+export type ResponseBody = ss.Infer<typeof ResponseBody>;
+
+function extractChildChainId(ancillaryData: string): number | undefined {
+  const childChainIdRegex = /childChainId:(\d+)/;
+  const match = ancillaryData.match(childChainIdRegex);
+  return match ? Number(match[1]) : undefined;
+}
+function constructOoUiLink(
+  txHash: string | undefined,
+  chainId: string | number | undefined,
+  oracleType: string | undefined,
+  eventIndex: string | undefined
+) {
+  if (!txHash || !chainId || !oracleType) return;
+  if (!isSupportedChainId(chainId)) return;
+  const subDomain = Number(chainId) === 5 ? "testnet." : "";
+  return `https://${subDomain}oracle.uma.xyz/request?transactionHash=${txHash}&chainId=${chainId}&oracleType=${castOracleNameForOOUi(
+    oracleType
+  )}&eventIndex=${eventIndex ?? ""}`;
+}
+
+function castOracleNameForOOUi(oracleType: string): string {
+  switch (oracleType) {
+    case "OptimisticOracle":
+      return "Optimistic";
+    case "OptimisticOracleV2":
+      return "OptimisticV2";
+    case "SkinnyOptimisticOracle":
+      return "Skinny";
+    case "OptimisticOracleV3":
+      return "OptimisticV3";
+    default:
+      throw new Error("Unable to cast oracle name for OO UI: " + oracleType);
+  }
+}
+
+async function voteQuery({
+  time,
+  identifier,
+  ancillaryData,
+}: Omit<OracleQueryParams, "chainId">) {
+  const id = makeUniqueKeyForVote(identifier, time, ancillaryData);
+  const query = gql`
+    query voteQuery($id: ID!) {
+      priceRequest(id: $id) {
+        requestTransaction
+      }
+    }
+  `;
+  type GqlRequest = {
+    requestTransaction: string;
+  };
+  type GqlResponse = {
+    priceRequest: GqlRequest | undefined | null;
+  };
+  try {
+    const data: GqlResponse = await request(VoteSubgraphURL, query, { id });
+    assert(data.priceRequest, "request not found");
+    return data?.priceRequest;
+  } catch (error) {
+    if (debug) console.error("vote fetch error:", error);
+    throw error;
+  }
+}
+async function ooSkinnyQuery({
+  time,
+  identifier,
+  chainId,
+}: OracleQueryParams): Promise<ResponseBody> {
+  const subgraph = getSubgraphConfig("Skinny Optimistic Oracle", chainId);
+  const query = gql`
+    query skinnyQuery($proposalTimestamp: Int!) {
+      optimisticPriceRequests(
+        where: { proposalTimestamp: $proposalTimestamp }
+      ) {
+        id
+        requestHash
+        requestLogIndex
+      }
+    }
+  `;
+  type GqlRequest = {
+    id: string;
+    requestHash: string;
+    requestLogIndex: string;
+  };
+  type GqlResponse = {
+    optimisticPriceRequests: GqlRequest[];
+  };
+
+  try {
+    const data: GqlResponse = await request(subgraph.url, query, {
+      proposalTimestamp: time,
+    });
+    assert(data.optimisticPriceRequests.length > 0, "request not found");
+    const [optimisticPriceRequest] = data.optimisticPriceRequests;
+    const requestHash = optimisticPriceRequest?.requestHash;
+    const requestLogIndex = optimisticPriceRequest?.requestLogIndex;
+    return {
+      time,
+      uniqueKey: optimisticPriceRequest.id,
+      identifier,
+      ooRequestUrl: constructOoUiLink(
+        requestHash,
+        chainId,
+        "SkinnyOptimisticOracle",
+        requestLogIndex
+      ),
+      originatingChainTxHash: requestHash,
+      originatingChainId: chainId,
+      originatingOracleType: "SkinnyOptimisticOracle",
+    };
+  } catch (error) {
+    if (debug) console.error("oo skinny error:", error);
+    throw error;
+  }
+}
+async function oov3Query({
+  time,
+  identifier,
+  chainId,
+}: OracleQueryParams): Promise<ResponseBody> {
+  const subgraph = getSubgraphConfig("Optimistic Oracle V3", chainId);
+  const query = gql`
+    query oov3Query($assertionTimestamp: Int!) {
+      assertions(where: { assertionTimestamp: $assertionTimestamp }) {
+        id
+        assertionHash
+        assertionLogIndex
+        assertionTimestamp
+        domainId
+        claim
+        asserter
+        callbackRecipient
+        escalationManager
+        expirationTime
+        caller
+      }
+    }
+  `;
+  type GqlRequest = {
+    id: string;
+    assertionHash: string;
+    assertionLogIndex: number;
+    assertionTimestamp: number;
+    domainId: string;
+    claim: string;
+    asserter: string;
+    callbackRecipient: string;
+    escalationManager: string;
+    expirationTime: number;
+    caller: string;
+  };
+  type GqlResponse = {
+    assertions: GqlRequest[];
+  };
+
+  try {
+    const data: GqlResponse = await request(subgraph.url, query, {
+      assertionTimestamp: time,
+    });
+    assert(data.assertions.length > 0, "request not found");
+    const [assertion] = data.assertions;
+    const assertionHash = assertion?.assertionHash;
+    const assertionLogIndex = assertion?.assertionLogIndex;
+
+    const assertionId = assertion?.id;
+    const domainId = assertion?.domainId;
+    const claim = assertion?.claim;
+    const asserter = assertion?.asserter;
+    const callbackRecipient = assertion?.callbackRecipient;
+    const escalationManager = assertion?.escalationManager;
+    const expirationTime = Number(assertion?.expirationTime);
+    const caller = assertion?.caller;
+    return {
+      time,
+      uniqueKey: assertionId,
+      identifier,
+      ooRequestUrl: constructOoUiLink(
+        assertionHash,
+        chainId,
+        "OptimisticOracleV3",
+        assertionLogIndex.toString()
+      ),
+      originatingChainTxHash: assertionHash,
+      originatingChainId: chainId,
+      originatingOracleType: "OptimisticOracleV3",
+      optimisticOracleV3Data: {
+        assertionId,
+        domainId,
+        claim,
+        asserter,
+        callbackRecipient,
+        escalationManager,
+        expirationTime,
+        caller,
+      },
+    };
+  } catch (error) {
+    if (debug) console.error("oov3 error:", error);
+    throw error;
+  }
+}
+async function oov2Query({
+  time,
+  identifier,
+  chainId,
+}: OracleQueryParams): Promise<ResponseBody> {
+  const subgraph = getSubgraphConfig("Optimistic Oracle V2", chainId);
+  const query = gql`
+    query oov2Query($proposalTimestamp: Int!) {
+      optimisticPriceRequests(
+        where: { proposalTimestamp: $proposalTimestamp }
+      ) {
+        id
+        requestHash
+        requestLogIndex
+      }
+    }
+  `;
+  type GqlRequest = {
+    id: string;
+    requestHash: string;
+    requestLogIndex: string;
+  };
+  type GqlResponse = {
+    optimisticPriceRequests: GqlRequest[];
+  };
+
+  try {
+    const data: GqlResponse = await request(subgraph.url, query, {
+      proposalTimestamp: time,
+    });
+    assert(data.optimisticPriceRequests.length > 0, "request not found");
+    const [optimisticPriceRequest] = data.optimisticPriceRequests;
+    const requestHash = optimisticPriceRequest.requestHash;
+    const requestLogIndex = optimisticPriceRequest.requestLogIndex;
+    const uniqueKey = optimisticPriceRequest.id;
+    return {
+      time,
+      uniqueKey,
+      identifier,
+      ooRequestUrl: constructOoUiLink(
+        requestHash,
+        chainId,
+        "OptimisticOracleV2",
+        requestLogIndex
+      ),
+      originatingChainTxHash: requestHash,
+      originatingChainId: chainId,
+      originatingOracleType: "OptimisticOracleV2",
+    };
+  } catch (error) {
+    if (debug) console.error("oov2 error:", error);
+    throw error;
+  }
+}
+async function oov1Query({
+  time,
+  identifier,
+  chainId,
+}: OracleQueryParams): Promise<ResponseBody> {
+  const subgraph = getSubgraphConfig("Optimistic Oracle V1", chainId);
+  const query = gql`
+    query oov1Query($proposalTimestamp: Int!) {
+      optimisticPriceRequests(
+        where: { proposalTimestamp: $proposalTimestamp }
+      ) {
+        id
+        requestHash
+        requestLogIndex
+        requestTimestamp
+      }
+    }
+  `;
+  type GqlRequest = {
+    id: string;
+    requestHash: string;
+    requestLogIndex: string;
+  };
+  type GqlResponse = {
+    optimisticPriceRequests: GqlRequest[];
+  };
+
+  try {
+    const data: GqlResponse = await request(subgraph.url, query, {
+      proposalTimestamp: time,
+    });
+    assert(data.optimisticPriceRequests.length > 0, "request not found");
+    const [optimisticPriceRequest] = data.optimisticPriceRequests;
+    const requestHash = optimisticPriceRequest?.requestHash;
+    const requestLogIndex = optimisticPriceRequest?.requestLogIndex;
+    const uniqueKey = optimisticPriceRequest?.id;
+    return {
+      time,
+      uniqueKey,
+      identifier,
+      ooRequestUrl: constructOoUiLink(
+        requestHash,
+        chainId,
+        "OptimisticOracle",
+        requestLogIndex
+      ),
+      originatingChainTxHash: requestHash,
+      originatingChainId: chainId,
+      originatingOracleType: "OptimisticOracle",
+    };
+  } catch (error) {
+    if (debug) console.error("oov1 error:", error);
+    throw error;
+  }
+}
+async function tryAllTypes(request: RequestBody): Promise<ResponseBody> {
+  const chainId =
+    extractChildChainId(decodeHexString(request.ancillaryData)) ?? 1;
+  const results = await Promise.allSettled([
+    oov1Query({ ...request, chainId }),
+    oov2Query({ ...request, chainId }),
+    oov3Query({ ...request, chainId }),
+    ooSkinnyQuery({ ...request, chainId }),
+  ]);
+  const successResult: undefined | PromiseFulfilledResult<ResponseBody> =
+    results.find(
+      (result): result is PromiseFulfilledResult<ResponseBody> =>
+        result.status === "fulfilled"
+    );
+
+  if (!successResult) {
+    throw new Error("All requests failed");
+  }
+
+  return successResult?.value;
+}
+
+async function augmentRequest(request: RequestBody): Promise<ResponseBody> {
+  const vote = await voteQuery(request);
+  const l1RequestTxHash = vote?.requestTransaction;
+  const result = await tryAllTypes(request);
+  return {
+    ...result,
+    l1RequestTxHash,
+  };
+}
+
+export default async function handler(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000"); // Cache for 30 days and re-build cache if re-deployed.
+
+  try {
+    const body: RequestBody = ss.create(request.body, RequestBody);
+    if (debug) console.log(body);
+    const result = await augmentRequest(body);
+    if (debug) console.log(result);
+    response.status(200).send(result);
+  } catch (e) {
+    if (debug) console.error("augment-request error:", e);
+    response.status(500).send({
+      message: "Error in fetching augmented information",
+      error: e instanceof Error ? e.message : e,
+    });
+  }
+}

--- a/pages/api/augment-request.ts
+++ b/pages/api/augment-request.ts
@@ -359,7 +359,7 @@ export default async function handler(
     const result = await augmentRequests(body);
     response.status(200).send(result);
   } catch (e) {
-    if (debug) console.error(e);
+    if (debug) console.error("augment-request error:", e);
     response.status(500).send({
       message: "Error in fetching augmented information",
       error: e instanceof Error ? e.message : e,

--- a/stories/mocks/votes.ts
+++ b/stories/mocks/votes.ts
@@ -39,7 +39,6 @@ export const defaultMockVote = (number = 1): VoteT => {
     decodedIdentifier,
     decodedAncillaryData,
     decodedAdminTransactions: undefined,
-    augmentedData: undefined,
     uniqueKey,
     encryptedVote: undefined,
     decryptedVote: undefined,

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -14,8 +14,7 @@ export type VoteT = PriceRequestT &
   VoteContentfulDataT &
   VoteParticipationT &
   VoteResultsT &
-  VoteDecodedAdminTransactionsT &
-  VoteAugmentedDataT;
+  VoteDecodedAdminTransactionsT;
 
 export type PriceRequestT = {
   // raw values
@@ -231,6 +230,7 @@ export type IdentifierAndTimeStampT = {
 export type OracleTypeT =
   | "OptimisticOracle"
   | "OptimisticOracleV2"
+  | "OptimisticOracleV3"
   | "SkinnyOptimisticOracle";
 
 export const AugmentedVoteDataResponseT = ss.object({

--- a/web3/queries/votes/getAugmentedVoteData.ts
+++ b/web3/queries/votes/getAugmentedVoteData.ts
@@ -1,33 +1,22 @@
 import * as ss from "superstruct";
-import {
-  AugmentedVoteDataResponseT,
-  AugmentedVoteDataByKeyT,
-  PriceRequestByKeyT,
-} from "types";
-import { config } from "helpers/config";
+import { AugmentedVoteDataResponseT } from "types";
 
 const ErrorT = ss.object({
   message: ss.string(),
   error: ss.string(),
 });
 
-export async function getAugmentedVoteData(
-  priceRequests: PriceRequestByKeyT,
-  chainId: number = config.chainId
-): Promise<AugmentedVoteDataByKeyT> {
-  const response = await fetch("/api/augment-request", {
+export async function getAugmentedVoteData(params: {
+  ancillaryData: string;
+  time: number;
+  identifier: string;
+}): Promise<AugmentedVoteDataResponseT> {
+  const response = await fetch("/api/augment-request-gql", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      l1Requests: Object.values(priceRequests).map((req) => ({
-        uniqueKey: req.uniqueKey,
-        time: req.time,
-        identifier: req.identifier,
-      })),
-      chainId,
-    }),
+    body: JSON.stringify(params),
   });
 
   if (!response.ok) {
@@ -35,21 +24,5 @@ export async function getAugmentedVoteData(
     throw new Error([message, error].join(": "));
   }
 
-  const result: AugmentedVoteDataResponseT[] = ss.create(
-    await response.json(),
-    ss.array(AugmentedVoteDataResponseT)
-  );
-
-  const init: Record<string, AugmentedVoteDataResponseT> = {};
-  return result.reduce((byKey, augmentedData: AugmentedVoteDataResponseT) => {
-    const key = augmentedData.uniqueKey;
-    byKey[key] = {
-      ...priceRequests[key],
-      ...augmentedData,
-    };
-    return byKey;
-    // this still needs to be casted because superstruct isnt validating the enumerated data such as
-    // chain id and oracle type which are stricter in typescript. this should prevent compile issues even though
-    // its not ideal
-  }, init) as AugmentedVoteDataByKeyT;
+  return ss.create(await response.json(), AugmentedVoteDataResponseT);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5153,6 +5153,20 @@
   resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.4.20.tgz#e1c51285920dcedc8191ea076f8f9329f74a822f"
   integrity sha512-TY2DcrJSAlUy5v2w8N8Hj4UjrercyKg60P13guBBQ41TsJu/q1xNE4V6QCLNG0KgpOJK7oG+Z/0N/4NlB7w2fQ==
 
+"@upstash/redis@^1.31.3":
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/@upstash/redis/-/redis-1.33.0.tgz#eefe14ea50136f2d14dda78cdc2e788230cd1683"
+  integrity sha512-5WOilc7AE0ITAdE3NCyMwgOq1n3RHcqW0OfmbotiAyfA+QAEe1R7kXin8L/Yladgdc5lkA0GcYyewqKfAw53jQ==
+  dependencies:
+    crypto-js "^4.2.0"
+
+"@vercel/kv@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@vercel/kv/-/kv-2.0.0.tgz#a0baa12563946cb35cee23d638b68f0fbbf76172"
+  integrity sha512-zdVrhbzZBYo5d1Hfn4bKtqCeKf0FuzW8rSHauzQVMUgv1+1JOwof2mWcBuI+YMJy8s0G0oqAUfQ7HgUDzb8EbA==
+  dependencies:
+    "@upstash/redis" "^1.31.3"
+
 "@walletconnect/browser-utils@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz#33c10e777aa6be86c713095b5206d63d32df0951"
@@ -7432,6 +7446,11 @@ crypto-es@^1.2.2:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/crypto-es/-/crypto-es-1.2.7.tgz#754a6d52319a94fb4eb1f119297f17196b360f88"
   integrity sha512-UUqiVJ2gUuZFmbFsKmud3uuLcNP2+Opt+5ysmljycFCyhA0+T16XJmo1ev/t5kMChMqWh7IEvURNCqsg+SjZGQ==
+
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -14436,10 +14455,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@4.8.3:
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
-  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
+typescript@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.3.tgz#e1b0a3c394190838a0b168e771b0ad56a0af0faa"
+  integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
# Motivation
augment request which is responsible for finding metadata about transactions has been failing

# changes
This updates augment request to use the graph and to only query for a single request as its displayed, this speeds up calls, improves caching, and hopefully stops erroring and timing out

oracle v3:
![image](https://github.com/user-attachments/assets/ec7528be-fdcb-454b-b58e-cf4cad7c0403)
oracle v2:
![image](https://github.com/user-attachments/assets/5180bbe4-ae05-4bf2-b36b-e76ea7a8059e)
skinny oo:
![image](https://github.com/user-attachments/assets/8b895be6-acd0-4088-a634-daee705e70d2)
