### PR TITLE
make default vote options based on identifier if no project matched

### DIFF
--- a/helpers/voting/getVoteMetaData.ts
+++ b/helpers/voting/getVoteMetaData.ts
@@ -178,10 +178,12 @@ export function getVoteMetaData(
     const umipOrUppNumber = identifierDetails.umipLink.number;
 
     const isYesNoQuery = decodedIdentifier === "YES_OR_NO_QUERY";
+    // Only apply identifier defaults for YES_OR_NO_QUERY. Scalar identifiers
+    // (e.g. ETH/BTC) must keep undefined so the numeric input renders correctly.
     const options = isYesNoQuery
       ? maybeMakePolymarketOptions(decodedAncillaryData) ??
         getDefaultOptionsForIdentifier(decodedIdentifier)
-      : getDefaultOptionsForIdentifier(decodedIdentifier);
+      : undefined;
 
     return {
       title,
@@ -428,8 +430,8 @@ function getDefaultOptionsForIdentifier(
     case "MULTIPLE_CHOICE_QUERY":
       return makeMultipleChoiceOptions(makeMultipleChoiceYesOrNoOptions());
     default:
-      // Approved and unknown identifiers: default to Yes/No/Custom
-      return yesOrNoOptions;
+      // Unknown or scalar identifiers: return undefined so numeric input renders
+      return undefined;
   }
 }
 

--- a/helpers/voting/getVoteMetaData.ts
+++ b/helpers/voting/getVoteMetaData.ts
@@ -122,8 +122,9 @@ export function getVoteMetaData(
       ancillaryDataDescription ?? "No description was found for this request.";
     const isYesNoQuery = decodedIdentifier === "YES_OR_NO_QUERY";
     const options = isYesNoQuery
-      ? maybeMakePolymarketOptions(decodedAncillaryData)
-      : undefined;
+      ? maybeMakePolymarketOptions(decodedAncillaryData) ??
+        getDefaultOptionsForIdentifier(decodedIdentifier)
+      : getDefaultOptionsForIdentifier(decodedIdentifier);
     const umipMetadata = isYesNoQuery
       ? getUmipMetadata(decodedIdentifier)
       : { umipOrUppLink: undefined, umipOrUppNumber: undefined };
@@ -176,8 +177,9 @@ export function getVoteMetaData(
 
     const isYesNoQuery = decodedIdentifier === "YES_OR_NO_QUERY";
     const options = isYesNoQuery
-      ? maybeMakePolymarketOptions(decodedAncillaryData)
-      : undefined;
+      ? maybeMakePolymarketOptions(decodedAncillaryData) ??
+        getDefaultOptionsForIdentifier(decodedIdentifier)
+      : getDefaultOptionsForIdentifier(decodedIdentifier);
 
     return {
       title,
@@ -206,7 +208,7 @@ export function getVoteMetaData(
       ancillaryDataDescription ?? "No description found for this request.",
     umipOrUppLink: undefined,
     umipOrUppNumber: undefined,
-    options: undefined,
+    options: getDefaultOptionsForIdentifier(decodedIdentifier),
     origin: "UMA",
     isGovernance: false,
     discordLink,
@@ -405,6 +407,59 @@ function makeAcrossV2Options() {
     { label: "Invalid", value: "0", secondaryLabel: "p1" },
     { label: "Valid", value: "1", secondaryLabel: "p2" },
   ];
+}
+
+/**
+ * Returns sensible default voting options based on the identifier type.
+ * Mirrors the oracle dapp's Identifier.makeDefaultProposeOptions() pattern:
+ * even when no project matches and no res_data is parseable from ancillary data,
+ * the voter should still see appropriate vote buttons instead of a raw text input.
+ */
+function getDefaultOptionsForIdentifier(
+  decodedIdentifier: string
+): DropdownItemT[] | undefined {
+  const earlyRequestOption = {
+    label: "Early request",
+    value: earlyRequestMagicNumber,
+    secondaryLabel: "p4",
+  };
+
+  switch (decodedIdentifier) {
+    case "YES_OR_NO_QUERY":
+      return [
+        { label: "Yes", value: "1", secondaryLabel: "1" },
+        { label: "No", value: "0", secondaryLabel: "0" },
+        { label: "Unknown", value: "0.5", secondaryLabel: "0.5" },
+        earlyRequestOption,
+        { label: "Custom", value: "custom" },
+      ];
+    case "ACROSS-V2":
+      return [
+        { label: "Yes", value: "1", secondaryLabel: "1" },
+        { label: "No", value: "0", secondaryLabel: "0" },
+        earlyRequestOption,
+      ];
+    case "MULTIPLE_CHOICE_QUERY":
+      return makeMultipleChoiceOptions(makeMultipleChoiceYesOrNoOptions());
+    case "NUMERICAL":
+      return [
+        {
+          label: "Unresolvable",
+          value: "0.5",
+          secondaryLabel: "Unresolvable",
+        },
+        earlyRequestOption,
+        { label: "Custom", value: "custom" },
+      ];
+    default:
+      // Approved and unknown identifiers: default to Yes/No/Custom
+      return [
+        { label: "Yes", value: "1", secondaryLabel: "1" },
+        { label: "No", value: "0", secondaryLabel: "0" },
+        earlyRequestOption,
+        { label: "Custom", value: "custom" },
+      ];
+  }
 }
 
 function maybeMakeUmipOrUppLink(

--- a/helpers/voting/getVoteMetaData.ts
+++ b/helpers/voting/getVoteMetaData.ts
@@ -121,10 +121,12 @@ export function getVoteMetaData(
     const description =
       ancillaryDataDescription ?? "No description was found for this request.";
     const isYesNoQuery = decodedIdentifier === "YES_OR_NO_QUERY";
+    // Only apply identifier defaults for YES_OR_NO_QUERY. Other identifiers
+    // like MULTIPLE_VALUES need undefined so the multi-value input UI renders.
     const options = isYesNoQuery
       ? maybeMakePolymarketOptions(decodedAncillaryData) ??
         getDefaultOptionsForIdentifier(decodedIdentifier)
-      : getDefaultOptionsForIdentifier(decodedIdentifier);
+      : undefined;
     const umipMetadata = isYesNoQuery
       ? getUmipMetadata(decodedIdentifier)
       : { umipOrUppLink: undefined, umipOrUppNumber: undefined };

--- a/helpers/voting/getVoteMetaData.ts
+++ b/helpers/voting/getVoteMetaData.ts
@@ -418,47 +418,16 @@ function makeAcrossV2Options() {
 function getDefaultOptionsForIdentifier(
   decodedIdentifier: string
 ): DropdownItemT[] | undefined {
-  const earlyRequestOption = {
-    label: "Early request",
-    value: earlyRequestMagicNumber,
-    secondaryLabel: "p4",
-  };
-
   switch (decodedIdentifier) {
     case "YES_OR_NO_QUERY":
-      return [
-        { label: "Yes", value: "1", secondaryLabel: "1" },
-        { label: "No", value: "0", secondaryLabel: "0" },
-        { label: "Unknown", value: "0.5", secondaryLabel: "0.5" },
-        earlyRequestOption,
-        { label: "Custom", value: "custom" },
-      ];
+      return yesOrNoOptions;
     case "ACROSS-V2":
-      return [
-        { label: "Yes", value: "1", secondaryLabel: "1" },
-        { label: "No", value: "0", secondaryLabel: "0" },
-        earlyRequestOption,
-      ];
+      return makeAcrossV2Options();
     case "MULTIPLE_CHOICE_QUERY":
       return makeMultipleChoiceOptions(makeMultipleChoiceYesOrNoOptions());
-    case "NUMERICAL":
-      return [
-        {
-          label: "Unresolvable",
-          value: "0.5",
-          secondaryLabel: "Unresolvable",
-        },
-        earlyRequestOption,
-        { label: "Custom", value: "custom" },
-      ];
     default:
       // Approved and unknown identifiers: default to Yes/No/Custom
-      return [
-        { label: "Yes", value: "1", secondaryLabel: "1" },
-        { label: "No", value: "0", secondaryLabel: "0" },
-        earlyRequestOption,
-        { label: "Custom", value: "custom" },
-      ];
+      return yesOrNoOptions;
   }
 }
 
@@ -681,3 +650,15 @@ function makeMultipleChoiceOptions(
     },
   ];
 }
+
+const yesOrNoOptions = [
+  { label: "Yes", value: "1", secondaryLabel: "1" },
+  { label: "No", value: "0", secondaryLabel: "0" },
+  { label: "Unknown", value: "0.5", secondaryLabel: "0.5" },
+  {
+    label: "Early request",
+    value: earlyRequestMagicNumber,
+    secondaryLabel: "p4",
+  },
+  { label: "Custom", value: "custom" },
+];

--- a/tests/helpers/voting/getVoteMetaData.test.ts
+++ b/tests/helpers/voting/getVoteMetaData.test.ts
@@ -26,7 +26,7 @@ vi.mock("helpers", async () => {
 import { getVoteMetaData } from "helpers/voting/getVoteMetaData";
 import { earlyRequestMagicNumber } from "constant/voting/earlyRequestMagicNumber";
 
-// Real ancillary data from a MetaMarket request that failed to match any project.
+// Real ancillary data from a MetaMarket request.
 // ooRequester 46500f8b... is MetaMarket (not registered in voter dapp).
 // No res_data: field, so maybeMakePolymarketOptions cannot parse options.
 const METAMARKET_YES_OR_NO_ANCIL_DATA = `title: Bitcoin Higher on April 21?, description: This market will resolve to "Hit" (Yes) if the final Binance 1 minute candle close price for BTC/USDT Apr 21 '26 12:00 in the ET timezone (noon) is higher than the "Close" price for the Apr 20 '26 12:00 ET candle.\n\nOtherwise this market will resolve to "Miss" (No).\n\nThe resolution source for this market is Binance, specifically the BTC/USDT "Close" prices currently available at https://www.binance.com/en/trade/BTC_USDT with "1m" and "Candles" selected on the top bar.\n\nNote, this market is based solely on the Binance BTC/USDT spot price, not on prices from other pairs or exchanges.,initializer:c7ad319cee0d92b607d07fa9847cbde08fff4528,ooRequester:46500f8bff8b8dee2da41e8960681c792270e10c,childRequester:880d041d67aab3b062995d11d4ad9c1018a3b02f,childChainId:8453`;
@@ -35,14 +35,17 @@ const METAMARKET_YES_OR_NO_ANCIL_DATA = `title: Bitcoin Higher on April 21?, des
 const BARE_YES_OR_NO_ANCIL_DATA =
   "title: Will it rain tomorrow?, description: Resolves Yes if it rains.";
 
-const BARE_NUMERICAL_ANCIL_DATA =
-  "title: What is the BTC price?, description: Report the BTC/USD price at settlement time.";
-
-const earlyRequestOption = {
-  label: "Early request",
-  value: earlyRequestMagicNumber,
-  secondaryLabel: "p4",
-};
+const expectedYesOrNoOptions = [
+  { label: "Yes", value: "1", secondaryLabel: "1" },
+  { label: "No", value: "0", secondaryLabel: "0" },
+  { label: "Unknown", value: "0.5", secondaryLabel: "0.5" },
+  {
+    label: "Early request",
+    value: earlyRequestMagicNumber,
+    secondaryLabel: "p4",
+  },
+  { label: "Custom", value: "custom" },
+];
 
 function optionLabels(
   options: { label: string }[] | undefined
@@ -52,7 +55,7 @@ function optionLabels(
 
 describe("getVoteMetaData identifier fallback options", () => {
   describe("YES_OR_NO_QUERY with no project match", () => {
-    it("returns default Yes/No/Unknown/Early/Custom options for MetaMarket request", () => {
+    it("returns default Yes/No/Unknown/Early/Custom options for unrecognized requester", () => {
       const result = getVoteMetaData(
         "YES_OR_NO_QUERY",
         METAMARKET_YES_OR_NO_ANCIL_DATA,
@@ -76,13 +79,7 @@ describe("getVoteMetaData identifier fallback options", () => {
         undefined
       );
 
-      expect(result.options).toEqual([
-        { label: "Yes", value: "1", secondaryLabel: "1" },
-        { label: "No", value: "0", secondaryLabel: "0" },
-        { label: "Unknown", value: "0.5", secondaryLabel: "0.5" },
-        earlyRequestOption,
-        { label: "Custom", value: "custom" },
-      ]);
+      expect(result.options).toEqual(expectedYesOrNoOptions);
     });
 
     it("extracts title from ancillary data", () => {
@@ -102,50 +99,20 @@ describe("getVoteMetaData identifier fallback options", () => {
         undefined
       );
 
-      expect(result.options).toBeDefined();
-      expect(optionLabels(result.options)).toEqual([
-        "Yes",
-        "No",
-        "Unknown",
-        "Early request",
-        "Custom",
-      ]);
+      expect(result.options).toEqual(expectedYesOrNoOptions);
       expect(result.title).toBe("Will it rain tomorrow?");
     });
   });
 
-  describe("NUMERICAL with no project match", () => {
-    it("returns Unresolvable/Early/Custom options", () => {
-      const result = getVoteMetaData(
-        "NUMERICAL",
-        BARE_NUMERICAL_ANCIL_DATA,
-        undefined
-      );
-
-      expect(result.options).toBeDefined();
-      expect(optionLabels(result.options)).toEqual([
-        "Unresolvable",
-        "Early request",
-        "Custom",
-      ]);
-    });
-  });
-
   describe("completely unknown identifier", () => {
-    it("returns default Yes/No/Early/Custom options", () => {
+    it("returns default Yes/No/Unknown/Early/Custom options", () => {
       const result = getVoteMetaData(
         "SOME_UNKNOWN_IDENTIFIER",
         "title: Unknown request, description: Something unknown.",
         undefined
       );
 
-      expect(result.options).toBeDefined();
-      expect(optionLabels(result.options)).toEqual([
-        "Yes",
-        "No",
-        "Early request",
-        "Custom",
-      ]);
+      expect(result.options).toEqual(expectedYesOrNoOptions);
     });
 
     it("uses identifier name as title when no title: token in ancillary data", () => {

--- a/tests/helpers/voting/getVoteMetaData.test.ts
+++ b/tests/helpers/voting/getVoteMetaData.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("helpers/config", () => ({
+  config: {},
+  appConfig: {},
+  env: {},
+}));
+
+// getVoteMetaData imports from the "helpers" barrel which triggers WalletConnect init.
+// Mock it, forwarding only the functions getVoteMetaData actually uses.
+vi.mock("helpers", async () => {
+  const polymarket = await import("helpers/voting/projects/polymarket");
+  const predictFun = await import("helpers/voting/projects/predictFun");
+  const probable = await import("helpers/voting/projects/probable");
+  const misc = await import("helpers/util/misc");
+  return {
+    checkIfIsPolymarket: polymarket.checkIfIsPolymarket,
+    checkIfIsPredictFun: predictFun.checkIfIsPredictFun,
+    checkIfIsProbable: probable.checkIfIsProbable,
+    encodeMultipleQuery: polymarket.encodeMultipleQuery,
+    maybeMakePolymarketOptions: polymarket.maybeMakePolymarketOptions,
+    makeBlockExplorerLink: misc.makeBlockExplorerLink,
+  };
+});
+
+import { getVoteMetaData } from "helpers/voting/getVoteMetaData";
+import { earlyRequestMagicNumber } from "constant/voting/earlyRequestMagicNumber";
+
+// Real ancillary data from a MetaMarket request that failed to match any project.
+// ooRequester 46500f8b... is MetaMarket (not registered in voter dapp).
+// No res_data: field, so maybeMakePolymarketOptions cannot parse options.
+const METAMARKET_YES_OR_NO_ANCIL_DATA = `title: Bitcoin Higher on April 21?, description: This market will resolve to "Hit" (Yes) if the final Binance 1 minute candle close price for BTC/USDT Apr 21 '26 12:00 in the ET timezone (noon) is higher than the "Close" price for the Apr 20 '26 12:00 ET candle.\n\nOtherwise this market will resolve to "Miss" (No).\n\nThe resolution source for this market is Binance, specifically the BTC/USDT "Close" prices currently available at https://www.binance.com/en/trade/BTC_USDT with "1m" and "Candles" selected on the top bar.\n\nNote, this market is based solely on the Binance BTC/USDT spot price, not on prices from other pairs or exchanges.,initializer:c7ad319cee0d92b607d07fa9847cbde08fff4528,ooRequester:46500f8bff8b8dee2da41e8960681c792270e10c,childRequester:880d041d67aab3b062995d11d4ad9c1018a3b02f,childChainId:8453`;
+
+// Ancillary data with no project indicators at all
+const BARE_YES_OR_NO_ANCIL_DATA =
+  "title: Will it rain tomorrow?, description: Resolves Yes if it rains.";
+
+const BARE_NUMERICAL_ANCIL_DATA =
+  "title: What is the BTC price?, description: Report the BTC/USD price at settlement time.";
+
+const earlyRequestOption = {
+  label: "Early request",
+  value: earlyRequestMagicNumber,
+  secondaryLabel: "p4",
+};
+
+function optionLabels(
+  options: { label: string }[] | undefined
+): string[] | undefined {
+  return options?.map((o) => o.label);
+}
+
+describe("getVoteMetaData identifier fallback options", () => {
+  describe("YES_OR_NO_QUERY with no project match", () => {
+    it("returns default Yes/No/Unknown/Early/Custom options for MetaMarket request", () => {
+      const result = getVoteMetaData(
+        "YES_OR_NO_QUERY",
+        METAMARKET_YES_OR_NO_ANCIL_DATA,
+        undefined
+      );
+
+      expect(result.options).toBeDefined();
+      expect(optionLabels(result.options)).toEqual([
+        "Yes",
+        "No",
+        "Unknown",
+        "Early request",
+        "Custom",
+      ]);
+    });
+
+    it("includes correct values for each option", () => {
+      const result = getVoteMetaData(
+        "YES_OR_NO_QUERY",
+        METAMARKET_YES_OR_NO_ANCIL_DATA,
+        undefined
+      );
+
+      expect(result.options).toEqual([
+        { label: "Yes", value: "1", secondaryLabel: "1" },
+        { label: "No", value: "0", secondaryLabel: "0" },
+        { label: "Unknown", value: "0.5", secondaryLabel: "0.5" },
+        earlyRequestOption,
+        { label: "Custom", value: "custom" },
+      ]);
+    });
+
+    it("extracts title from ancillary data", () => {
+      const result = getVoteMetaData(
+        "YES_OR_NO_QUERY",
+        METAMARKET_YES_OR_NO_ANCIL_DATA,
+        undefined
+      );
+
+      expect(result.title).toBe("Bitcoin Higher on April 21?");
+    });
+
+    it("returns default options for bare YES_OR_NO_QUERY with no project indicators", () => {
+      const result = getVoteMetaData(
+        "YES_OR_NO_QUERY",
+        BARE_YES_OR_NO_ANCIL_DATA,
+        undefined
+      );
+
+      expect(result.options).toBeDefined();
+      expect(optionLabels(result.options)).toEqual([
+        "Yes",
+        "No",
+        "Unknown",
+        "Early request",
+        "Custom",
+      ]);
+      expect(result.title).toBe("Will it rain tomorrow?");
+    });
+  });
+
+  describe("NUMERICAL with no project match", () => {
+    it("returns Unresolvable/Early/Custom options", () => {
+      const result = getVoteMetaData(
+        "NUMERICAL",
+        BARE_NUMERICAL_ANCIL_DATA,
+        undefined
+      );
+
+      expect(result.options).toBeDefined();
+      expect(optionLabels(result.options)).toEqual([
+        "Unresolvable",
+        "Early request",
+        "Custom",
+      ]);
+    });
+  });
+
+  describe("completely unknown identifier", () => {
+    it("returns default Yes/No/Early/Custom options", () => {
+      const result = getVoteMetaData(
+        "SOME_UNKNOWN_IDENTIFIER",
+        "title: Unknown request, description: Something unknown.",
+        undefined
+      );
+
+      expect(result.options).toBeDefined();
+      expect(optionLabels(result.options)).toEqual([
+        "Yes",
+        "No",
+        "Early request",
+        "Custom",
+      ]);
+    });
+
+    it("uses identifier name as title when no title: token in ancillary data", () => {
+      const result = getVoteMetaData(
+        "SOME_UNKNOWN_IDENTIFIER",
+        "no structured data here",
+        undefined
+      );
+
+      expect(result.title).toBe("SOME_UNKNOWN_IDENTIFIER");
+      expect(result.options).toBeDefined();
+    });
+  });
+});

--- a/tests/helpers/voting/getVoteMetaData.test.ts
+++ b/tests/helpers/voting/getVoteMetaData.test.ts
@@ -104,15 +104,15 @@ describe("getVoteMetaData identifier fallback options", () => {
     });
   });
 
-  describe("completely unknown identifier", () => {
-    it("returns default Yes/No/Unknown/Early/Custom options", () => {
+  describe("unknown or scalar identifier", () => {
+    it("returns undefined options so numeric input renders", () => {
       const result = getVoteMetaData(
         "SOME_UNKNOWN_IDENTIFIER",
         "title: Unknown request, description: Something unknown.",
         undefined
       );
 
-      expect(result.options).toEqual(expectedYesOrNoOptions);
+      expect(result.options).toBeUndefined();
     });
 
     it("uses identifier name as title when no title: token in ancillary data", () => {
@@ -123,7 +123,7 @@ describe("getVoteMetaData identifier fallback options", () => {
       );
 
       expect(result.title).toBe("SOME_UNKNOWN_IDENTIFIER");
-      expect(result.options).toBeDefined();
+      expect(result.options).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
closes FE-563
## Summary
  - When a request doesn't match any known project, the voter dapp now falls back to default voting options based on the identifier type instead of showing a raw text input.

  ## Context

  A recent MetaMarket request (`ooRequester:46500f8b...`, `YES_OR_NO_QUERY`, no `res_data:`) failed every `checkIfIs*` project check and `maybeMakePolymarketOptions` returned
  `undefined`, leaving voters with only a custom text input — an anti-pattern we want to avoid entirely.

  ## Changes

  **`helpers/voting/getVoteMetaData.ts`**

  Added `getDefaultOptionsForIdentifier()` that returns sensible vote buttons per identifier type:
