### PR TITLE
fix: make wallet and transaction error banners sticky

### DIFF
--- a/components/ErrorBanner/ErrorBanner.tsx
+++ b/components/ErrorBanner/ErrorBanner.tsx
@@ -12,15 +12,24 @@ import {
   Wrapper,
 } from "./styles";
 
-export function ErrorBanner({ errorOrigin }: { errorOrigin?: ErrorOriginT }) {
+export function ErrorBanner({
+  errorOrigin,
+  isSticky = false,
+}: {
+  errorOrigin?: ErrorOriginT;
+  isSticky?: boolean;
+}) {
   const { isWrongChain } = useWalletContext();
   const { errorMessages, removeErrorMessage } = useErrorContext(errorOrigin);
 
-  if (!errorMessages.length && !isWrongChain) return null;
+  const showWrongChain =
+    isWrongChain && (!errorOrigin || errorOrigin === "default");
+
+  if (!errorMessages.length && !showWrongChain) return null;
 
   return (
-    <Wrapper>
-      {isWrongChain ? (
+    <Wrapper $isSticky={isSticky}>
+      {showWrongChain ? (
         <Error message={wrongChainMessage} />
       ) : (
         <>

--- a/components/ErrorBanner/styles.tsx
+++ b/components/ErrorBanner/styles.tsx
@@ -3,7 +3,7 @@ import Close from "public/assets/icons/close.svg";
 import Warning from "public/assets/icons/warning.svg";
 import styled from "styled-components";
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ $isSticky?: boolean }>`
   background: var(--red-500);
   min-height: 60px;
   max-width: 100vw;
@@ -13,6 +13,14 @@ export const Wrapper = styled.div`
   align-items: center;
   justify-content: center;
   padding-block: 15px;
+  ${({ $isSticky }) =>
+    $isSticky
+      ? `
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  `
+      : ""}
 `;
 
 export const ErrorMessageWrapper = styled.div`

--- a/components/ErrorBanner/styles.tsx
+++ b/components/ErrorBanner/styles.tsx
@@ -16,8 +16,10 @@ export const Wrapper = styled.div<{ $isSticky?: boolean }>`
   ${({ $isSticky }) =>
     $isSticky
       ? `
-    position: sticky;
+    position: fixed;
     top: 0;
+    left: 0;
+    right: 0;
     z-index: 10;
   `
       : ""}

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -35,4 +35,5 @@ export function Layout({ children, title }: Props) {
 
 const Main = styled.main`
   height: 100%;
+  isolation: isolate;
 `;

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -22,9 +22,10 @@ export function Layout({ children, title }: Props) {
       <Meta title={title} />
       <Main>
         <GasRebateBanner />
-        <ErrorBanner />
+        <ErrorBanner errorOrigin="pageLoad" />
         <OldDesignatedVotingAccountWarningBanner />
         <Header />
+        <ErrorBanner isSticky />
         {children}
         <Footer />
       </Main>

--- a/contexts/ErrorContext.tsx
+++ b/contexts/ErrorContext.tsx
@@ -13,6 +13,7 @@ export interface ErrorContextState {
 export const defaultErrorContextState: ErrorContextState = {
   errorMessages: {
     default: [],
+    pageLoad: [],
     vote: [],
     stake: [],
     unstake: [],

--- a/hooks/helpers/useHandleError.ts
+++ b/hooks/helpers/useHandleError.ts
@@ -16,8 +16,11 @@ export function useHandleError(options?: Options) {
     isDataFetching = false,
     customErrorMessage,
   } = options || {};
+  const effectiveOrigin: ErrorOriginT | undefined = isDataFetching
+    ? "pageLoad"
+    : errorOrigin;
   const { addErrorMessage, clearErrorMessages, errorMessages } =
-    useErrorContext(errorOrigin);
+    useErrorContext(effectiveOrigin);
 
   function onError(error: unknown) {
     if (errorMessages.includes(wrongChainMessage)) return;

--- a/types/ui.ts
+++ b/types/ui.ts
@@ -39,6 +39,7 @@ export type PageStatesT = Record<PaginateForT, PageStateT>;
 
 export type ErrorOriginT =
   | "default"
+  | "pageLoad"
   | "vote"
   | "stake"
   | "unstake"


### PR DESCRIPTION
## Summary

- Wallet and transaction error banners (wrong-chain, commit/reveal mutation failures) now stay pinned to the top of the viewport while the user scrolls, so they remain visible when the user is on the Commit/Reveal button at the bottom of the page.
- Page-load errors (e.g. "Something went wrong while fetching vote data. Please refresh the page and try again.") are unchanged — they sit at the top of the document and scroll away with the page.

## How it works

- Added a new `pageLoad` value to `ErrorOriginT`. `useHandleError` now routes any error with `isDataFetching: true` to this new origin, separating data-fetching errors from the `default` origin (which still holds commit/reveal mutation errors).
- `ErrorBanner` gained an `isSticky` prop. The sticky variant uses `position: fixed; top: 0; left: 0; right: 0; z-index: 10` so it pins to the viewport regardless of scroll position or parent layout. (Initial commit used `position: sticky`, but `<Main>` is `height: 100%` so sticky only worked for the first viewport of scroll — see commit 5e91cf3.)
- To avoid duplicating the wrong-chain message in both banners when both are mounted, the wrong-chain message only renders in banners that read the `default` origin.
- `Layout` now renders a non-sticky `<ErrorBanner errorOrigin="pageLoad" />` above the header and a sticky `<ErrorBanner isSticky />` below the header.

Closes [ENG-248](https://linear.app/uma/issue/ENG-248/voter-dapp-error-banners-should-be-fixed).

## Test plan

- [ ] Trigger a commit/reveal error while scrolled to the bottom of the active votes page — the red banner is visible pinned at the top of the viewport.
- [ ] Trigger a wrong-chain wallet state — the banner appears once (pinned to top) and not twice.
- [ ] Force a vote-data fetch error (e.g. via offline mode) — the page-load banner appears at the top of the document and does NOT stick to the viewport while scrolling.
- [ ] Existing panel-scoped error banners (vote/stake/etc.) still behave the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)