### PR TITLE
fix: resolve Across V2 discord threads by display title, not "N/A"

### DIFF
--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -2,12 +2,7 @@ import removeMarkdown from "remove-markdown";
 import { useCallback, useRef, useState } from "react";
 
 import { Tabs } from "components";
-import {
-  config,
-  decodeHexString,
-  getClaimTitle,
-  getDiscordThreadTitle,
-} from "helpers";
+import { config, decodeHexString, getClaimTitle } from "helpers";
 import { getOptimisticGovernorTitle } from "helpers/voting/optimisticGovernor";
 import {
   usePanelContext,
@@ -37,7 +32,6 @@ interface Props {
 }
 export function VotePanel({ content }: Props) {
   const {
-    identifier,
     time,
     title,
     decodedIdentifier,
@@ -116,17 +110,14 @@ export function VotePanel({ content }: Props) {
     : "";
 
   const voteOrigin = isOptimisticGovernorVote ? "OSnap" : origin;
-  // The discord-lookup title (ancillary-data title or "N/A") is what threads
-  // and summaries are cached under — must match what the warm-* crons write.
-  const discordLookupTitle = getDiscordThreadTitle(decodedAncillaryData);
   const {
     data: discussion,
     isFetching: discussionLoading,
     isError: discussionError,
   } = useVoteDiscussion({
-    identifier,
+    identifier: decodedIdentifier,
     time,
-    title: discordLookupTitle,
+    title,
   });
   const { data: claim } = useAssertionClaim(assertionChildChainId, assertionId);
   const { data: augmentedVoteData } = useAugmentedVoteData({
@@ -159,10 +150,7 @@ export function VotePanel({ content }: Props) {
             {
               title: "Discord Summary",
               content: (
-                <DiscussionSummary
-                  query={{ ...content, title: discordLookupTitle }}
-                  bulletins={bulletins.data}
-                />
+                <DiscussionSummary query={content} bulletins={bulletins.data} />
               ),
             },
           ]

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -14,7 +14,7 @@ export {
   getVoteMetaData,
   getDescriptionFromAncillaryData,
   getTitleFromAncillaryData,
-  getDiscordThreadTitle,
+  resolveDiscordThreadTitle,
   MISSING_DISCORD_TITLE_FALLBACK,
 } from "./voting/getVoteMetaData";
 export { makePriceRequestsByKey } from "./voting/makePriceRequestsByKey";

--- a/helpers/voting/getVoteMetaData.ts
+++ b/helpers/voting/getVoteMetaData.ts
@@ -379,14 +379,17 @@ export function getTitleFromAncillaryData(
   return title.endsWith(",") ? title.slice(0, -1) : title;
 }
 
-// The dispute bot names Discord threads "<title> - <timestamp>" using the
-// ancillary-data title, or "N/A" when no title is present. We replicate that
-// here so thread lookup works for titleless requests.
 export const MISSING_DISCORD_TITLE_FALLBACK = "N/A";
 
-export function getDiscordThreadTitle(decodedAncillaryData: string): string {
-  const title = getTitleFromAncillaryData(decodedAncillaryData);
-  return title && title.trim() !== "" ? title : MISSING_DISCORD_TITLE_FALLBACK;
+// getVoteMetaData's title falls back to the bare identifier when a request has
+// no real title; the dispute bot names those threads "N/A".
+export function resolveDiscordThreadTitle(
+  title: string | undefined,
+  decodedIdentifier: string
+): string {
+  return title && title !== decodedIdentifier
+    ? title
+    : MISSING_DISCORD_TITLE_FALLBACK;
 }
 
 export function getDescriptionFromAncillaryData(

--- a/pages/api/cron/warm-discord-threads.ts
+++ b/pages/api/cron/warm-discord-threads.ts
@@ -3,8 +3,8 @@ import { VoteDiscussionT, PriceRequestT } from "types";
 import { createVotingContractInstance } from "web3/contracts/createVotingContractInstance";
 import { getActiveVotes, getUpcomingVotes } from "web3";
 import {
-  getDiscordThreadTitle,
   getVoteMetaData,
+  resolveDiscordThreadTitle,
 } from "helpers/voting/getVoteMetaData";
 import { computeRoundId } from "helpers/voting/voteTiming";
 import { makeKey } from "lib/discord-utils";
@@ -26,7 +26,6 @@ interface VoteInfo {
   requestKey: string;
   identifier: string;
   time: number;
-  title: string;
 }
 
 interface ThreadMapRefreshResult {
@@ -56,17 +55,19 @@ async function fetchAllVotes(): Promise<PriceRequestT[]> {
 
 function buildVoteInfos(votes: PriceRequestT[]): VoteInfo[] {
   return votes.map((vote) => {
-    const metadata = getVoteMetaData(
+    const { title } = getVoteMetaData(
       vote.decodedIdentifier,
       vote.decodedAncillaryData,
       undefined
     );
-    const discordTitle = getDiscordThreadTitle(vote.decodedAncillaryData);
+    const discordTitle = resolveDiscordThreadTitle(
+      title,
+      vote.decodedIdentifier
+    );
     return {
       requestKey: makeKey(discordTitle, vote.time),
       identifier: vote.identifier,
       time: vote.time,
-      title: metadata.title,
     };
   });
 }

--- a/pages/api/cron/warm-summaries.ts
+++ b/pages/api/cron/warm-summaries.ts
@@ -1,7 +1,10 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { createVotingContractInstance } from "web3/contracts/createVotingContractInstance";
 import { getActiveVotes, getUpcomingVotes } from "web3";
-import { getDiscordThreadTitle } from "helpers/voting/getVoteMetaData";
+import {
+  getVoteMetaData,
+  resolveDiscordThreadTitle,
+} from "helpers/voting/getVoteMetaData";
 import { computeRoundId } from "helpers/voting/voteTiming";
 import { makeKey } from "lib/discord-utils";
 import { getCachedProcessedThread } from "../discord-thread/_utils";
@@ -76,12 +79,18 @@ export default async function handler(
       });
     }
 
-    // 2. Build vote info. `title` is forwarded to /api/update-summary, which
-    // forwards it again to /api/discord-thread and uses it as part of the
-    // summary cache key — so it must be the discord-lookup title (with "N/A"
-    // fallback), not the display title.
+    // `title` is forwarded to /api/update-summary and used in the summary cache
+    // key, so it must be the resolved lookup title matching what the frontend sends.
     const voteInfos: VoteInfo[] = allVotes.map((vote) => {
-      const discordTitle = getDiscordThreadTitle(vote.decodedAncillaryData);
+      const { title } = getVoteMetaData(
+        vote.decodedIdentifier,
+        vote.decodedAncillaryData,
+        undefined
+      );
+      const discordTitle = resolveDiscordThreadTitle(
+        title,
+        vote.decodedIdentifier
+      );
       const requestKey = makeKey(discordTitle, vote.time);
       return {
         requestKey,

--- a/pages/api/discord-thread/index.ts
+++ b/pages/api/discord-thread/index.ts
@@ -1,11 +1,10 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { VoteDiscussionT, L1Request } from "types";
 import * as ss from "superstruct";
-import { stripInvalidCharacters } from "lib/utils";
 import { getCachedProcessedThread } from "./_utils";
 import { makeKey } from "lib/discord-utils";
 import { validateQueryParams } from "../_utils/validation";
-import { MISSING_DISCORD_TITLE_FALLBACK } from "helpers/voting/getVoteMetaData";
+import { resolveDiscordThreadTitle } from "helpers/voting/getVoteMetaData";
 
 export const DiscordThreadRequestBody = L1Request;
 export type DiscordThreadRequestBody = ss.Infer<
@@ -22,15 +21,7 @@ export default async function handler(
       DiscordThreadRequestBody
     );
 
-    const titleSanitized = stripInvalidCharacters(title);
-
-    // Mirrors the dispute bot's thread naming: titleless requests live under "N/A".
-    const effectiveTitle =
-      titleSanitized.trim() === ""
-        ? MISSING_DISCORD_TITLE_FALLBACK
-        : titleSanitized;
-
-    // Build the request key
+    const effectiveTitle = resolveDiscordThreadTitle(title, identifier);
     const requestKey = makeKey(effectiveTitle, time);
 
     // Fetch from Redis cache (populated by cron job)

--- a/tests/helpers/voting/getVoteMetaData.test.ts
+++ b/tests/helpers/voting/getVoteMetaData.test.ts
@@ -24,7 +24,7 @@ vi.mock("helpers", async () => {
 });
 
 import {
-  getDiscordThreadTitle,
+  resolveDiscordThreadTitle,
   getVoteMetaData,
 } from "helpers/voting/getVoteMetaData";
 import { earlyRequestMagicNumber } from "constant/voting/earlyRequestMagicNumber";
@@ -107,18 +107,25 @@ describe("getVoteMetaData identifier fallback options", () => {
     });
   });
 
-  describe("getDiscordThreadTitle", () => {
-    it("returns the ancillary-data title when present", () => {
-      expect(getDiscordThreadTitle(BARE_YES_OR_NO_ANCIL_DATA)).toBe(
-        "Will it rain tomorrow?"
-      );
+  describe("resolveDiscordThreadTitle", () => {
+    it("returns the display title when it is a real title", () => {
+      expect(
+        resolveDiscordThreadTitle("Will it rain tomorrow?", "YES_OR_NO_QUERY")
+      ).toBe("Will it rain tomorrow?");
     });
 
-    it('returns "N/A" when no title: token is present', () => {
-      // Matches the dispute bot's thread naming for titleless requests.
-      const noTitle =
-        "q: Will the highest temperature in Wellington be 18°C or higher on May 19? description: ...";
-      expect(getDiscordThreadTitle(noTitle)).toBe("N/A");
+    it('returns "N/A" when the title is just the identifier (titleless)', () => {
+      expect(
+        resolveDiscordThreadTitle("YES_OR_NO_QUERY", "YES_OR_NO_QUERY")
+      ).toBe("N/A");
+    });
+
+    it("keeps the identifier-derived display title for ACROSS-V2", () => {
+      // getVoteMetaData maps ACROSS-V2 -> "Across V2", which differs from the
+      // identifier, so the bot names the thread "Across V2" rather than "N/A".
+      expect(resolveDiscordThreadTitle("Across V2", "ACROSS-V2")).toBe(
+        "Across V2"
+      );
     });
   });
 


### PR DESCRIPTION
## Problem

The `warm-discord-threads` cron logs lines like:

```
[warm-discord-threads] no thread found for: N/A-1780055831, N/A-1780058603
```

for `ACROSS-V2` requests. The thread title should be `"Across V2"`, not `"N/A"`. This is a regression.

## Root cause

[#453](https://github.com/UMAprotocol/voter-dapp-v2/pull/453) centralized discord thread-title lookup into a helper that read the title **only** from ancillary data, falling back to `"N/A"`. That fixed titleless Polymarket requests — but `ACROSS-V2` requests carry no `title:` token while the dispute bot names their threads `"Across V2"`, so Across threads started keying on `N/A-<time>` and never matched.

## Fix / approach

Move the `"N/A"` resolution out of the frontend and into the **serverless layer**. The frontend forwards its existing display title (from `getVoteMetaData`) plus the decoded identifier; the discord-thread endpoint and the `warm-*` crons resolve the lookup title via a shared `resolveDiscordThreadTitle` helper:

```ts
title && title !== decodedIdentifier ? title : "N/A"
```

`getVoteMetaData`'s display title falls back to the bare identifier for titleless requests (→ `"N/A"`), but yields `"Across V2"` for `ACROSS-V2` — which differs from the identifier, so it's treated as a real title and kept. Across therefore resolves correctly **without any special-casing**, and cron-write / endpoint-read stay in agreement from a single source of truth.

### Changes
- `resolveDiscordThreadTitle(title, decodedIdentifier)` replaces the frontend-resolving `getDiscordThreadTitle`.
- `discord-thread` endpoint resolves from the (decoded) `identifier` + display `title` query params; `VotePanel` now sends `decodedIdentifier` and its display title (no `"N/A"` logic in the frontend).
- `warm-discord-threads` / `warm-summaries` use the shared resolver; dropped a dead `VoteInfo.title` field in the threads cron.

> The Discord Summary tab only renders for Polymarket votes, which always carry a real title, so the summary cache key (`discord-summary:<time>:<identifier>:<title>`) is unaffected by the Across/titleless edge — write (`warm-summaries`) and read (`VotePanel`) use the identical display title.

## Testing

- `resolveDiscordThreadTitle` unit tests: real title passthrough, `title === identifier` → `"N/A"`, and `ACROSS-V2`'s `"Across V2"` kept.
- Full vitest suite (65 tests) passes; `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)