### PR TITLE
Remap Polymarket bulletin owner

### DIFF
--- a/helpers/voting/projects/__tests__/polymarket.test.ts
+++ b/helpers/voting/projects/__tests__/polymarket.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deprecatedPolymarketBulletinOwnerCutoffTimestamp,
+  getBulletinOwnerQueries,
+  resolveBulletinOwner,
+} from "../polymarketBulletinOwners";
+
+const deprecatedInitializer = "0x91430cad2d3975766499717fa0d66a78d814e5c5";
+const currentBulletinOwner = "0xF43d55F3A8B7484Ed4B6931f93CB6F9eF5Dd369D";
+
+describe("resolveBulletinOwner", () => {
+  it("maps the deprecated Polymarket initializer to the current bulletin owner", () => {
+    expect(resolveBulletinOwner(deprecatedInitializer)).toBe(
+      currentBulletinOwner
+    );
+  });
+
+  it("matches deprecated initializer addresses case-insensitively", () => {
+    expect(resolveBulletinOwner(deprecatedInitializer.toUpperCase())).toBe(
+      currentBulletinOwner
+    );
+  });
+
+  it("returns unmapped initializer addresses unchanged", () => {
+    const initializer = "0x1111111111111111111111111111111111111111";
+
+    expect(resolveBulletinOwner(initializer)).toBe(initializer);
+  });
+});
+
+describe("getBulletinOwnerQueries", () => {
+  it("queries the current owner and the deprecated owner with a cutoff", () => {
+    expect(getBulletinOwnerQueries(deprecatedInitializer)).toEqual([
+      { owner: currentBulletinOwner },
+      {
+        owner: deprecatedInitializer,
+        maxTimestamp: deprecatedPolymarketBulletinOwnerCutoffTimestamp,
+      },
+    ]);
+  });
+
+  it("returns one unchanged owner query for unmapped initializers", () => {
+    const initializer = "0x1111111111111111111111111111111111111111";
+
+    expect(getBulletinOwnerQueries(initializer)).toEqual([
+      { owner: initializer },
+    ]);
+  });
+});

--- a/helpers/voting/projects/index.ts
+++ b/helpers/voting/projects/index.ts
@@ -1,3 +1,4 @@
 export * from "./polymarket";
+export * from "./polymarketBulletinOwners";
 export * from "./predictFun";
 export * from "./probable";

--- a/helpers/voting/projects/polymarketBulletinOwners.ts
+++ b/helpers/voting/projects/polymarketBulletinOwners.ts
@@ -1,7 +1,7 @@
 // Maps deprecated initializer EOAs to the current bulletin-board owner that
 // posts clarifications on their behalf. The questionId remains unchanged.
 // May 20, 2026 at 1:00 PM PT.
