### PR TITLE
feat: serve UMIP metadata from cached API route

### DIFF
--- a/helpers/config.ts
+++ b/helpers/config.ts
@@ -16,8 +16,6 @@ const Env = ss.object({
   NEXT_PUBLIC_WALLET_CONNECT: ss.string(),
   NEXT_PUBLIC_GRAPH_STUDIO_API_KEY: ss.string(),
   // optional envs
-  NEXT_PUBLIC_CONTENTFUL_SPACE_ID: ss.optional(ss.string()),
-  NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN: ss.optional(ss.string()),
   NEXT_PUBLIC_THE_GRAPH_API_KEY: ss.optional(ss.string()),
   NEXT_PUBLIC_GRAPH_ENDPOINT: ss.optional(ss.string()),
   NEXT_PUBLIC_DEPLOY_BLOCK: ss.optional(ss.string()),
@@ -62,10 +60,6 @@ export const env = ss.create(
     NEXT_PUBLIC_ONBOARD_API_KEY: process.env.NEXT_PUBLIC_ONBOARD_API_KEY,
     NEXT_PUBLIC_CURRENT_ENV: process.env.NEXT_PUBLIC_CURRENT_ENV,
     NEXT_PUBLIC_WALLET_CONNECT: process.env.NEXT_PUBLIC_WALLET_CONNECT,
-    NEXT_PUBLIC_CONTENTFUL_SPACE_ID:
-      process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
-    NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN:
-      process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN,
     NEXT_PUBLIC_CHAIN_ID: process.env.NEXT_PUBLIC_CHAIN_ID,
     NEXT_PUBLIC_OVERRIDE_APR: process.env.NEXT_PUBLIC_OVERRIDE_APR,
     NEXT_PUBLIC_DESIGNATED_VOTING_FACTORY_V1_ADDRESS:
@@ -109,10 +103,7 @@ const AppConfig = ss.object({
   graphStudioApiKey: ss.string(),
   graphEndpointV1: ss.optional(ss.string()),
   graphEndpoint: ss.optional(ss.string()),
-  contentfulSpace: ss.optional(ss.string()),
-  contentfulAccessToken: ss.optional(ss.string()),
   graphV2Enabled: ss.defaulted(ss.boolean(), false),
-  contentfulEnabled: ss.defaulted(ss.boolean(), false),
   overrideApr: ss.optional(ss.string()),
   designatedVotingFactoryV1Address: ss.string(),
   phaseLength: ss.number(),
@@ -142,8 +133,6 @@ export const appConfig = ss.create(
     votingContractAddress: env.NEXT_PUBLIC_VOTING_CONTRACT_ADDRESS,
     votingTokenContractAddress: env.NEXT_PUBLIC_VOTING_TOKEN_CONTRACT_ADDRESS,
     votingV1ContractAddress: env.NEXT_PUBLIC_VOTING_V1_CONTRACT_ADDRESS,
-    contentfulSpace: env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
-    contentfulAccessToken: env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN,
     graphEndpoint: env.NEXT_PUBLIC_GRAPH_ENDPOINT,
     signingMessage:
       env.NEXT_PUBLIC_SIGNING_MESSAGE ?? "Login to UMA Voter dApp",
@@ -154,9 +143,6 @@ export const appConfig = ss.create(
       Number(env.NEXT_PUBLIC_CHAIN_ID ?? "1") === 11155111 ? true : false,
     walletConnectProjectId: env.NEXT_PUBLIC_WALLET_CONNECT,
     graphV2Enabled: !!env.NEXT_PUBLIC_GRAPH_ENDPOINT,
-    contentfulEnabled:
-      !!env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN &&
-      !!env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
     overrideApr: env.NEXT_PUBLIC_OVERRIDE_APR,
     designatedVotingFactoryV1Address:
       env.NEXT_PUBLIC_DESIGNATED_VOTING_FACTORY_V1_ADDRESS ??

--- a/hooks/queries/votes/useContentfulData.ts
+++ b/hooks/queries/votes/useContentfulData.ts
@@ -1,7 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { contentfulDataKey, oneMinute } from "constant";
-import * as contentful from "contentful";
-import { config } from "helpers/config";
 import {
   useActiveVotes,
   useHandleError,
@@ -10,44 +8,25 @@ import {
 } from "hooks";
 import { ContentfulDataByKeyT, ContentfulDataT, UniqueKeyT } from "types";
 
-const { contentfulSpace, contentfulAccessToken } = config;
-
-const contentfulClient =
-  contentfulSpace && contentfulAccessToken
-    ? contentful.createClient({
-        space: contentfulSpace,
-        accessToken: contentfulAccessToken,
-      })
-    : undefined;
-
 async function getContentfulData(
   adminProposalNumbersByKey: Record<UniqueKeyT, number>
-) {
-  if (!contentfulClient) throw new Error("Contentful API not available");
+): Promise<ContentfulDataByKeyT> {
+  const numbers = Array.from(new Set(Object.values(adminProposalNumbersByKey)));
+  if (numbers.length === 0) return {};
 
-  const adminProposalNumbers = Object.values(adminProposalNumbersByKey);
-  if (adminProposalNumbers.length === 0) return {};
+  const url = `/api/umip-metadata?numbers=${numbers.join(",")}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`UMIP metadata request failed: ${response.status}`);
+  }
+  const byNumber = (await response.json()) as Record<string, ContentfulDataT>;
 
-  const numberFieldsString = adminProposalNumbers.join(",");
-
-  const entries = await contentfulClient.getEntries<ContentfulDataT>({
-    content_type: "umip",
-    "fields.number[in]": numberFieldsString,
-  });
-
-  const fields = entries.items.map(({ fields }) => fields);
-  const contentfulDataByKey: ContentfulDataByKeyT = {};
-
-  fields.forEach((field) => {
-    const voteKeyForNumber = Object.keys(adminProposalNumbersByKey).find(
-      (key) => adminProposalNumbersByKey[key] === field.number
-    );
-    if (voteKeyForNumber) {
-      contentfulDataByKey[voteKeyForNumber] = field;
-    }
-  });
-
-  return contentfulDataByKey;
+  const byKey: ContentfulDataByKeyT = {};
+  for (const [uniqueKey, number] of Object.entries(adminProposalNumbersByKey)) {
+    const entry = byNumber[number];
+    if (entry) byKey[uniqueKey] = entry;
+  }
+  return byKey;
 }
 
 export function useContentfulData() {
@@ -79,7 +58,6 @@ export function useContentfulData() {
     ],
     queryFn: () => getContentfulData(adminProposalNumbersByKey),
     refetchInterval: oneMinute,
-    enabled: !!contentfulClient,
     onError,
   });
 

--- a/pages/api/umip-metadata.ts
+++ b/pages/api/umip-metadata.ts
@@ -1,0 +1,166 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { Redis } from "@upstash/redis";
+import * as contentful from "contentful";
+import { ContentfulDataT } from "types";
+import { createCacheKey } from "lib/cache-keys";
+import { handleApiError, HttpError } from "./_utils/errors";
+
+// Per-UMIP entries are effectively immutable once the proposal lands. A long
+// server-side TTL means at most one Contentful call per UMIP per hour, no
+// matter how many tabs are open across all clients. Misses get a shorter TTL
+// so we don't keep hammering Contentful for numbers that don't exist there.
+const HIT_TTL_SECONDS = 60 * 60;
+const MISS_TTL_SECONDS = 5 * 60;
+
+// Cap to defend against pathological clients. Real callers send <= ~50.
+const MAX_NUMBERS_PER_REQUEST = 200;
+
+const SPACE_ID =
+  process.env.CONTENTFUL_SPACE_ID ??
+  process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID;
+const ACCESS_TOKEN =
+  process.env.CONTENTFUL_ACCESS_TOKEN ??
+  process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN;
+const DISABLE_REDIS = process.env.DISABLE_REDIS === "true";
+
+const contentfulClient =
+  SPACE_ID && ACCESS_TOKEN
+    ? contentful.createClient({ space: SPACE_ID, accessToken: ACCESS_TOKEN })
+    : undefined;
+
+let redis: Redis | undefined;
+function getRedis(): Redis | null {
+  if (DISABLE_REDIS) return null;
+  redis ??= Redis.fromEnv();
+  return redis;
+}
+
+function cacheKeyForNumber(n: number): string {
+  return createCacheKey(`umip:metadata:${n}`);
+}
+
+// Sentinel stored when Contentful had no entry for this UMIP number.
+const MISS_SENTINEL = "__miss__";
+type CachedEntry = ContentfulDataT | typeof MISS_SENTINEL;
+
+function parseNumbers(raw: string | string[] | undefined): number[] {
+  if (!raw) {
+    throw new HttpError({ statusCode: 400, msg: "Missing 'numbers' query param" });
+  }
+  const flat = Array.isArray(raw) ? raw.join(",") : raw;
+  const parsed = flat
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => Number(s));
+
+  if (parsed.length === 0) {
+    throw new HttpError({ statusCode: 400, msg: "'numbers' is empty" });
+  }
+  if (parsed.length > MAX_NUMBERS_PER_REQUEST) {
+    throw new HttpError({
+      statusCode: 400,
+      msg: `'numbers' exceeds max of ${MAX_NUMBERS_PER_REQUEST}`,
+    });
+  }
+  if (parsed.some((n) => !Number.isInteger(n) || n < 0)) {
+    throw new HttpError({
+      statusCode: 400,
+      msg: "'numbers' must be a comma-separated list of non-negative integers",
+    });
+  }
+  return Array.from(new Set(parsed));
+}
+
+async function fetchFromContentful(
+  numbers: number[]
+): Promise<Record<number, ContentfulDataT>> {
+  if (!contentfulClient || numbers.length === 0) return {};
+
+  const entries = await contentfulClient.getEntries<ContentfulDataT>({
+    content_type: "umip",
+    "fields.number[in]": numbers.join(","),
+  });
+
+  const byNumber: Record<number, ContentfulDataT> = {};
+  for (const item of entries.items) {
+    byNumber[item.fields.number] = item.fields;
+  }
+  return byNumber;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  try {
+    if (!contentfulClient) {
+      throw new HttpError({
+        statusCode: 503,
+        msg: "Contentful is not configured on this server",
+      });
+    }
+
+    const numbers = parseNumbers(req.query.numbers);
+    const result: Record<number, ContentfulDataT> = {};
+    const redisClient = getRedis();
+
+    // 1. Read cache for everything we know about
+    let toFetch = numbers;
+    if (redisClient) {
+      const keys = numbers.map(cacheKeyForNumber);
+      const cached = await redisClient.mget<(CachedEntry | null)[]>(...keys);
+      const missing: number[] = [];
+      cached.forEach((value, i) => {
+        const n = numbers[i];
+        if (value === null) {
+          missing.push(n);
+        } else if (value !== MISS_SENTINEL) {
+          result[n] = value;
+        }
+        // MISS_SENTINEL: leave out of result, do not refetch
+      });
+      toFetch = missing;
+    }
+
+    // 2. Fetch missing from Contentful (single batched query)
+    if (toFetch.length > 0) {
+      const fetched = await fetchFromContentful(toFetch);
+      for (const n of toFetch) {
+        const entry = fetched[n];
+        if (entry) result[n] = entry;
+      }
+
+      // 3. Write back to cache
+      if (redisClient) {
+        const pipeline = redisClient.pipeline();
+        for (const n of toFetch) {
+          const entry = fetched[n];
+          if (entry) {
+            pipeline.set(cacheKeyForNumber(n), entry, { ex: HIT_TTL_SECONDS });
+          } else {
+            pipeline.set(cacheKeyForNumber(n), MISS_SENTINEL, {
+              ex: MISS_TTL_SECONDS,
+            });
+          }
+        }
+        await pipeline.exec();
+      }
+    }
+
+    // CDN cache: edges absorb identical query strings within the window so
+    // the function itself doesn't even run for repeat hits.
+    res.setHeader(
+      "Cache-Control",
+      "public, s-maxage=3600, stale-while-revalidate=86400"
+    );
+    return res.status(200).json(result);
+  } catch (error) {
+    return handleApiError(error, res);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `/api/umip-metadata` as a single server-side proxy to Contentful with per-UMIP Redis caching (1h hit TTL, 5min miss sentinel) and Vercel edge cache headers (`s-maxage=3600, stale-while-revalidate=86400`).
- Rewrites the `useContentfulData` client hook to call this endpoint instead of contacting Contentful directly. Same return shape, so `VotesContext` and `getVoteMetaData` are untouched.
- Drops `contentfulSpace`, `contentfulAccessToken`, and `contentfulEnabled` from the client-side `AppConfig` and removes the matching `NEXT_PUBLIC_CONTENTFUL_*` entries from the env schema. The API route reads `CONTENTFUL_SPACE_ID` / `CONTENTFUL_ACCESS_TOKEN`, falling back to the legacy `NEXT_PUBLIC_*` names so deploys keep working before the Vercel env vars are renamed.

## Why
N tabs × M votes worth of UMIP metadata used to mean N×M Contentful calls per minute. With this PR, all clients share one cached endpoint, collapsing that to roughly one Contentful call per UMIP per hour regardless of client count.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 50 tests pass
- [x] `next build` compiles successfully (page-data collection fails locally only because `.env.local` is absent in this worktree)
- [ ] Deploy to preview, hit `/api/umip-metadata?numbers=170,107` and verify shape `{ "170": {...}, "107": {...} }`
- [ ] Open active votes page on preview, confirm UMIP titles/descriptions still render
- [ ] Verify cache headers via `curl -I /api/umip-metadata?numbers=1`
- [ ] After merge: rename Vercel envs `NEXT_PUBLIC_CONTENTFUL_*` → `CONTENTFUL_*` (server-only); follow-up PR can drop the fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)