### PR TITLE
fix: voting history

### DIFF
--- a/components/VoteHistoryTable/VoteHistoryTableRow.tsx
+++ b/components/VoteHistoryTable/VoteHistoryTableRow.tsx
@@ -19,15 +19,19 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
 
   function makeFormattedSlashAmount() {
     const formattedSlashAmount = formatNumberForDisplay(slashAmount);
+    if (staking && (formattedSlashAmount === "0" || formattedSlashAmount === "-0")) return "pending";
     if (formattedSlashAmount === "-0") return "0";
     return formattedSlashAmount;
   }
 
   function getScoreColor() {
+    if (formattedSlashAmount === "pending") return black;
     if (formattedSlashAmount === "0") return black;
     if (formattedSlashAmount.startsWith("-")) return red500;
     return green;
   }
+
+  const pendingEarningsTooltip = "Your earnings will display as soon as you interact (commit or reveal) with the dApp."
 
   return (
     <Tr>
@@ -58,7 +62,13 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
         </Correctness>
       </CorrectnessTd>
       <ScoreTd style={{ "--color": scoreColor } as CSSProperties}>
-        {formattedSlashAmount}
+        {formattedSlashAmount === "pending" ? (
+          <Tooltip label={pendingEarningsTooltip}>
+            <PendingChip>Pending</PendingChip>
+          </Tooltip>
+        ) : (
+          formattedSlashAmount
+        )}
       </ScoreTd>
     </Tr>
   );
@@ -67,6 +77,8 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
 function getBarColor(value: boolean) {
   return value ? green : grey500;
 }
+
+// Styled Components
 const BarInnerWrapper = styled.div`
   padding-block: 4px;
   border-top: 1px solid var(--grey-500);
@@ -129,4 +141,17 @@ const VoteNumberV1 = styled.span`
   &:hover {
     text-decoration: underline;
   }
+`;
+
+const PendingChip = styled.span`
+  display: inline-block;
+  padding: 2px 4px;
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--white);
+  background: var(--grey-500);
+  border-radius: 5px;
+  text-transform: uppercase;
+  text-align: center;
+  cursor: default;
 `;

--- a/components/VoteHistoryTable/VoteHistoryTableRow.tsx
+++ b/components/VoteHistoryTable/VoteHistoryTableRow.tsx
@@ -19,7 +19,11 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
 
   function makeFormattedSlashAmount() {
     const formattedSlashAmount = formatNumberForDisplay(slashAmount);
-    if (staking && (formattedSlashAmount === "0" || formattedSlashAmount === "-0")) return "pending";
+    if (
+      staking &&
+      (formattedSlashAmount === "0" || formattedSlashAmount === "-0")
+    )
+      return "pending";
     if (formattedSlashAmount === "-0") return "0";
     return formattedSlashAmount;
   }
@@ -31,7 +35,8 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
     return green;
   }
 
-  const pendingEarningsTooltip = "Your earnings will display as soon as you interact (commit or reveal) with the dApp."
+  const pendingEarningsTooltip =
+    "Your earnings will display as soon as you interact (commit or reveal) with the dApp.";
 
   return (
     <Tr>

--- a/components/VoteHistoryTable/VoteHistoryTableRow.tsx
+++ b/components/VoteHistoryTable/VoteHistoryTableRow.tsx
@@ -145,7 +145,7 @@ const VoteNumberV1 = styled.span`
 
 const PendingChip = styled.span`
   display: inline-block;
-  padding: 2px 4px;
+  padding: 1px 4px;
   font-size: 10px;
   font-weight: 800;
   color: var(--white);

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -195,6 +195,15 @@ export function VotesProvider({ children }: { children: ReactNode }) {
           vote.revealedVoteByAddress[designatedVotingV1Address]) ||
         (userOrDelegatorAddress &&
           vote.revealedVoteByAddress[userOrDelegatorAddress]);
+
+      // This resolves the graph's limitation of not reflecting the voter's latest participation until they commit to 
+      // the next vote.
+      if (voteHistoryByKey && voteHistoryByKey[uniqueKey] !== undefined) {
+        voteHistoryByKey[uniqueKey].correctness = vote.correctVote
+          ? pastVoteRevealed === vote.correctVote
+          : false;
+      }
+
       return {
         ...vote,
         // prefer active vote results first, this will either exist or not, if not we can just fall back to the default vote results
@@ -244,8 +253,8 @@ export function VotesProvider({ children }: { children: ReactNode }) {
   const activityStatus: ActivityStatusT = hasActiveVotes
     ? "active"
     : hasUpcomingVotes
-    ? "upcoming"
-    : "past";
+      ? "upcoming"
+      : "past";
   const isActive = activityStatus === "active";
   const isUpcoming = activityStatus === "upcoming";
   const isPast = activityStatus === "past";

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -196,7 +196,7 @@ export function VotesProvider({ children }: { children: ReactNode }) {
         (userOrDelegatorAddress &&
           vote.revealedVoteByAddress[userOrDelegatorAddress]);
 
-      // This resolves the graph's limitation of not reflecting the voter's latest participation until they commit to 
+      // This resolves the graph's limitation of not reflecting the voter's latest participation until they commit to
       // the next vote.
       if (voteHistoryByKey && voteHistoryByKey[uniqueKey] !== undefined) {
         voteHistoryByKey[uniqueKey].correctness = vote.correctVote
@@ -253,8 +253,8 @@ export function VotesProvider({ children }: { children: ReactNode }) {
   const activityStatus: ActivityStatusT = hasActiveVotes
     ? "active"
     : hasUpcomingVotes
-      ? "upcoming"
-      : "past";
+    ? "upcoming"
+    : "past";
   const isActive = activityStatus === "active";
   const isUpcoming = activityStatus === "upcoming";
   const isPast = activityStatus === "past";


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes the voting history issues
- Depends on the new version of the voting v2 subgraph https://github.com/UMAprotocol/subgraphs/pull/85

Due to TheGraph working memory limitations we need to show a "pending" chip for recent past votes earnings. These are updated once the voter interacts with the contract.


![image](https://github.com/user-attachments/assets/6ed2c238-5e00-44be-bfe6-a42dabcf7ba0)
