### PR TITLE
fix: warn voters when custom vote value would overflow int256

### DIFF
--- a/components/VoteList/VoteListItem.tsx
+++ b/components/VoteList/VoteListItem.tsx
@@ -47,6 +47,7 @@ export function VoteListItem(props: VoteListItemProps) {
     isDirty,
     origin,
     moreDetailsAction,
+    customInputError,
   } = useVoteListItem(props);
 
   const { isOptimisticGovernorVote, explanationText } =
@@ -118,13 +119,20 @@ export function VoteListItem(props: VoteListItemProps) {
               onSelect={onSelectVote}
             />
           ) : (
-            <TextInput
-              value={selectedVote ?? getDecryptedVoteAsString() ?? ""}
-              onInput={selectVote}
-              onClear={() => exitCustomInput()}
-              maxDecimals={maxDecimals}
-              type="number"
-            />
+            <>
+              <TextInput
+                value={selectedVote ?? getDecryptedVoteAsString() ?? ""}
+                onInput={selectVote}
+                onClear={() => exitCustomInput()}
+                maxDecimals={maxDecimals}
+                type="number"
+              />
+              {customInputError ? (
+                <span className="mt-1 block text-xs text-red-500">
+                  {customInputError}
+                </span>
+              ) : null}
+            </>
           )}
         </div>
       ) : null}

--- a/components/VoteList/VoteTableRow.tsx
+++ b/components/VoteList/VoteTableRow.tsx
@@ -63,6 +63,7 @@ export function VoteTableRow(props: VoteListItemProps) {
     multipleInputProps,
     dropdownOptions,
     selectedDropdownOption,
+    customInputError,
   } = useVoteListItem(props);
 
   const { isOptimisticGovernorVote, explanationText } =
@@ -146,13 +147,20 @@ export function VoteTableRow(props: VoteListItemProps) {
               onSelect={onSelectVote}
             />
           ) : (
-            <TextInput
-              value={selectedVote ?? getDecryptedVoteAsString() ?? ""}
-              onInput={selectVote}
-              onClear={() => exitCustomInput()}
-              maxDecimals={maxDecimals}
-              type="number"
-            />
+            <>
+              <TextInput
+                value={selectedVote ?? getDecryptedVoteAsString() ?? ""}
+                onInput={selectVote}
+                onClear={() => exitCustomInput()}
+                maxDecimals={maxDecimals}
+                type="number"
+              />
+              {customInputError ? (
+                <span className="mt-1 block text-xs text-red-500">
+                  {customInputError}
+                </span>
+              ) : null}
+            </>
           )}
         </td>
       ) : null}

