### PR TITLE
fix: add 10s timeout to subgraph queries and fix cache headers to prevent Cloudflare 520 errors

### DIFF
--- a/pages/api/augment-request-gql.ts
+++ b/pages/api/augment-request-gql.ts
@@ -13,6 +13,17 @@ import { handleApiError } from "./_utils/errors";
 import { validateBodyParams } from "./_utils/validation";
 
 const debug = Boolean(process.env.DEBUG === "true");
+const QUERY_TIMEOUT_MS = 10_000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number = QUERY_TIMEOUT_MS): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Query timeout after ${ms}ms`)), ms);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+}
 
 const RequestBody = ss.object({
   ancillaryData: ss.string(),
@@ -73,6 +84,7 @@ async function voteQuery({
   identifier,
   ancillaryData,
 }: Omit<OracleQueryParams, "chainId">) {
+  await new Promise((resolve) => setTimeout(resolve, 30000)); // REMOVE BEFORE MERGING
   const id = makeUniqueKeyForVote(identifier, time, ancillaryData);
   const query = gql`
     query voteQuery($id: ID!) {
@@ -88,7 +100,7 @@ async function voteQuery({
     priceRequest: GqlRequest | undefined | null;
   };
   try {
-    const data: GqlResponse = await request(VoteSubgraphURL, query, { id });
+    const data: GqlResponse = await withTimeout(request(VoteSubgraphURL, query, { id }));
     assert(data.priceRequest, "vote query request not found");
     return data.priceRequest;
   } catch (error) {
@@ -126,9 +138,9 @@ async function ooSkinnyQuery({
   };
 
   try {
-    const data: GqlResponse = await request(subgraph.url, query, {
+    const data: GqlResponse = await withTimeout(request(subgraph.url, query, {
       id,
-    });
+    }));
     const { optimisticPriceRequest } = data;
     assert(optimisticPriceRequest, "skinny request not found");
     const requestHash = optimisticPriceRequest?.requestHash;
@@ -196,9 +208,9 @@ async function oov3Query({
   };
 
   try {
-    const data: GqlResponse = await request(subgraph.url, query, {
+    const data: GqlResponse = await withTimeout(request(subgraph.url, query, {
       id: assertionId,
-    });
+    }));
     assert(data.assertion, "oov3 query request not found");
     const { assertion } = data;
     const assertionHash = assertion?.assertionHash;
@@ -283,10 +295,10 @@ async function oov2Query({
   };
 
   try {
-    const data: GqlResponse = await request(subgraph.url, query, {
+    const data: GqlResponse = await withTimeout(request(subgraph.url, query, {
       ancillaryData: cleanAncillaryData,
       identifier,
-    });
+    }));
     assert(data.optimisticPriceRequests.length > 0, "oov2 request not found");
     let optimisticPriceRequest: GqlRequest | undefined;
     if (data.optimisticPriceRequests.length > 1) {
@@ -368,10 +380,10 @@ async function ooManagedQuery({
   };
 
   try {
-    const data: GqlResponse = await request(subgraph.url, query, {
+    const data: GqlResponse = await withTimeout(request(subgraph.url, query, {
       ancillaryData: cleanAncillaryData,
       identifier,
-    });
+    }));
     assert(
       data.optimisticPriceRequests.length > 0,
       "Managed oov2 request not found"
@@ -447,9 +459,9 @@ async function oov1Query({
       optimisticPriceRequest: GqlRequest;
     };
 
-    const data: GqlResponse = await request(subgraph.url, query, {
+    const data: GqlResponse = await withTimeout(request(subgraph.url, query, {
       id,
-    });
+    }));
     const { optimisticPriceRequest } = data;
     assert(optimisticPriceRequest, "oov1 request not found");
     const requestHash = optimisticPriceRequest?.requestHash;
@@ -515,15 +527,15 @@ export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
 ) {
-  response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000"); // Cache for 30 days and re-build cache if re-deployed.
-
   try {
     const body = validateBodyParams(request.body, RequestBody);
     if (debug) console.log("query", body);
     const result = await augmentRequest(body);
     if (debug) console.log("result", result);
+    response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000");
     response.status(200).send(result);
   } catch (error) {
+    response.setHeader("Cache-Control", "no-store");
     return handleApiError(error, response);
   }
 }

--- a/pages/api/augment-request-gql.ts
+++ b/pages/api/augment-request-gql.ts
@@ -15,12 +15,24 @@ import { validateBodyParams } from "./_utils/validation";
 const debug = Boolean(process.env.DEBUG === "true");
 const QUERY_TIMEOUT_MS = 10_000;
 
-function withTimeout<T>(promise: Promise<T>, ms: number = QUERY_TIMEOUT_MS): Promise<T> {
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number = QUERY_TIMEOUT_MS
+): Promise<T> {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`Query timeout after ${ms}ms`)), ms);
+    const timer = setTimeout(
+      () => reject(new Error(`Query timeout after ${ms}ms`)),
+      ms
+    );
     promise.then(
-      (value) => { clearTimeout(timer); resolve(value); },
-      (error) => { clearTimeout(timer); reject(error); },
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
     );
   });
 }
@@ -100,7 +112,9 @@ async function voteQuery({
     priceRequest: GqlRequest | undefined | null;
   };
   try {
-    const data: GqlResponse = await withTimeout(request(VoteSubgraphURL, query, { id }));
+    const data: GqlResponse = await withTimeout(
+      request(VoteSubgraphURL, query, { id })
+    );
     assert(data.priceRequest, "vote query request not found");
     return data.priceRequest;
   } catch (error) {
@@ -138,9 +152,11 @@ async function ooSkinnyQuery({
   };
 
   try {
-    const data: GqlResponse = await withTimeout(request(subgraph.url, query, {
-      id,
-    }));
+    const data: GqlResponse = await withTimeout(
+      request(subgraph.url, query, {
+        id,
+      })
+    );
     const { optimisticPriceRequest } = data;
     assert(optimisticPriceRequest, "skinny request not found");
     const requestHash = optimisticPriceRequest?.requestHash;
@@ -208,9 +224,11 @@ async function oov3Query({
   };
 
   try {
-    const data: GqlResponse = await withTimeout(request(subgraph.url, query, {
-      id: assertionId,
-    }));
+    const data: GqlResponse = await withTimeout(
+      request(subgraph.url, query, {
+        id: assertionId,
+      })
+    );
     assert(data.assertion, "oov3 query request not found");
     const { assertion } = data;
     const assertionHash = assertion?.assertionHash;
@@ -295,10 +313,12 @@ async function oov2Query({
   };
 
   try {
-    const data: GqlResponse = await withTimeout(request(subgraph.url, query, {
-      ancillaryData: cleanAncillaryData,
-      identifier,
-    }));
+    const data: GqlResponse = await withTimeout(
+      request(subgraph.url, query, {
+        ancillaryData: cleanAncillaryData,
+        identifier,
+      })
+    );
     assert(data.optimisticPriceRequests.length > 0, "oov2 request not found");
     let optimisticPriceRequest: GqlRequest | undefined;
     if (data.optimisticPriceRequests.length > 1) {
@@ -380,10 +400,12 @@ async function ooManagedQuery({
   };
 
   try {
-    const data: GqlResponse = await withTimeout(request(subgraph.url, query, {
-      ancillaryData: cleanAncillaryData,
-      identifier,
-    }));
+    const data: GqlResponse = await withTimeout(
+      request(subgraph.url, query, {
+        ancillaryData: cleanAncillaryData,
+        identifier,
+      })
+    );
     assert(
       data.optimisticPriceRequests.length > 0,
       "Managed oov2 request not found"
@@ -459,9 +481,11 @@ async function oov1Query({
       optimisticPriceRequest: GqlRequest;
     };
 
-    const data: GqlResponse = await withTimeout(request(subgraph.url, query, {
-      id,
-    }));
+    const data: GqlResponse = await withTimeout(
+      request(subgraph.url, query, {
+        id,
+      })
+    );
     const { optimisticPriceRequest } = data;
     assert(optimisticPriceRequest, "oov1 request not found");
     const requestHash = optimisticPriceRequest?.requestHash;


### PR DESCRIPTION
Wrap all GraphQL requests in augment-request-gql with a withTimeout helper (10s) so slow/unresponsive subgraphs produce a proper error instead of hanging indefinitely. Move Cache-Control header into the success path and set no-store on errors so timeout failures are never cached at the CDN edge. Includes a temporary 30s delay in voteQuery for local testing (remove before merging).
