### PR TITLE
fix: place GA tracker in correct component

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,6 +14,8 @@ import {
 import type { AppProps } from "next/app";
 import "styles/fonts.css";
 import "styles/globals.css";
+import { GoogleAnalytics } from "@next/third-parties/google";
+import { config } from "helpers";
 
 const queryClient = new QueryClient();
 
@@ -32,6 +34,7 @@ function MyApp({ Component, pageProps }: AppProps) {
                       <Component {...pageProps} />
                       <Panel />
                       <Notifications />
+                      {config.gaTag && <GoogleAnalytics gaId={config.gaTag} />}
                     </PanelProvider>
                   </VotesProvider>
                 </DelegationProvider>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,8 +6,7 @@ import Document, {
   NextScript,
 } from "next/document";
 import { ServerStyleSheet } from "styled-components";
-import { GoogleAnalytics } from "@next/third-parties/google";
-import { config } from "helpers";
+
 export default class MyDocument extends Document {
   /*
     This logic is required to make styled components work nicely with nextjs's ssr features
@@ -100,7 +99,6 @@ export default class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-        {config.gaTag && <GoogleAnalytics gaId={config.gaTag} />}
       </Html>
     );
   }


### PR DESCRIPTION
- places the tracker in the correct component as per [docs](https://nextjs.org/docs/pages/building-your-application/optimizing/third-party-libraries#google-analytics)