-export const deprecatedPolymarketBulletinOwnerCutoffTimestamp = 1779307200;
+export const deprecatedPolymarketBulletinOwnerCutoffTimestamp = 1779436800;
 
 type BulletinOwnerRemap = {
   owner: string;

--- a/helpers/voting/projects/polymarketBulletinOwners.ts
+++ b/helpers/voting/projects/polymarketBulletinOwners.ts
@@ -1,6 +1,6 @@
 // Maps deprecated initializer EOAs to the current bulletin-board owner that
 // posts clarifications on their behalf. The questionId remains unchanged.
-// May 20, 2026 at 1:00 PM PT.
+// May 22, 2026 at 1:00 AM PT.
 export const deprecatedPolymarketBulletinOwnerCutoffTimestamp = 1779436800;
 
 type BulletinOwnerRemap = {

--- a/helpers/voting/projects/polymarketBulletinOwners.ts
+++ b/helpers/voting/projects/polymarketBulletinOwners.ts
@@ -1,0 +1,47 @@
+// Maps deprecated initializer EOAs to the current bulletin-board owner that
+// posts clarifications on their behalf. The questionId remains unchanged.
+// May 20, 2026 at 1:00 PM PT.
+export const deprecatedPolymarketBulletinOwnerCutoffTimestamp = 1779307200;
+
+type BulletinOwnerRemap = {
+  owner: string;
+  deprecatedOwnerUpdatesUntil?: number;
+};
+
+export type BulletinOwnerQuery = {
+  owner: string;
+  maxTimestamp?: number;
+};
+
+const bulletinOwnerRemaps: Record<string, BulletinOwnerRemap> = {
+  "0x91430cad2d3975766499717fa0d66a78d814e5c5": {
+    owner: "0xF43d55F3A8B7484Ed4B6931f93CB6F9eF5Dd369D",
+    deprecatedOwnerUpdatesUntil:
+      deprecatedPolymarketBulletinOwnerCutoffTimestamp,
+  },
+};
+
+export function resolveBulletinOwner(initializer: string): string {
+  return bulletinOwnerRemaps[initializer.toLowerCase()]?.owner ?? initializer;
+}
+
+export function getBulletinOwnerQueries(
+  initializer: string
+): BulletinOwnerQuery[] {
+  const ownerRemap = bulletinOwnerRemaps[initializer.toLowerCase()];
+
+  if (!ownerRemap) {
+    return [{ owner: initializer }];
+  }
+
+  const ownerQueries: BulletinOwnerQuery[] = [{ owner: ownerRemap.owner }];
+
+  if (ownerRemap.deprecatedOwnerUpdatesUntil !== undefined) {
+    ownerQueries.push({
+      owner: initializer,
+      maxTimestamp: ownerRemap.deprecatedOwnerUpdatesUntil,
+    });
+  }
+
+  return ownerQueries;
+}

--- a/web3/queries/getPolymarketBulletins.ts
+++ b/web3/queries/getPolymarketBulletins.ts
@@ -1,4 +1,7 @@
-import { createPolymarketBulletinContract } from "../contracts/createPolymarketBulletin";
+import {
+  createPolymarketBulletinContract,
+  type RawBulletin,
+} from "../contracts/createPolymarketBulletin";
 import { ethers, utils } from "ethers";
 import assert from "assert";
 import {
@@ -8,6 +11,10 @@ import {
   getRequester,
   sanitizeAncillaryData,
 } from "helpers";
+import {
+  type BulletinOwnerQuery,
+  getBulletinOwnerQueries,
+} from "helpers/voting/projects/polymarketBulletinOwners";
 
 export function getPolymarketBulletinContractFromAncillaryData(
   queryText: string
@@ -34,6 +41,22 @@ export type Bulletin = {
   update: string;
 };
 
+function formatBulletinUpdates(
+  updates: RawBulletin[],
+  ownerQuery: BulletinOwnerQuery
+): Bulletin[] {
+  return updates
+    .map((update) => ({
+      timestamp: update.timestamp.toNumber(),
+      update: utils.toUtf8String(update.update),
+    }))
+    .filter(
+      (bulletin) =>
+        ownerQuery.maxTimestamp === undefined ||
+        bulletin.timestamp <= ownerQuery.maxTimestamp
+    );
+}
+
 export async function getPolymarketBulletins(
   ancillaryHex: string
 ): Promise<Bulletin[]> {
@@ -51,12 +74,17 @@ export async function getPolymarketBulletins(
   const ownerAddress = getInitializer(ancillaryData);
 
   assert(ownerAddress, "Bulletin owner address not found.");
+  const ownerQueries = getBulletinOwnerQueries(ownerAddress);
   // ancillary data has stuff appended to it, which needs to be removed before calculating question id.
   const cleanHex = cleanAncillaryData(ancillaryHex);
   const questionId = utils.keccak256(cleanHex);
-  const updates = await contract.getUpdates(questionId, ownerAddress);
-  return updates.map((update) => ({
-    timestamp: update.timestamp.toNumber(),
-    update: utils.toUtf8String(update.update),
-  }));
+  const updates = await Promise.all(
+    ownerQueries.map(async (ownerQuery) =>
+      formatBulletinUpdates(
+        await contract.getUpdates(questionId, ownerQuery.owner),
+        ownerQuery
+      )
+    )
+  );
+  return updates.flat().sort((a, b) => a.timestamp - b.timestamp);
 }


### PR DESCRIPTION
## Summary
Re-lands #455 onto master (was accidentally merged into `feat/update-predict-fun-tagging`).

- add a hardcoded remap from deprecated Polymarket initializer 0x91430cad2d3975766499717fa0d66a78d814e5c5 to current bulletin owner 0xF43d55F3A8B7484Ed4B6931f93CB6F9eF5Dd369D
- for remapped requests, read bulletins from both the current owner and the deprecated initializer owner
- include deprecated-initializer bulletins only through May 22, 2026 at 1:00 AM PT (Unix timestamp 1779436800), while keeping current-owner bulletins unbounded
- merge and sort bulletin updates chronologically before rendering
- cover mapped, unmapped, case-insensitive, and dual-owner query behavior

## Tests
- yarn test
- yarn tsc --noEmit --pretty false
- yarn lint