### PR TITLE
fix: fix issue with some voters not showing they voted in past votes

### DIFF
--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -82,14 +82,14 @@ export async function getPastVotesV2() {
           totalTokensCommitted
           minAgreementRequirement
           minParticipationRequirement
-          groups {
+          groups(first: 1000) {
             price
             totalVoteAmount
           }
-          committedVotes {
+          committedVotes(first: 1000) {
             id
           }
-          revealedVotes {
+          revealedVotes(first: 1000) {
             id
             voter {
               address


### PR DESCRIPTION
# motivation
some users are being told they didnt participate in a past vote when they did.  did not affect rewards, only shows wrong information in ui

# changes
This was caused by having over 100 voters, and gql by default limits array queries to 100, unless specified. This means some revealed vote data was being cutoff, and this would affect voters somewhat randomly.  This increases array limit on revealed votes and others to 100, which gives us a lot more room to grow.  we are around 110 voters or so