### PR TITLE
handle comma in decimals

### DIFF
--- a/components/Input/TextInput.tsx
+++ b/components/Input/TextInput.tsx
@@ -33,7 +33,7 @@ export function TextInput({
     onInput,
     maxDecimals,
     allowNegative,
-    _type
+    type
   );
 
   return (
@@ -46,6 +46,8 @@ export function TextInput({
         type={_type}
         autoComplete="off"
         autoCorrect="off"
+        lang="en"
+        data-decimal-separator="."
         placeholder={placeholder ?? "Enter value"}
         minLength={1}
         maxLength={79}

--- a/hooks/helpers/useHandleDecimalInput.ts
+++ b/hooks/helpers/useHandleDecimalInput.ts
@@ -22,6 +22,9 @@ export function useHandleDecimalInput(
       value = value.replace(maximumApprovalAmountString, "");
     }
 
+    // Replace commas with periods for decimal handling
+    value = value.replace(/,/g, ".");
+
     const decimalsErrorMessage = `Cannot have more than ${maxDecimals} decimals.`;
     const negativeAllowedDecimalRegex = /^-?\d*\.?\d{0,}$/;
     const onlyPositiveDecimalsRegex = /^\d*\.?\d{0,}$/;


### PR DESCRIPTION
Some mobile browsers set the default decimal separator as a comma instead of a period.

The Fix:
- Attempt to hint at mobile browsers which separator to use.
- Replace commas with periods when input mode is decimal and input type is number