### PR TITLE
fix: hanging calls to discord-thread 

### DIFF
--- a/pages/api/discord-thread/index.ts
+++ b/pages/api/discord-thread/index.ts
@@ -185,11 +185,16 @@ async function fetchDiscordThread(
     finalMessages.push({ ...orphanedReply, replies: [] });
   });
 
+  if (isStaleData) {
+    console.warn(`Returning stale data for request ${requestedId}`, {
+      at: "/api/discord-thread",
+    });
+  }
+
   return {
     identifier: l1Request.identifier,
     time: l1Request.time,
     thread: finalMessages,
-    isStaleData,
   };
 }
 

--- a/pages/api/discord-thread/index.ts
+++ b/pages/api/discord-thread/index.ts
@@ -81,12 +81,14 @@ function concatenateAttachments(
 
 async function fetchDiscordThread(
   l1Request: L1Request
-): Promise<VoteDiscussionT> {
+): Promise<VoteDiscussionT & { isStaleData?: boolean }> {
   // Create the request key using the same logic as before
   const requestedId = makeKey(l1Request.title, l1Request.time);
 
   // Use the new cache-aware function to get thread messages
-  const { messages } = await getThreadMessagesForRequest(requestedId);
+  const { messages, isStaleData } = await getThreadMessagesForRequest(
+    requestedId
+  );
 
   // First, process all messages into a flat structure
   const allProcessedMessages: (DiscordMessageT & {
@@ -187,6 +189,7 @@ async function fetchDiscordThread(
     identifier: l1Request.identifier,
     time: l1Request.time,
     thread: finalMessages,
+    isStaleData,
   };
 }
 
@@ -232,7 +235,7 @@ export default async function handler(
       body.l1Request
     );
     response
-      .setHeader("Cache-Control", "max-age=0, s-maxage=180")
+      .setHeader("Cache-Control", "max-age=0, s-maxage=300")
       .status(200)
       .send(voteDiscussion);
   } catch (e) {

--- a/pages/api/discord-thread/index.ts
+++ b/pages/api/discord-thread/index.ts
@@ -235,7 +235,7 @@ export default async function handler(
       body.l1Request
     );
     response
-      .setHeader("Cache-Control", "max-age=0, s-maxage=300")
+      .setHeader("Cache-Control", "max-age=0, s-maxage=180")
       .status(200)
       .send(voteDiscussion);
   } catch (e) {

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -304,7 +304,7 @@ export const DiscordMessageT: ss.Describe<{
 });
 export type DiscordMessageT = ss.Infer<typeof DiscordMessageT>;
 
-export const VoteDiscussionT = ss.object({
+export const VoteDiscussionT = ss.type({
   identifier: ss.string(),
   time: ss.number(),
   thread: ss.array(DiscordMessageT),

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,9 @@
     },
     "pages/api/update-summary.ts": {
       "maxDuration": 300
+    },
+    "pages/api/discord-thread/index.ts": {
+      "maxDuration": 300
     }
   },
   "headers": [


### PR DESCRIPTION
closes FE-54

## Work done
1. Set max duration to 5 minutes to prevent timeouts
2. In case of an error after max retries, return a stale response we can cache in redis.
