### PR TITLE
fix: unset max width in multiple values modal for better mobile responsiveness

### DIFF
--- a/components/Input/TextInput.tsx
+++ b/components/Input/TextInput.tsx
@@ -14,6 +14,7 @@ interface Props {
   maxDecimals?: number;
   allowNegative?: boolean;
   id?: string;
+  styles?: React.CSSProperties;
 }
 export function TextInput({
   value,
@@ -25,6 +26,7 @@ export function TextInput({
   type = "text",
   maxDecimals = 18,
   allowNegative = true,
+  styles,
 }: Props) {
   const inputMode = type === "text" ? "text" : "decimal";
   // treat all as text inputs to avoid unwanted automatic number formatting
@@ -37,7 +39,7 @@ export function TextInput({
   );
 
   return (
-    <_Wrapper aria-disabled={disabled}>
+    <_Wrapper style={styles} aria-disabled={disabled}>
       <_Input
         value={value ?? undefined}
         onChange={onChange}

--- a/components/Modals/MultipleValuesInputModal.tsx
+++ b/components/Modals/MultipleValuesInputModal.tsx
@@ -46,6 +46,9 @@ export function MultipleValuesInputModal(props: MultipleInputProps) {
                   onClear={() => props.onInputChange({ label, value: "" })}
                   maxDecimals={0}
                   type="number"
+                  styles={{
+                    minWidth: "unset",
+                  }}
                 />
               </label>
               {i === 0 && items?.length === 2 && (


### PR DESCRIPTION
## Fixes
1. Remove redundant secondary labels for MULTIPLE_VALUES dropdown items, breaking the layout a bit.
2. Disable the max-width of input fields in the multiple values input modal to prevent overflow on mobile

<img width="406" height="606" alt="Screenshot 2025-08-24 at 08 54 00" src="https://github.com/user-attachments/assets/366db0aa-509e-48fe-b3d7-da2b97e3ae85" />
<img width="287" height="254" alt="Screenshot 2025-08-24 at 08 54 15" src="https://github.com/user-attachments/assets/dd0da97e-b73b-4d95-ad5b-72b78b5265a3" />
