### PR TITLE
Update gas rebate banner: voting pool ineligibility from June 15

### DIFF
--- a/components/AnnouncementBanners/GasRebateBanner.tsx
+++ b/components/AnnouncementBanners/GasRebateBanner.tsx
@@ -6,16 +6,16 @@ import { AnnouncementBannerWrapper } from "./AnnouncementBannerWrapper";
 
 export function GasRebateBanner() {
   return (
-    <AnnouncementBannerWrapper localStorageKey="show-gas-rebate-banner-jan-2026">
+    <AnnouncementBannerWrapper localStorageKey="show-gas-rebate-banner-june-2026">
       <InfoIcon />
       <Text>
-        Voter gas rebates for priority gas fees will be capped as of January 14.
-        See updated gas rebate details{" "}
+        Starting June 15th, delegates that are part of a voting pool (UMA.rocks
+        or others) will no longer be eligible for monthly voting gas rebates.{" "}
         <Link
           href="https://docs.uma.xyz/using-uma/voting-walkthrough/voting-gas-rebates"
           target="_blank"
         >
-          here
+          Learn more
         </Link>
         .
       </Text>


### PR DESCRIPTION
## Summary
- Replace the existing gas-rebate announcement banner copy with the upcoming voting-pool eligibility change (effective June 15).
- Bump `localStorageKey` to `show-gas-rebate-banner-june-2026` so users who dismissed the previous banner see this one.

New copy:
> Starting June 15th, delegates that are part of a voting pool (UMA.rocks or others) will no longer be eligible for monthly voting gas rebates. [Learn more](https://docs.uma.xyz/using-uma/voting-walkthrough/voting-gas-rebates).

Context: announcement going out tomorrow ([doc](https://docs.google.com/document/d/1Ukvot0jBzdfTvJUafZrPmK95D7uHrXXoAJaoXI1Cz4E/edit?usp=sharing)). Per request in Slack, please merge **after** the announcement goes live.

## Test plan
- [ ] Banner renders at top of every page with the new copy.
- [ ] "Learn more" links to the voting-gas-rebates doc.
- [ ] Dismissing the banner persists across reloads (new localStorage key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)