### PR TITLE
use new committed tokens counter from graph

### DIFF
--- a/components/Panel/VotePanel/Result.tsx
+++ b/components/Panel/VotePanel/Result.tsx
@@ -39,8 +39,12 @@ export function Result({
 
   if (!participation || !results) return null;
 
-  const { uniqueCommitAddresses, uniqueRevealAddresses, totalTokensVotedWith } =
-    participation;
+  const {
+    uniqueCommitAddresses,
+    uniqueRevealAddresses,
+    totalTokensVotedWith,
+    totalTokensCommitted,
+  } = participation;
 
   const resultsWithLabels = results.map(({ vote, tokensVotedWith }) => {
     const formatted = formatVoteStringWithPrecision(vote, decodedIdentifier);
@@ -126,18 +130,28 @@ export function Result({
           <span>Unique reveal addresses</span>
           <Strong>{uniqueRevealAddresses}</Strong>
         </ParticipationItem>
-        {/* <ParticipationItem>
-          <span>Total tokens that committed</span>
-          <Strong>
-            {totalTokensCommitted
-              ? commify(truncateDecimals(totalTokensCommitted, 2))
-              : 0}
-          </Strong>
-        </ParticipationItem> */}
+        {totalTokensCommitted && (
+          <ParticipationItem>
+            <span>Total tokens that committed</span>
+            <Strong>
+              {totalTokensCommitted
+                ? commify(truncateDecimals(totalTokensCommitted, 2))
+                : 0}
+            </Strong>
+          </ParticipationItem>
+        )}
 
         <ParticipationItem>
           <span>Total tokens that revealed</span>
           <Strong>
+            {totalTokensCommitted && (
+              <Span>
+                {((totalTokensVotedWith / totalTokensCommitted) * 100).toFixed(
+                  1
+                )}
+                %
+              </Span>
+            )}
             {totalTokensVotedWith
               ? commify(truncateDecimals(totalTokensVotedWith, 2))
               : 0}
@@ -259,10 +273,10 @@ const QuorumItem = styled.div`
   align-items: center;
 `;
 
-// const Span = styled.span`
-//   color: var(--red-500);
-//   margin-inline: 1em;
-// `;
+const Span = styled.span`
+  color: var(--red-500);
+  margin-inline: 1em;
+`;
 
 const Wrapper = styled.div`
   margin-top: 20px;

--- a/graph/queries/getActiveVoteResults.ts
+++ b/graph/queries/getActiveVoteResults.ts
@@ -38,15 +38,13 @@ export async function getActiveVoteResults(): Promise<
           totalVotesRevealed
           minAgreementRequirement
           minParticipationRequirement
+          totalTokensCommitted
           groups {
             price
             totalVoteAmount
           }
           committedVotes {
             id
-            voter {
-              voterStake
-            }
           }
           revealedVotes {
             id
@@ -76,14 +74,8 @@ export async function getActiveVoteResults(): Promise<
         const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
 
         // for v1 this data is missing so we need to dynamically check this
-        const hasVoterStakeDetails = latestRound.committedVotes.some(
-          (v) => v.voter?.voterStake
-        );
-        // no counter field in subgraph entity so we must do this calculation client side
-        const totalTokensCommitted = hasVoterStakeDetails
-          ? latestRound.committedVotes
-              .map((v) => Number(v?.voter?.voterStake))
-              .reduce((acc, curr) => acc + curr, 0)
+        const totalTokensCommitted = latestRound.totalTokensCommitted
+          ? Number(latestRound.totalTokensCommitted)
           : undefined;
 
         const participation = {

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -79,6 +79,7 @@ export async function getPastVotesV2() {
         rollCount
         latestRound {
           totalVotesRevealed
+          totalTokensCommitted
           minAgreementRequirement
           minParticipationRequirement
           groups {
@@ -87,9 +88,6 @@ export async function getPastVotesV2() {
           }
           committedVotes {
             id
-            voter {
-              voterStake
-            }
           }
           revealedVotes {
             id
@@ -123,14 +121,8 @@ export async function getPastVotesV2() {
       const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
 
       // for v1 this data is missing so we need to dynamically check this
-      const hasVoterStakeDetails = latestRound.committedVotes.some(
-        (v) => v.voter?.voterStake
-      );
-      // no counter field in subgraph entity so we must do this calculation client side
-      const totalTokensCommitted = hasVoterStakeDetails
-        ? latestRound.committedVotes
-            .map((v) => Number(v?.voter?.voterStake))
-            .reduce((acc, curr) => acc + curr, 0)
+      const totalTokensCommitted = latestRound.totalTokensCommitted
+        ? Number(latestRound.totalTokensCommitted)
         : undefined;
 
       const participation = {

--- a/types/queries.ts
+++ b/types/queries.ts
@@ -11,15 +11,13 @@ export type PastVotesQuery = {
       totalVotesRevealed: string;
       minAgreementRequirement: string;
       minParticipationRequirement: string;
+      totalTokensCommitted?: string;
       groups: {
         price: string;
         totalVoteAmount: string;
       }[];
       committedVotes: {
         id: string;
-        voter?: {
-          voterStake: string;
-        };
       }[];
       revealedVotes: {
         id: string;


### PR DESCRIPTION
## motivation

Since updates to the subgraph [here](https://github.com/UMAprotocol/subgraphs/pull/80), we are tracking the tokens staked by each committer, when they commit their vote. We now use this value to calculate the percentage of tokens that revealed.

![Screenshot 2024-08-05 at 11 53 25](https://github.com/user-attachments/assets/ca354fc0-b829-456e-b37d-8703121e88cc)
