### PR TITLE
sanitize and hash ancillary data for question ID

### DIFF
--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -8,6 +8,7 @@ import {
   checkIfIsPolymarket,
   decodeHexString,
   formatNumberForDisplay,
+  getQuestionId,
   makeBlockExplorerLink,
   makeTransactionHashLink,
   parseEtherSafe,
@@ -138,7 +139,12 @@ export function Details({
     Boolean(hash) &&
     Boolean(config.chainId === 1); // skip testnet
 
-  const { data: polymarketLink } = usePolymarketLink(hash, shouldFetch);
+  const { data: polymarketLink } = usePolymarketLink(
+    getQuestionId({
+      decodedAncillaryData,
+    }),
+    shouldFetch
+  );
 
   return (
     <Wrapper>

--- a/helpers/voting/projects/polymarket.ts
+++ b/helpers/voting/projects/polymarket.ts
@@ -1,6 +1,7 @@
 import { earlyRequestMagicNumber } from "constant";
-import { DropdownItemT } from "types";
+import { DropdownItemT, VoteT } from "types";
 import chunk from "lodash/chunk";
+import { solidityKeccak256 } from "ethers/lib/utils";
 
 const polymarketChainId = 137;
 
@@ -224,5 +225,30 @@ export function maybeMakePolymarketOptions(
         value: "custom",
       },
     ];
+  }
+}
+
+/**
+ * Strips the following keys from ancillary data (and any possible preceding commas):
+ * 1. ooRequester
+ * 2. initializer
+ * 3. childRequester
+ * 4. childChainId
+ */
+export function sanitizeAncillaryData(decodedAncillaryData: string): string {
+  const regex =
+    /(?:,\s*)?(initializer|ooRequester|childChainId|childRequester):[^,]+/g;
+  const stripped = decodedAncillaryData.replace(regex, "");
+  return stripped;
+}
+
+export function getQuestionId({
+  decodedAncillaryData,
+}: Partial<Pick<VoteT, "decodedAncillaryData">>): string | undefined {
+  if (decodedAncillaryData) {
+    return solidityKeccak256(
+      ["string"],
+      [sanitizeAncillaryData(decodedAncillaryData)]
+    );
   }
 }

--- a/helpers/voting/projects/polymarket.ts
+++ b/helpers/voting/projects/polymarket.ts
@@ -231,13 +231,13 @@ export function maybeMakePolymarketOptions(
 /**
  * Strips the following keys from ancillary data (and any possible preceding commas):
  * 1. ooRequester
- * 2. initializer
- * 3. childRequester
- * 4. childChainId
+ * 2. childRequester
+ * 3. childChainId
  */
+
+// questionId is a hash of ancillaryData + initializer EOA
 export function sanitizeAncillaryData(decodedAncillaryData: string): string {
-  const regex =
-    /(?:,\s*)?(initializer|ooRequester|childChainId|childRequester):[^,]+/g;
+  const regex = /(?:,\s*)?(ooRequester|childChainId|childRequester):[^,]+/g;
   const stripped = decodedAncillaryData.replace(regex, "");
   return stripped;
 }

--- a/hooks/queries/votes/usePolymarketLink.ts
+++ b/hooks/queries/votes/usePolymarketLink.ts
@@ -6,10 +6,16 @@ const returnData = type({
   slug: optional(string()),
 });
 
-async function getPolymarketLink(txHash: string): Promise<string | undefined> {
+async function getPolymarketLink(
+  questionId: string | undefined
+): Promise<string | undefined> {
+  if (!questionId) {
+    throw new Error("Unable to fetch polymarket link. Missing Question ID");
+  }
+
   const POLYMARKET_BASE_URL = "https://polymarket.com";
   const params = buildSearchParams({
-    txHash,
+    questionId,
   });
 
   const response = await fetch(`/api/get-polymarket-link?${params}`, {
@@ -28,13 +34,19 @@ async function getPolymarketLink(txHash: string): Promise<string | undefined> {
   }
 }
 
-export function usePolymarketLink(txHash: string, shouldFetch = true) {
+export function usePolymarketLink(
+  questionId: string | undefined,
+  shouldFetch = true
+) {
   return useQuery({
-    queryKey: [txHash],
-    queryFn: () => getPolymarketLink(txHash),
+    queryKey: [questionId],
+    queryFn: () => getPolymarketLink(questionId),
     onError: (err) =>
-      console.warn(`Unable to fetch slug for tx ${txHash}`, { cause: err }),
-    enabled: !!txHash && shouldFetch,
+      console.warn(
+        `Unable to fetch slug for tx ${questionId ?? "MISSING PARAM"}`,
+        { cause: err }
+      ),
+    enabled: !!questionId && shouldFetch,
     refetchInterval: Infinity,
     refetchOnMount: false,
   });

--- a/pages/api/get-polymarket-link.ts
+++ b/pages/api/get-polymarket-link.ts
@@ -24,8 +24,6 @@ export default async function handler(
       });
     }
 
-    console.log(`Fetching data for question ID: ${questionId}`);
-
     const data = (await fetch(
       `https://gamma-api.polymarket.com/markets?${buildSearchParams({
         question_ids: questionId,
@@ -36,10 +34,9 @@ export default async function handler(
       }>;
     }>;
 
-    console.log(`Found DATA for question ID: ${questionId}`, data);
-    console.log("events", data[0]["events"]);
-
     const slug = data?.[0]?.events?.[0]?.slug;
+
+    console.log(`Found polymarket slug for question ID: ${questionId}`, slug);
 
     response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000");
     response.status(200).send({ slug });

--- a/pages/api/get-polymarket-link.ts
+++ b/pages/api/get-polymarket-link.ts
@@ -30,11 +30,16 @@ export default async function handler(
       `https://gamma-api.polymarket.com/markets?${buildSearchParams({
         question_ids: questionId,
       })}`
-    ).then((res) => res.json())) as Array<{ slug: string }>;
+    ).then((res) => res.json())) as Array<{
+      events: Array<{
+        slug: string;
+      }>;
+    }>;
 
     console.log(`Found DATA for question ID: ${questionId}`, data);
+    console.log("events", data[0]["events"]);
 
-    const slug = data?.[0]?.slug;
+    const slug = data?.[0]?.events?.[0]?.slug;
 
     response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000");
     response.status(200).send({ slug });


### PR DESCRIPTION
We strip all tags (childChainId, ooRequester and childRequester) from DVM ancillary data, leaving only original ancillary data + initializer. we hash this to find the questionId, replicating Polymarket's logic.
