### PR TITLE
fix: fix accepting delegate when changing delgated wallet

### DIFF
--- a/web3/queries/delegation/getDelegateSetEvents.ts
+++ b/web3/queries/delegation/getDelegateSetEvents.ts
@@ -19,7 +19,10 @@ export async function getDelegateSetEvents(
     }))
     .filter(({ delegate }) => delegate !== zeroAddress);
 
-  const onlyOne = onlyOneRequestPerAddress(parsedEvents, queryFor);
+  // this onlyOne function returns the oldest event by default if collisions happen, so we reverse the list
+  // to run newest requests first, ensuring we get the latest event.  previously this was not reversed
+  // causing issues with accounts that are attempting to delegate to a new delegator
+  const onlyOne = onlyOneRequestPerAddress(parsedEvents.reverse(), queryFor);
   return removeDanglingDelegateEvents(voting, onlyOne);
 }
 


### PR DESCRIPTION
# motivation
that has been report that accounts cannot accept delegate request

# changes
narrowed this down to a call which picks a single request out of all the delegate requests an address was sent.  previously taking the oldest, now taking the newest request. 