### PR TITLE
fix: use l1 ancillary data for commits

### DIFF
--- a/helpers/voting/formatVotes.ts
+++ b/helpers/voting/formatVotes.ts
@@ -51,7 +51,13 @@ export async function formatVotesToCommit({
       // if not, exclude this vote from the final array
       if (!selectedVote) return null;
 
-      const { identifier, decodedIdentifier, ancillaryData, time } = vote;
+      const {
+        identifier,
+        decodedIdentifier,
+        ancillaryData,
+        time,
+        ancillaryDataL1,
+      } = vote;
       // the selected option for a vote is called `price` for legacy reasons
       const price = parseVoteStringWithPrecision(
         selectedVote,
@@ -64,7 +70,7 @@ export async function formatVotesToCommit({
         salt,
         account,
         time,
-        ancillaryData,
+        ancillaryDataL1 ?? ancillaryData,
         roundId,
         identifier
       );
@@ -90,14 +96,15 @@ export function formatVotesToReveal(decryptedVotesForUser: VoteT[]) {
   return decryptedVotesForUser.flatMap((vote) => {
     if (vote.isRevealed || !vote.isCommitted || !vote.decryptedVote) return [];
 
-    const { identifier, decryptedVote, ancillaryData, time } = vote;
+    const { identifier, decryptedVote, ancillaryData, ancillaryDataL1, time } =
+      vote;
     const { price, salt } = decryptedVote;
 
     return {
       identifier,
       time,
       price,
-      ancillaryData,
+      ancillaryData: ancillaryDataL1 ?? ancillaryData,
       salt,
     };
   });

--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -40,6 +40,7 @@ function formatPriceRequest(
   const timeAsDate = new Date(timeMilliseconds);
   const identifier = priceRequest.identifier;
   const ancillaryData = priceRequest.ancillaryData;
+  const ancillaryDataL1 = priceRequest.ancillaryDataL1;
   let decodedIdentifier = "";
   let decodedAncillaryData = "";
   const revealedVoteByAddress = priceRequest.revealedVoteByAddress || {};
@@ -85,6 +86,7 @@ function formatPriceRequest(
     time,
     identifier,
     ancillaryData,
+    ancillaryDataL1,
     timeMilliseconds,
     timeAsDate,
     decodedIdentifier,

--- a/helpers/voting/resolveAncillaryData.ts
+++ b/helpers/voting/resolveAncillaryData.ts
@@ -66,6 +66,7 @@ export async function resolveAncillaryDataForRequests<
   );
   return requests.map((request, i) => ({
     ...request,
+    ancillaryDataL1: request.ancillaryData,
     ancillaryData: resolvedAncillaryData[i],
   }));
 }

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -21,6 +21,7 @@ export type PriceRequestT = {
   time: number;
   identifier: string;
   ancillaryData: string;
+  ancillaryDataL1?: string;
   correctVote?: string;
   // computed values
   timeMilliseconds: number;
@@ -63,6 +64,7 @@ export type RawPriceRequestDataT = {
   time: BigNumber | number;
   identifier: string;
   ancillaryData: string;
+  ancillaryDataL1?: string;
   lastVotingRound?: number;
   correctVote?: string;
   participation?: ParticipationT;

--- a/web3/mutations/votes/commitVotes.ts
+++ b/web3/mutations/votes/commitVotes.ts
@@ -9,12 +9,19 @@ export async function commitVotes({ voting, formattedVotes }: CommitVotes) {
 
     if (!vote) return;
 
-    const { identifier, time, ancillaryData, hash, encryptedVote } = vote;
+    const {
+      identifier,
+      time,
+      ancillaryData,
+      ancillaryDataL1,
+      hash,
+      encryptedVote,
+    } = vote;
 
     const tx = await voting.functions.commitAndEmitEncryptedVote(
       identifier,
       time,
-      ancillaryData,
+      ancillaryDataL1 ?? ancillaryData,
       hash,
       encryptedVote
     );
@@ -32,12 +39,20 @@ export async function commitVotes({ voting, formattedVotes }: CommitVotes) {
   const calldata = formattedVotes.flatMap((vote) => {
     if (!vote) return [];
 
-    const { identifier, time, ancillaryData, hash, encryptedVote } = vote;
+    const {
+      identifier,
+      time,
+      ancillaryData,
+      ancillaryDataL1,
+      hash,
+      encryptedVote,
+    } = vote;
+
     // @ts-expect-error todo figure out why it thinks this doesn't exist
     return voting.interface.encodeFunctionData(commitVoteFunctionFragment, [
       identifier,
       time,
-      ancillaryData,
+      ancillaryDataL1 ?? ancillaryData,
       hash,
       encryptedVote,
     ]);


### PR DESCRIPTION
# motivation
Commit is broken since upgrade, we need to change how commits are handled slightly

# changes
this uses the L1 ancillary data, rather than the fetched L2 original data