### PR TITLE
fix: unable to edit committed multiple values vote

### DIFF
--- a/components/Modals/MultipleValuesInputModal.tsx
+++ b/components/Modals/MultipleValuesInputModal.tsx
@@ -10,11 +10,16 @@ import React from "react";
 export function MultipleValuesInputModal(props: MultipleInputProps) {
   const items = Object.entries(props?.inputValues);
 
+  function handleClose() {
+    props.resetToCommittedVote();
+    props.closeInputModal();
+  }
+
   return (
     <Modal
       className={cn(items?.length > 2 ? "max-w-[540px]" : "max-w-[560px]")}
       isOpen={props.inputModalOpen}
-      onDismiss={props.closeInputModal}
+      onDismiss={handleClose}
     >
       <div className="mb-4 flex items-center gap-2">
         <PencilIcon className="h-5 w-5" />


### PR DESCRIPTION
## Problem
- input values set to committed vote values on every render in useEffect, effectively stopping us from updating our vote.

## Solution
- Set initial input values only once when committed vote is first decrypted. Keep track of this with a ref.