### PR TITLE
fix: include closed Polymarket markets when resolving link (FE-545)

### DIFF
--- a/pages/api/get-polymarket-link.ts
+++ b/pages/api/get-polymarket-link.ts
@@ -25,17 +25,22 @@ export default async function handler(
       });
     }
 
-    const data = (await fetch(
-      `https://gamma-api.polymarket.com/markets?${buildSearchParams({
-        question_ids: questionId,
-      })}`
-    ).then((res) => res.json())) as Array<{
-      events: Array<{
-        slug: string;
-      }>;
-    }>;
+    type Market = { events: Array<{ slug: string }> };
+    const baseUrl = "https://gamma-api.polymarket.com/markets";
+    const [openMarkets, closedMarkets] = (await Promise.all([
+      fetch(
+        `${baseUrl}?${buildSearchParams({ question_ids: questionId })}`
+      ).then((res) => res.json()),
+      fetch(
+        `${baseUrl}?${buildSearchParams({
+          question_ids: questionId,
+          closed: "true",
+        })}`
+      ).then((res) => res.json()),
+    ])) as [Market[] | null, Market[] | null];
 
-    const slug = data?.[0]?.events?.[0]?.slug;
+    const markets = [...(openMarkets ?? []), ...(closedMarkets ?? [])];
+    const slug = markets[0]?.events?.[0]?.slug;
     response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000");
     response.status(200).send({ slug });
   } catch (e) {

--- a/pages/api/get-polymarket-link.ts
+++ b/pages/api/get-polymarket-link.ts
@@ -37,11 +37,22 @@ export default async function handler(
       fetchMarkets({ question_ids: questionId }),
       fetchMarkets({ question_ids: questionId, closed: "true" }),
     ]);
+    if (results.every((r) => r.status === "rejected")) {
+      throw new HttpError({
+        statusCode: 502,
+        msg: "Unable to reach Polymarket gamma API",
+      });
+    }
+
     const markets = results.flatMap((r) =>
       r.status === "fulfilled" ? r.value : []
     );
     const slug = markets[0]?.events?.[0]?.slug;
-    response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000");
+
+    const allSucceeded = results.every((r) => r.status === "fulfilled");
+    if (slug || allSucceeded) {
+      response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000");
+    }
     response.status(200).send({ slug });
   } catch (e) {
     return handleApiError(e, response);

--- a/pages/api/get-polymarket-link.ts
+++ b/pages/api/get-polymarket-link.ts
@@ -27,19 +27,19 @@ export default async function handler(
 
     type Market = { events: Array<{ slug: string }> };
     const baseUrl = "https://gamma-api.polymarket.com/markets";
-    const [openMarkets, closedMarkets] = (await Promise.all([
-      fetch(
-        `${baseUrl}?${buildSearchParams({ question_ids: questionId })}`
-      ).then((res) => res.json()),
-      fetch(
-        `${baseUrl}?${buildSearchParams({
-          question_ids: questionId,
-          closed: "true",
-        })}`
-      ).then((res) => res.json()),
-    ])) as [Market[] | null, Market[] | null];
+    async function fetchMarkets(params: Record<string, string>) {
+      const res = await fetch(`${baseUrl}?${buildSearchParams(params)}`);
+      const payload: unknown = await res.json();
+      return Array.isArray(payload) ? (payload as Market[]) : [];
+    }
 
-    const markets = [...(openMarkets ?? []), ...(closedMarkets ?? [])];
+    const results = await Promise.allSettled([
+      fetchMarkets({ question_ids: questionId }),
+      fetchMarkets({ question_ids: questionId, closed: "true" }),
+    ]);
+    const markets = results.flatMap((r) =>
+      r.status === "fulfilled" ? r.value : []
+    );
     const slug = markets[0]?.events?.[0]?.slug;
     response.setHeader("Cache-Control", "max-age=0, s-maxage=2592000");
     response.status(200).send({ slug });


### PR DESCRIPTION
## Summary

- Fixes [FE-545](https://linear.app/uma/issue/FE-545/voter-dapp-polymarket-link-often-missing): ~80% of vote detail panels were missing the "See on Polymarket" link.
- Root cause: Polymarket's gamma API excludes closed markets by default. Voter-dapp votes fire only after a market closes on Polymarket, so `GET /markets?question_ids=<hex>` returned `[]` for virtually every vote, leaving `slug` undefined and the link hidden.
- Fix: in `pages/api/get-polymarket-link.ts`, query open and closed markets in parallel and return whichever yields a slug.

## Verification

Confirmed the API behavior against the live gamma endpoint with a real closed-market questionID:

- `GET /markets?question_ids=0xd2f779…ec88e` → `[]`
- `GET /markets?question_ids=0xd2f779…ec88e&closed=true` → returns the market with `events[0].slug`

## Test plan

- [x] `yarn test tests/helpers/voting/projects/polymarket.test.ts` still passes
- [x] `yarn tsc --noEmit` clean
- [x] Open the voter dapp, navigate to a recently-resolved Polymarket vote (e.g. "HYPE Up or Down - April 8, 7PM ET"), confirm the "See on Polymarket" link appears and opens the correct market
- [x] Verify the link still works for any still-open Polymarket vote (open-market path not regressed)