### PR TITLE
use correct cumulative stake value

### DIFF
--- a/components/Panel/VotePanel/Result.tsx
+++ b/components/Panel/VotePanel/Result.tsx
@@ -143,11 +143,11 @@ export function Result({
             <span>Total tokens that revealed</span>
             <Strong>
               <Span>
-                (%
+                (
                 {((totalTokensVotedWith / totalTokensCommitted) * 100).toFixed(
                   2
                 )}
-                )
+                %)
               </Span>
               {totalTokensVotedWith
                 ? commify(truncateDecimals(totalTokensVotedWith, 2))

--- a/graph/queries/getActiveVoteResults.ts
+++ b/graph/queries/getActiveVoteResults.ts
@@ -38,15 +38,13 @@ export async function getActiveVoteResults(): Promise<
           totalVotesRevealed
           minAgreementRequirement
           minParticipationRequirement
+          cumulativeStakeAtRound
           groups {
             price
             totalVoteAmount
           }
           committedVotes {
             id
-            voter {
-              voterStake
-            }
           }
           revealedVotes {
             id
@@ -75,16 +73,7 @@ export async function getActiveVoteResults(): Promise<
         const correctVote = price;
         const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
 
-        // for v1 this data is missing so we need to dynamically check this
-        const hasVoterStakeDetails = latestRound.committedVotes.some(
-          (v) => v.voter?.voterStake
-        );
-        // no counter field in subgraph entity so we must do this calculation client side
-        const totalTokensCommitted = hasVoterStakeDetails
-          ? latestRound.committedVotes
-              .map((v) => Number(v?.voter?.voterStake))
-              .reduce((acc, curr) => acc + curr, 0)
-          : undefined;
+        const totalTokensCommitted = Number(latestRound.cumulativeStakeAtRound);
 
         const participation = {
           uniqueCommitAddresses: latestRound.committedVotes.length,

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -81,15 +81,13 @@ export async function getPastVotesV2() {
           totalVotesRevealed
           minAgreementRequirement
           minParticipationRequirement
+          cumulativeStakeAtRound
           groups {
             price
             totalVoteAmount
           }
           committedVotes {
             id
-            voter {
-              voterStake
-            }
           }
           revealedVotes {
             id
@@ -122,16 +120,7 @@ export async function getPastVotesV2() {
       const correctVote = price;
       const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
 
-      // for v1 this data is missing so we need to dynamically check this
-      const hasVoterStakeDetails = latestRound.committedVotes.some(
-        (v) => v.voter?.voterStake
-      );
-      // no counter field in subgraph entity so we must do this calculation client side
-      const totalTokensCommitted = hasVoterStakeDetails
-        ? latestRound.committedVotes
-            .map((v) => Number(v?.voter?.voterStake))
-            .reduce((acc, curr) => acc + curr, 0)
-        : undefined;
+      const totalTokensCommitted = Number(latestRound.cumulativeStakeAtRound);
 
       const participation = {
         uniqueCommitAddresses: latestRound.committedVotes.length,

--- a/types/queries.ts
+++ b/types/queries.ts
@@ -11,15 +11,13 @@ export type PastVotesQuery = {
       totalVotesRevealed: string;
       minAgreementRequirement: string;
       minParticipationRequirement: string;
+      cumulativeStakeAtRound: string;
       groups: {
         price: string;
         totalVoteAmount: string;
       }[];
       committedVotes: {
         id: string;
-        voter?: {
-          voterStake: string;
-        };
       }[];
       revealedVotes: {
         id: string;


### PR DESCRIPTION
The correct value to use was actually in the gql schema for price request, called `cumulativeStakeAtRound`