### PR TITLE
sanitize titles on the frontend also

### DIFF
--- a/helpers/voting/getVoteMetaData.ts
+++ b/helpers/voting/getVoteMetaData.ts
@@ -18,6 +18,7 @@ import {
 import { checkIfIsInfiniteGames } from "./projects/infiniteGames";
 import * as s from "superstruct";
 import { maxInt256, minInt256 } from "constant/web3/numbers";
+import { stripInvalidCharacters } from "lib/utils";
 
 /** Finds a title and description, and UMIP link (if it exists) for a decodedIdentifier.
  *
@@ -37,7 +38,7 @@ export function getVoteMetaData(
   );
   if (isAssertion) {
     const assertionData = parseAssertionAncillaryData(decodedAncillaryData);
-    const title = decodedIdentifier;
+    const title = stripInvalidCharacters(decodedIdentifier);
     const description = makeAssertionDescription(assertionData);
     return {
       title,
@@ -58,7 +59,9 @@ export function getVoteMetaData(
   // if we are dealing with a UMIP, get the title, description and UMIP url from Contentful
   const isUmip = decodedIdentifier.includes("Admin");
   if (isUmip) {
-    const title = umipDataFromContentful?.title ?? decodedIdentifier;
+    const title = stripInvalidCharacters(
+      umipDataFromContentful?.title ?? decodedIdentifier
+    );
     const description =
       umipDataFromContentful?.description ??
       "No description was found for this UMIP.";
@@ -113,7 +116,9 @@ export function getVoteMetaData(
     const ancillaryDataTitle = getTitleFromAncillaryData(decodedAncillaryData);
     const ancillaryDataDescription =
       getDescriptionFromAncillaryData(decodedAncillaryData);
-    const title = ancillaryDataTitle ?? decodedIdentifier;
+    const title = stripInvalidCharacters(
+      ancillaryDataTitle ?? decodedIdentifier
+    );
     const description =
       ancillaryDataDescription ?? "No description was found for this request.";
     const isYesNoQuery = decodedIdentifier === "YES_OR_NO_QUERY";
@@ -155,7 +160,7 @@ export function getVoteMetaData(
   const identifierDetails = approvedIdentifiers[decodedIdentifier];
   const isApprovedIdentifier = Boolean(identifierDetails);
   if (isApprovedIdentifier) {
-    const title = identifierDetails.identifier;
+    const title = stripInvalidCharacters(identifierDetails.identifier);
     const description = identifierDetails.summary;
     const umipOrUppUrl = identifierDetails.umipLink.url;
     const umipOrUppNumber = identifierDetails.umipLink.number;
@@ -180,7 +185,7 @@ export function getVoteMetaData(
 
   // if all checks fail, return with generic values generated from the data we have
   return {
-    title: decodedIdentifier,
+    title: stripInvalidCharacters(decodedIdentifier),
     description: "No description found for this request.",
     umipOrUppLink: undefined,
     umipOrUppNumber: undefined,
@@ -217,7 +222,7 @@ function decodeMultipleValuesQuery(decodedAncillaryData: string) {
     throw new Error("MULTIPLE_VALUES only support up to 7 labels");
 
   return {
-    title: json.title,
+    title: stripInvalidCharacters(json.title),
     description: json.description,
     options: json.labels.map((label) => {
       return {
@@ -497,7 +502,7 @@ function decodeMultipleChoiceQuery(decodedAncillaryData: string) {
   if (!isMultipleChoiceQueryFormat(json))
     throw new Error("Malformed ancillary data");
   return {
-    title: json.title,
+    title: stripInvalidCharacters(json.title),
     description: json.description,
     options: makeMultipleChoiceOptions(
       (

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+// Strip invalid characters that Discord strips from titles
+export function stripInvalidCharacters(str: string): string {
+  const invalidCharacters = [
+    "\u202f", // hyphenation point
+  ];
+  let sanitized = str;
+  for (const char of invalidCharacters) {
+    sanitized = sanitized.replace(new RegExp(char, "g"), "");
+  }
+  return sanitized;
+}

--- a/pages/api/discord-thread.ts
+++ b/pages/api/discord-thread.ts
@@ -10,6 +10,7 @@ import {
 
 import * as ss from "superstruct";
 import { APIEmbed } from "discord-api-types/v10";
+import { stripInvalidCharacters } from "lib/utils";
 
 // converts markdown headers #, ## and ### to bold instead so we dont render large text in discussion panel
 export function stripMarkdownHeaders(message: string): string {
@@ -138,22 +139,8 @@ function truncateTitle(title: string) {
   return title.substring(0, 60);
 }
 
-const invalidCharacters = [
-  "\u202f", // narrow no-break space
-  // Add more characters here as needed
-];
-
-// Strip invalid characters that Discord strips from titles
-function sanitizeTitle(title: string): string {
-  let result = title;
-  for (const char of invalidCharacters) {
-    result = result.replace(new RegExp(char, "g"), "");
-  }
-  return result;
-}
-
 function makeKey(title: string, timestamp: string | number) {
-  const cleanedTitle = sanitizeTitle(truncateTitle(title));
+  const cleanedTitle = stripInvalidCharacters(truncateTitle(title));
   return `${cleanedTitle}-${String(timestamp)}`.replaceAll(" ", "");
 }
 
@@ -240,7 +227,9 @@ export default async function handler(
         l1Request: {
           time: Number(request.query.time),
           identifier: request.query.identifier,
-          title: sanitizeTitle(request.query.title?.toString().trim() || ""),
+          title: stripInvalidCharacters(
+            request.query.title?.toString().trim() || ""
+          ),
         },
       },
       DiscordThreadRequestBody


### PR DESCRIPTION
Follow-up of https://github.com/UMAprotocol/voter-dapp-v2/pull/377

## Changes
- Move sanitize logic to shared util folder
- Sanitize titles for display in the frontend