### PR TITLE
use title and timestamp to index discord threads

### DIFF
--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -48,6 +48,7 @@ export function VotePanel({ content }: Props) {
   } = useVoteDiscussion({
     identifier,
     time,
+    title,
   });
   const { data: claim } = useAssertionClaim(assertionChildChainId, assertionId);
 

--- a/hooks/queries/votes/useVoteDiscussion.ts
+++ b/hooks/queries/votes/useVoteDiscussion.ts
@@ -3,10 +3,10 @@ import { voteDiscussionKey } from "constant";
 import { L1Request } from "types";
 import { getVoteDiscussion } from "web3";
 
-export function useVoteDiscussion({ identifier, time }: L1Request) {
+export function useVoteDiscussion({ identifier, time, title }: L1Request) {
   return useQuery({
-    queryKey: [voteDiscussionKey, identifier, time],
-    queryFn: () => getVoteDiscussion({ identifier, time }),
+    queryKey: [voteDiscussionKey, identifier, time, title],
+    queryFn: () => getVoteDiscussion({ identifier, time, title }),
     onError: (err) => console.error(err),
     refetchOnWindowFocus: true,
     refetchInterval: 20_000,

--- a/pages/api/discord-thread.ts
+++ b/pages/api/discord-thread.ts
@@ -55,6 +55,7 @@ export async function discordRequest(endpoint: string) {
 export async function getDiscordMessages(threadId: string, limit = 100) {
   return discordRequest(`channels/${threadId}/messages?limit=${limit}`);
 }
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -133,14 +134,16 @@ function concatenateAttachments(
   return [message, concat.join(",  ")].join("\n");
 }
 
-function extractValidateTimestamp(msg?: string) {
+function extractValidateTItleAndTimestamp(msg?: string) {
   // All messages are structured with the unixtimestamp at the end, such as
   // Across Dispute November 24th 2022 at 1669328675
   if (msg === undefined || msg === null) return null;
   const time = parseInt(msg.substring(msg.length - 10, msg.length));
   // All times must be newer than 2021-01-01 and older than the current time.
-  const isValid = new Date(time).getTime() > 1577858461 && time < Date.now();
-  return isValid ? time : null;
+  const isTimeValid =
+    new Date(time).getTime() > 1577858461 && time < Date.now();
+  // use "title - timstamp" to find thread
+  return isTimeValid ? msg : null;
 }
 
 async function fetchDiscordThread(
@@ -159,21 +162,20 @@ async function fetchDiscordThread(
     // if for some reason the thread was changed, it will only reflect in thread.name.
     // message.content only reflects the original message, not edits ( or edits by another admin)
     // so first check for message.thread.name and fallback to message.content
-    const time = extractValidateTimestamp(
+    const titleAndTimstamp = extractValidateTItleAndTimestamp(
       message?.thread?.name ?? message.content
     );
-    if (time) timeToThread[time.toString()] = message.thread?.id;
+
+    if (titleAndTimstamp) timeToThread[titleAndTimstamp] = message.thread?.id;
   });
-  // Associate the threadId with each timestamp provided in the payload.
-  const requestsToThread: { [key: string]: string | undefined } = {};
-  const time = l1Request.time.toString();
-  if (timeToThread[time]) requestsToThread[time] = timeToThread[time];
-  else requestsToThread[time] = "";
+  // Associate the threadId with each title-timestamp provided in the payload.
+  const requestedId = `${l1Request.title} - ${l1Request.time}`;
+
+  const threadId = timeToThread?.[requestedId];
 
   let messages: RawDiscordThreadT = [];
-  const thread = requestsToThread[time];
-  if (thread) {
-    messages = await getDiscordMessagesPaginated(thread);
+  if (threadId) {
+    messages = await getDiscordMessagesPaginated(threadId);
   }
 
   const processedMessages: DiscordMessageT[] = messages
@@ -210,6 +212,7 @@ export default async function handler(
         l1Request: {
           time: Number(request.query.time),
           identifier: request.query.identifier,
+          title: request.query.title,
         },
       },
       DiscordThreadRequestBody

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -300,5 +300,6 @@ export type VoteDiscussionT = ss.Infer<typeof VoteDiscussionT>;
 export const L1Request = ss.object({
   time: ss.number(),
   identifier: ss.string(),
+  title: ss.string(),
 });
 export type L1Request = ss.Infer<typeof L1Request>;

--- a/web3/queries/votes/getVoteDiscussion.ts
+++ b/web3/queries/votes/getVoteDiscussion.ts
@@ -5,7 +5,7 @@ export async function getVoteDiscussion(
   l1Request: L1Request
 ): Promise<VoteDiscussionT> {
   const response = await fetch(
-    `/api/discord-thread?time=${l1Request.time}&identifier=${l1Request.identifier}`
+    `/api/discord-thread?time=${l1Request.time}&identifier=${l1Request.identifier}&title=${l1Request.title}`
   );
 
   if (!response.ok) {


### PR DESCRIPTION
Currently we only use the Identifier and timestamp to fetch the associated thread from discord.
In this PR we also use the title to find the thread.