### PR TITLE
fix: increase subgraph query limits for commits and reveals

### DIFF
--- a/graph/queries/getActiveVoteResults.ts
+++ b/graph/queries/getActiveVoteResults.ts
@@ -43,10 +43,10 @@ export async function getActiveVoteResults(): Promise<
             price
             totalVoteAmount
           }
-          committedVotes {
+          committedVotes(first: 1000) {
             id
           }
-          revealedVotes {
+          revealedVotes(first: 1000) {
             id
             voter {
               address


### PR DESCRIPTION
# motivation
We are only ever seeing max 100 commit addresses

# changes
apparently gql query limits you to 100 returned values, so we increased the limit, which should hold us over for a while