### PR TITLE
fix: increase message query size

### DIFF
--- a/pages/api/discord-thread.ts
+++ b/pages/api/discord-thread.ts
@@ -47,7 +47,7 @@ export async function discordRequest(endpoint: string) {
 }
 
 export async function getDiscordMessages(threadId: string) {
-  return discordRequest(`channels/${threadId}/messages`);
+  return discordRequest(`channels/${threadId}/messages?limit=100`);
 }
 
 function discordPhoto(userId: string, userAvatar: string | null) {
@@ -142,7 +142,6 @@ async function fetchDiscordThread(
     .filter((message) => message.content != "")
     .map((msg: RawDiscordMessageT) => {
       const sanitized = fixMarkdownBold(stripMarkdownHeaders(msg.content));
-
       return {
         message: concatenateAttachments(
           replaceEmbeds(replaceMentions(sanitized, msg.mentions), msg.embeds),


### PR DESCRIPTION
# motivation
this discussion is missing the first X number of posts `Will Israel invade Lebanon in September?`

# changes 
the discord api returns posts in reverse order, ie newest first. and theres a limit on number of messages that get returned. we can modify this to a max of 100, which fixes the issue for now, but we need to spend more time to add pagination to this call.

you can see in discussion tab in this pr DOMAH is first which matches discussion in discord evidence rationale
vs the prod app it shows someone else
