### PR TITLE
Make commit/reveal CTA sticky on mobile (UMA-2997)

### DIFF
--- a/components/Votes/ActiveVotes.tsx
+++ b/components/Votes/ActiveVotes.tsx
@@ -345,7 +345,7 @@ export function ActiveVotes() {
             </InfoText>
           </Tooltip>
         ) : null}
-        <ButtonInnerWrapper>
+        <ButtonInnerWrapper $stickyOnMobile>
           {isDirty() ? (
             <>
               <Button

--- a/components/Votes/ActiveVotes.tsx
+++ b/components/Votes/ActiveVotes.tsx
@@ -24,6 +24,7 @@ import {
 import { useState } from "react";
 import { VoteT } from "types";
 import {
+  ActiveVotesWrapper,
   ButtonInnerWrapper,
   ButtonOuterWrapper,
   ButtonSpacer,
@@ -322,7 +323,7 @@ export function ActiveVotes() {
   }));
 
   return (
-    <>
+    <ActiveVotesWrapper>
       <Title> Active votes: </Title>
       <VoteTimeline />
       <VotesTableWrapper>
@@ -379,6 +380,6 @@ export function ActiveVotes() {
         </ButtonInnerWrapper>
       </ButtonOuterWrapper>
       <Divider />
-    </>
+    </ActiveVotesWrapper>
   );
 }

--- a/components/Votes/ActiveVotes.tsx
+++ b/components/Votes/ActiveVotes.tsx
@@ -334,7 +334,7 @@ export function ActiveVotes() {
           * Changes to committed votes need to be re-committed
         </RecommittingVotesMessage>
       ) : null}
-      <ButtonOuterWrapper>
+      <ButtonOuterWrapper $stickyOnMobile>
         {actionStatus.infoText ? (
           <Tooltip label={actionStatus.infoText.tooltip}>
             <InfoText>

--- a/components/Votes/style.tsx
+++ b/components/Votes/style.tsx
@@ -14,10 +14,13 @@ export const Title = styled.h1`
   margin-bottom: 20px;
 `;
 
-export const ButtonOuterWrapper = styled.div`
+export const ButtonOuterWrapper = styled.div<{ $stickyOnMobile?: boolean }>`
   margin-top: 30px;
 
   @media ${mobileAndUnder} {
+    ${({ $stickyOnMobile }) =>
+      $stickyOnMobile
+        ? `
     position: sticky;
     bottom: 0;
     z-index: 5;
@@ -26,6 +29,8 @@ export const ButtonOuterWrapper = styled.div`
     background: var(--white);
     border-top: 1px solid var(--black-opacity-25);
     box-shadow: var(--shadow-2);
+        `
+        : ""}
   }
 `;
 

--- a/components/Votes/style.tsx
+++ b/components/Votes/style.tsx
@@ -23,7 +23,7 @@ export const ButtonOuterWrapper = styled.div<{ $stickyOnMobile?: boolean }>`
         ? `
     position: sticky;
     bottom: 0;
-    z-index: 5;
+    z-index: 1;
     margin-top: 20px;
     padding: 12px var(--page-padding) calc(12px + env(safe-area-inset-bottom));
     background: var(--white);

--- a/components/Votes/style.tsx
+++ b/components/Votes/style.tsx
@@ -1,5 +1,8 @@
+import { mobileAndUnder } from "constant";
 import Warning from "public/assets/icons/warning.svg";
 import styled from "styled-components";
+
+export const ActiveVotesWrapper = styled.div``;
 
 export const VotesTableWrapper = styled.div`
   margin-top: var(--margin-top, 35px);
@@ -13,6 +16,17 @@ export const Title = styled.h1`
 
 export const ButtonOuterWrapper = styled.div`
   margin-top: 30px;
+
+  @media ${mobileAndUnder} {
+    position: sticky;
+    bottom: 0;
+    z-index: 5;
+    margin-top: 20px;
+    padding: 12px var(--page-padding) calc(12px + env(safe-area-inset-bottom));
+    background: var(--white);
+    border-top: 1px solid var(--black-opacity-25);
+    box-shadow: var(--shadow-2);
+  }
 `;
 
 export const ButtonInnerWrapper = styled.div`
@@ -22,6 +36,26 @@ export const ButtonInnerWrapper = styled.div`
 
   button {
     text-transform: capitalize;
+  }
+
+  @media ${mobileAndUnder} {
+    gap: 12px;
+
+    > * {
+      flex: 1;
+    }
+
+    button {
+      width: 100%;
+    }
+  }
+`;
+
+export const ButtonSpacer = styled.div`
+  width: 10px;
+
+  @media ${mobileAndUnder} {
+    display: none;
   }
 `;
 
@@ -43,10 +77,6 @@ export const WarningIcon = styled(Warning)`
 
 export const PaginationWrapper = styled.div`
   margin-block: 30px;
-`;
-
-export const ButtonSpacer = styled.div`
-  width: 10px;
 `;
 
 export const Divider = styled.div`

--- a/components/Votes/style.tsx
+++ b/components/Votes/style.tsx
@@ -34,7 +34,7 @@ export const ButtonOuterWrapper = styled.div<{ $stickyOnMobile?: boolean }>`
   }
 `;
 
-export const ButtonInnerWrapper = styled.div`
+export const ButtonInnerWrapper = styled.div<{ $stickyOnMobile?: boolean }>`
   display: flex;
   justify-content: end;
   gap: 15px;
@@ -44,6 +44,9 @@ export const ButtonInnerWrapper = styled.div`
   }
 
   @media ${mobileAndUnder} {
+    ${({ $stickyOnMobile }) =>
+      $stickyOnMobile
+        ? `
     gap: 12px;
 
     > * {
@@ -53,6 +56,8 @@ export const ButtonInnerWrapper = styled.div`
     button {
       width: 100%;
     }
+        `
+        : ""}
   }
 `;
 


### PR DESCRIPTION
## Summary
Closes [UMA-2997](https://linear.app/uma/issue/UMA-2997/voterdapp-frontend-feature-sticky-commitreveal-cta-with-vote-count).

On mobile (≤550px), the commit / reveal CTA now sticks to the bottom of the viewport while the user scrolls through active votes, so the action (and its `X/Y votes` count) is always reachable without scrolling past a long vote list.

- `components/Votes/style.tsx` — `position: sticky; bottom: 0` on `ButtonOuterWrapper` at `mobileAndUnder`, with a white background, top border, and shadow so it visually separates from the votes list. Buttons stretch full-width on mobile (CTA + Reset Changes share the row).
- `components/Votes/ActiveVotes.tsx` — wrap the section in `ActiveVotesWrapper` (a plain `div`) so the sticky bar's containing block is the active-votes section. The bar releases naturally once the user scrolls into upcoming / past votes.

Ticket bullets already satisfied by existing code (no changes needed):
- **Vote count on button** — `ActiveVotes.tsx` already renders `Commit ${selectedVotesCount}/${activeVoteList.length} votes`.
- **Remove pagination over 20 votes** — `ActiveVotes` does not use pagination at all (only `Upcoming` / `Past` do); the full active list is always rendered.
- **Clear / reset button** — the existing "Reset Changes" button appears when there are dirty inputs.

Desktop behavior is unchanged.

## Test plan
- [ ] On desktop, the CTA renders below the vote list in its existing position with no visual change.
- [ ] On mobile (≤550px), with many active votes, the commit/reveal CTA stays pinned to the bottom of the viewport while scrolling the vote list, and shows the live `X/Y votes` count.
- [ ] When the user has dirty inputs, the "Reset Changes" + primary CTA share the sticky bar full-width on mobile.
- [ ] When the user scrolls past the active votes into upcoming / past sections, the sticky bar releases (does not float over those sections).
- [ ] Safe-area inset is honored on notched mobile devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)