--- a/components/VoteList/useVoteListItem.tsx
+++ b/components/VoteList/useVoteListItem.tsx
@@ -4,6 +4,7 @@ import {
   formatVoteStringWithPrecision,
   getPrecisionForIdentifier,
   getClaimTitle,
+  validateCustomVoteInput,
 } from "helpers";
 import { config } from "helpers/config";
 import {
@@ -198,6 +199,15 @@ export function useVoteListItem({
     ? multipleInputProps.selectedDropdownOption
     : getExistingOrSelectedVoteFromOptions();
 
+  const showsCustomInput = isCustomInput || !dropdownOptions;
+  const customInputValidation =
+    showsCustomInput && !isMultipleValuesVote
+      ? validateCustomVoteInput(selectedVote, decodedIdentifier)
+      : { isValid: true as const };
+  const customInputError = customInputValidation.isValid
+    ? undefined
+    : customInputValidation.message;
+
   function getYourVote() {
     // Check if wallet is connected
     if (!address && !delegatorAddress) {
@@ -370,5 +380,6 @@ export function useVoteListItem({
     moreDetailsAction,
     multipleInputProps,
     selectedDropdownOption,
+    customInputError,
   };
 }

--- a/components/Votes/ActiveVotes.tsx
+++ b/components/Votes/ActiveVotes.tsx
@@ -6,7 +6,7 @@ import {
   VoteList,
   VoteTimeline,
 } from "components";
-import { formatVotesToCommit } from "helpers";
+import { formatVotesToCommit, validateCustomVoteInput } from "helpers";
 import { config } from "helpers/config";
 import {
   useAccountDetails,
@@ -110,6 +110,11 @@ export function ActiveVotes() {
           : true
         : false;
     const hasVotesToReveal = getVotesToReveal().length > 0;
+    const hasInvalidSelectedVote = !!activeVoteList?.some((vote) => {
+      const value = selectedVotes[vote.uniqueKey];
+      if (!value) return false;
+      return !validateCustomVoteInput(value, vote.decodedIdentifier).isValid;
+    });
     // the current account is editing a previously committed value from another account, either delegate or delegator
     const isEditingUnknownVote = Boolean(
       activeVoteList?.filter((vote) => {
@@ -200,6 +205,11 @@ export function ActiveVotes() {
         actionConfig.disabled = true;
         actionConfig.tooltip =
           "You must enter your votes before you can continue.";
+        return actionConfig;
+      }
+      if (hasInvalidSelectedVote) {
+        actionConfig.disabled = true;
+        actionConfig.tooltip = "Fix invalid custom votes before committing.";
         return actionConfig;
       }
       actionConfig.canCommit = true;

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -20,6 +20,7 @@ export { makeUniqueKeyForVote } from "./voting/makeUniqueKeyForVote";
 export { onlyOneRequestPerAddress } from "./voting/onlyOneRequestPerAddress";
 export * from "./voting/optimisticGovernor";
 export * from "./voting/projects";
+export * from "./voting/validateCustomVoteInput";
 export * from "./voting/voteTiming";
 export * from "./web3/crypto";
 export {

--- a/helpers/voting/validateCustomVoteInput.ts
+++ b/helpers/voting/validateCustomVoteInput.ts
@@ -1,0 +1,36 @@
+import { parseFixed } from "@ethersproject/bignumber";
+import { maxInt256, minInt256 } from "constant/web3/numbers";
+import { getPrecisionForIdentifier } from "helpers/web3/crypto";
+
+export type CustomVoteInputValidation =
+  | { isValid: true }
+  | { isValid: false; message: string };
+
+export function validateCustomVoteInput(
+  value: string | undefined,
+  decodedIdentifier: string
+): CustomVoteInputValidation {
+  if (!value || value === "-" || value === ".") return { isValid: true };
+  if (decodedIdentifier === "MULTIPLE_VALUES") return { isValid: true };
+
+  const precision = getPrecisionForIdentifier(decodedIdentifier);
+
+  let parsed;
+  try {
+    parsed = parseFixed(value, precision);
+  } catch {
+    return { isValid: false, message: "Invalid number." };
+  }
+
+  if (parsed.gt(maxInt256) || parsed.lt(minInt256)) {
+    const missingDecimal = !value.includes(".");
+    const hint = missingDecimal
+      ? ` Values are parsed with ${precision} decimals of precision — did you forget to include the decimal point? e.g. "1.5" is encoded as 1500000000000000000.`
+      : "";
+    return {
+      isValid: false,
+      message: `Value is out of range for a 256-bit signed integer.${hint}`,
+    };
+  }
+  return { isValid: true };
+}

--- a/helpers/voting/validateCustomVoteInput.ts
+++ b/helpers/voting/validateCustomVoteInput.ts
@@ -1,10 +1,25 @@
-import { parseFixed } from "@ethersproject/bignumber";
+import { formatFixed, parseFixed } from "@ethersproject/bignumber";
+import { BigNumber } from "ethers";
 import { maxInt256, minInt256 } from "constant/web3/numbers";
 import { getPrecisionForIdentifier } from "helpers/web3/crypto";
 
 export type CustomVoteInputValidation =
   | { isValid: true }
-  | { isValid: false; message: string };
+  | { isValid: false; message: string; suggestion?: string };
+
+function suggestUnscaledValue(
+  value: string,
+  precision: number
+): string | undefined {
+  if (value.includes(".")) return undefined;
+  try {
+    const asInt = BigNumber.from(value);
+    if (asInt.gt(maxInt256) || asInt.lt(minInt256)) return undefined;
+    return formatFixed(asInt, precision);
+  } catch {
+    return undefined;
+  }
+}
 
 export function validateCustomVoteInput(
   value: string | undefined,
@@ -23,13 +38,18 @@ export function validateCustomVoteInput(
   }
 
   if (parsed.gt(maxInt256) || parsed.lt(minInt256)) {
-    const missingDecimal = !value.includes(".");
-    const hint = missingDecimal
-      ? ` Values are parsed with ${precision} decimals of precision — did you forget to include the decimal point? e.g. "1.5" is encoded as 1500000000000000000.`
-      : "";
+    const suggestion = suggestUnscaledValue(value, precision);
+    const umipRule = `Per UMIP-107, enter unscaled decimal values — the interface scales by 10^${precision} for you.`;
+    if (suggestion) {
+      return {
+        isValid: false,
+        message: `This looks like a pre-scaled value. ${umipRule} Did you mean ${suggestion}?`,
+        suggestion,
+      };
+    }
     return {
       isValid: false,
-      message: `Value is out of range for a 256-bit signed integer.${hint}`,
+      message: `Value is out of range for a 256-bit signed integer. ${umipRule}`,
     };
   }
   return { isValid: true };

--- a/tests/helpers/voting/validateCustomVoteInput.test.ts
+++ b/tests/helpers/voting/validateCustomVoteInput.test.ts
@@ -48,24 +48,27 @@ describe("validateCustomVoteInput", () => {
     });
   });
 
-  it("rejects out-of-range values entered without a decimal point and suggests the decimal", () => {
+  it("detects the pre-scaled p4 magic number and suggests the correct unscaled value", () => {
     const result = validateCustomVoteInput(OVERFLOW_NO_DECIMAL, NUMERIC_ID);
     expect(result.isValid).toBe(false);
     if (!result.isValid) {
-      expect(result.message).toMatch(/out of range/i);
-      expect(result.message).toMatch(/decimal point/i);
-      expect(result.message).toMatch(/18 decimals of precision/);
+      expect(result.suggestion).toBe(MIN_INT_256_DECIMAL);
+      expect(result.message).toMatch(/pre-scaled/i);
+      expect(result.message).toMatch(/UMIP-107/);
+      expect(result.message).toMatch(/10\^18/);
+      expect(result.message).toContain(MIN_INT_256_DECIMAL);
     }
   });
 
-  it("rejects out-of-range values that already include a decimal without the missing-decimal hint", () => {
+  it("rejects out-of-range values that cannot be reversed into an int256 without a suggestion", () => {
     const tooLargeWithDecimal =
       "99999999999999999999999999999999999999999999999999999999999.0";
     const result = validateCustomVoteInput(tooLargeWithDecimal, NUMERIC_ID);
     expect(result.isValid).toBe(false);
     if (!result.isValid) {
+      expect(result.suggestion).toBeUndefined();
       expect(result.message).toMatch(/out of range/i);
-      expect(result.message).not.toMatch(/decimal point/i);
+      expect(result.message).toMatch(/UMIP-107/);
     }
   });
 

--- a/tests/helpers/voting/validateCustomVoteInput.test.ts
+++ b/tests/helpers/voting/validateCustomVoteInput.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("helpers/config", () => ({
+  config: {},
+  appConfig: {},
+  env: {},
+}));
+
+vi.mock("helpers/web3/initOnboard", () => ({
+  initOnboard: () => undefined,
+}));
+
+import { validateCustomVoteInput } from "helpers/voting/validateCustomVoteInput";
+
+const NUMERIC_ID = "YES_OR_NO_QUERY";
+const MIN_INT_256_DECIMAL =
+  "-57896044618658097711785492504343953926634992332820282019728.792003956564819968";
+const MAX_INT_256_DECIMAL =
+  "57896044618658097711785492504343953926634992332820282019728.792003956564819967";
+const OVERFLOW_NO_DECIMAL =
+  "-57896044618658097711785492504343953926634992332820282019728792003956564819968";
+
+describe("validateCustomVoteInput", () => {
+  it("treats empty / partial inputs as valid", () => {
+    expect(validateCustomVoteInput("", NUMERIC_ID)).toEqual({ isValid: true });
+    expect(validateCustomVoteInput(undefined, NUMERIC_ID)).toEqual({
+      isValid: true,
+    });
+    expect(validateCustomVoteInput("-", NUMERIC_ID)).toEqual({ isValid: true });
+    expect(validateCustomVoteInput(".", NUMERIC_ID)).toEqual({ isValid: true });
+  });
+
+  it("accepts well-formed decimal values inside int256 bounds", () => {
+    expect(validateCustomVoteInput("1.5", NUMERIC_ID)).toEqual({
+      isValid: true,
+    });
+    expect(validateCustomVoteInput("-42", NUMERIC_ID)).toEqual({
+      isValid: true,
+    });
+  });
+
+  it("accepts exact minInt256 and maxInt256 boundary values", () => {
+    expect(validateCustomVoteInput(MIN_INT_256_DECIMAL, NUMERIC_ID)).toEqual({
+      isValid: true,
+    });
+    expect(validateCustomVoteInput(MAX_INT_256_DECIMAL, NUMERIC_ID)).toEqual({
+      isValid: true,
+    });
+  });
+
+  it("rejects out-of-range values entered without a decimal point and suggests the decimal", () => {
+    const result = validateCustomVoteInput(OVERFLOW_NO_DECIMAL, NUMERIC_ID);
+    expect(result.isValid).toBe(false);
+    if (!result.isValid) {
+      expect(result.message).toMatch(/out of range/i);
+      expect(result.message).toMatch(/decimal point/i);
+      expect(result.message).toMatch(/18 decimals of precision/);
+    }
+  });
+
+  it("rejects out-of-range values that already include a decimal without the missing-decimal hint", () => {
+    const tooLargeWithDecimal =
+      "99999999999999999999999999999999999999999999999999999999999.0";
+    const result = validateCustomVoteInput(tooLargeWithDecimal, NUMERIC_ID);
+    expect(result.isValid).toBe(false);
+    if (!result.isValid) {
+      expect(result.message).toMatch(/out of range/i);
+      expect(result.message).not.toMatch(/decimal point/i);
+    }
+  });
+
+  it("rejects non-numeric garbage", () => {
+    expect(validateCustomVoteInput("abc", NUMERIC_ID)).toEqual({
+      isValid: false,
+      message: "Invalid number.",
+    });
+  });
+
+  it("bypasses validation for MULTIPLE_VALUES identifier", () => {
+    expect(
+      validateCustomVoteInput(OVERFLOW_NO_DECIMAL, "MULTIPLE_VALUES")
+    ).toEqual({ isValid: true });
+  });
+
+  it("uses non-18 precision when configured for the identifier", () => {
+    const max6 =
+      "57896044618658097711785492504343953926634992332820282019728792003956564.819967";
+    expect(validateCustomVoteInput(max6, "STABLESPREAD/USDC").isValid).toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Some voters on today's "Bitcoin Higher on April 21?" request entered the P4 value without the decimal point (the raw 77-digit integer instead of `-57896…19728.79200…19968`). The commit path then re-scaled it by 10^18 in `parseFixed`, pushed the BigNumber past int256, and `makeVoteHash` threw silently — nothing in the UI told the voter their commit had failed.

This PR adds client-side validation that catches the overflow before submit and tells the voter what to fix.

## What changed

- **New helper** `helpers/voting/validateCustomVoteInput.ts` runs the same `parseFixed(value, precision)` the commit path uses and checks the result lies in `[minInt256, maxInt256]`. When the value is out of range *and* has no `.`, the error specifically flags the missing decimal and states the precision rule.
- **Inline warning** below the custom `TextInput` in both `VoteListItem` and `VoteTableRow` whenever the current value fails validation.
- **Commit button is disabled** (with tooltip) whenever any selected vote fails validation, so overflowing values no longer silently fail at submit time.
- Unit tests cover empty/partial input, valid decimals, exact `minInt256` / `maxInt256` boundaries, overflow with and without a decimal, non-numeric input, `MULTIPLE_VALUES` bypass, and non-18 precision identifiers.

`MULTIPLE_VALUES` votes are unaffected — they take pre-encoded strings and are explicitly skipped.

## Test plan

- [x] `vitest run` — 52/52 passing (8 new tests)
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — clean
- [x] Manually type the P4 overflow value (no decimal) into the active Bitcoin vote row → expect inline red warning and disabled Commit button with tooltip
- [x] Replace with the correctly-decimated value → warning disappears, Commit button re-enables
- [x] Verify a regular YES/NO / preset-option vote is unaffected

I haven't visually dogfooded this live yet — worth a 30-second manual pass on a dev build before merging.