### PR TITLE
fix: live-fetch discord threads on cache miss for past votes (ENG-249)

### DIFF
--- a/pages/api/cron/warm-discord-threads.ts
+++ b/pages/api/cron/warm-discord-threads.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { VoteDiscussionT, PriceRequestT } from "types";
+import { PriceRequestT } from "types";
 import { createVotingContractInstance } from "web3/contracts/createVotingContractInstance";
 import { getActiveVotes, getUpcomingVotes } from "web3";
 import {
@@ -12,11 +12,9 @@ import {
   buildThreadIdMap,
   getCachedThreadIdMap,
   setCachedThreadIdMap,
-  getDiscordMessagesPaginated,
-  setCachedProcessedThread,
+  fetchAndCacheProcessedThread,
   shouldDoFullRebuild,
 } from "../discord-thread/_utils";
-import { processRawMessages } from "../discord-thread/_message-processing";
 
 const log = (msg: string) => console.log(`[warm-discord-threads] ${msg}`);
 const logError = (msg: string, err?: unknown) =>
@@ -90,7 +88,13 @@ async function refreshThreadIdMap(): Promise<ThreadMapRefreshResult> {
     log("cache: empty, doing full rebuild");
   }
 
-  const existingMap = isFullRebuild ? {} : cached?.threadIdMap ?? {};
+  // Preserve previously cached entries across full rebuilds so that past votes
+  // whose threads are older than the rebuild lookback window remain resolvable
+  // by the discord-thread endpoint's cache-miss fallback. The full rebuild still
+  // refetches the lookback window from scratch to catch threads missed by
+  // incremental updates; we just merge those into the existing map instead of
+  // replacing it.
+  const existingMap = cached?.threadIdMap ?? {};
   const afterMessageId = isFullRebuild
     ? undefined
     : cached?.latestThreadId ?? undefined;
@@ -109,9 +113,9 @@ async function refreshThreadIdMap(): Promise<ThreadMapRefreshResult> {
   );
 
   log(
-    `cache updated: ${newThreadCount} ${
-      isFullRebuild ? "total" : "new"
-    } threads fetched, ${Object.keys(threadIdMap).length} total cached`
+    `cache updated: ${newThreadCount} threads fetched (${
+      isFullRebuild ? "lookback rebuild" : "incremental"
+    }), ${Object.keys(threadIdMap).length} total cached`
   );
 
   return { threadIdMap, isFullRebuild, cachedThreadCount, newThreadCount };
@@ -121,17 +125,13 @@ async function processVoteThread(
   voteInfo: VoteInfo,
   threadId: string
 ): Promise<number> {
-  const { messages } = await getDiscordMessagesPaginated(threadId);
-  const processedMessages = processRawMessages(messages);
-
-  const voteDiscussion: VoteDiscussionT = {
-    identifier: voteInfo.identifier,
-    time: voteInfo.time,
-    thread: processedMessages,
-  };
-
-  await setCachedProcessedThread(voteInfo.requestKey, voteDiscussion);
-  return processedMessages.length;
+  const voteDiscussion = await fetchAndCacheProcessedThread(
+    threadId,
+    voteInfo.identifier,
+    voteInfo.time,
+    voteInfo.requestKey
+  );
+  return voteDiscussion.thread.length;
 }
 
 async function processAllVotes(

--- a/pages/api/cron/warm-discord-threads.ts
+++ b/pages/api/cron/warm-discord-threads.ts
@@ -125,12 +125,22 @@ async function processVoteThread(
   voteInfo: VoteInfo,
   threadId: string
 ): Promise<number> {
-  const voteDiscussion = await fetchAndCacheProcessedThread(
-    threadId,
-    voteInfo.identifier,
-    voteInfo.time,
-    voteInfo.requestKey
-  );
+  const { voteDiscussion, cacheWriteError } =
+    await fetchAndCacheProcessedThread(
+      threadId,
+      voteInfo.identifier,
+      voteInfo.time,
+      voteInfo.requestKey
+    );
+  // The helper swallows cache write failures so the discord-thread endpoint can
+  // still serve fresh data on a Redis blip. In the cron, an unwritten cache
+  // means warm-summaries won't see this vote, so surface it as a per-vote
+  // error to keep monitoring honest.
+  if (cacheWriteError) {
+    throw cacheWriteError instanceof Error
+      ? cacheWriteError
+      : new Error(String(cacheWriteError));
+  }
   return voteDiscussion.thread.length;
 }
 
@@ -182,22 +192,25 @@ export default async function handler(
     const votes = await fetchAllVotes();
     log(`fetched ${votes.length} votes (${Date.now() - votesStart}ms)`);
 
+    // Step 2: Refresh thread map — done unconditionally so the discord-thread
+    // endpoint's past-vote fallback can resolve threads even during quiet
+    // periods with zero active/upcoming votes, including after a Redis reset.
+    const refreshStart = Date.now();
+    const { threadIdMap, isFullRebuild } = await refreshThreadIdMap();
+    log(`thread map refreshed (${Date.now() - refreshStart}ms)`);
+
     if (votes.length === 0) {
       return response.status(200).json({
         success: true,
         message: "No votes to process",
         processed: 0,
+        isFullRebuild,
         duration: Date.now() - startTime,
       });
     }
 
-    // Step 2: Build vote infos
+    // Step 3: Build vote infos
     const voteInfos = buildVoteInfos(votes);
-
-    // Step 3: Refresh thread map
-    const refreshStart = Date.now();
-    const { threadIdMap, isFullRebuild } = await refreshThreadIdMap();
-    log(`thread map refreshed (${Date.now() - refreshStart}ms)`);
 
     // Step 4: Process votes
     const processStart = Date.now();

--- a/pages/api/discord-thread/_utils.ts
+++ b/pages/api/discord-thread/_utils.ts
@@ -170,20 +170,28 @@ export async function setCachedProcessedThread(
   return result;
 }
 
-// Fetch a thread from Discord, process its messages, and write the result to the
-// processed-thread cache. Shared by the warm-discord-threads cron (which warms
-// active+upcoming votes ahead of time) and the discord-thread endpoint's
+export interface FetchAndCacheResult {
+  voteDiscussion: VoteDiscussionT;
+  // Non-null when the Redis write failed. The endpoint ignores this so users
+  // still see fresh data; the cron surfaces it as a per-vote error so warm-
+  // summaries doesn't silently skip uncached votes and monitoring can react.
+  cacheWriteError: unknown;
+}
+
+// Fetch a thread from Discord, process its messages, and write the result to
+// the processed-thread cache. Shared by the warm-discord-threads cron (which
+// warms active+upcoming votes ahead of time) and the discord-thread endpoint's
 // on-demand fallback (which fills cache misses for past votes).
 //
-// The cache write is best-effort: if Redis is degraded we still return the
-// processed thread so the endpoint can serve it to the user. The next request
-// will retry the write.
+// The cache write is best-effort here — a failure is reported via
+// `cacheWriteError` instead of throwing — so the endpoint can still serve the
+// freshly fetched discussion when Redis is degraded.
 export async function fetchAndCacheProcessedThread(
   threadId: string,
   identifier: string,
   time: number,
   requestKey: string
-): Promise<VoteDiscussionT> {
+): Promise<FetchAndCacheResult> {
   const { messages } = await getDiscordMessagesPaginated(threadId);
   const processedMessages = processRawMessages(messages);
 
@@ -193,16 +201,18 @@ export async function fetchAndCacheProcessedThread(
     thread: processedMessages,
   };
 
+  let cacheWriteError: unknown = null;
   try {
     await setCachedProcessedThread(requestKey, voteDiscussion);
-  } catch (cacheError) {
+  } catch (error) {
+    cacheWriteError = error;
     console.warn(
-      `[fetchAndCacheProcessedThread] cache write failed for ${requestKey}, returning data without cache:`,
-      cacheError
+      `[fetchAndCacheProcessedThread] cache write failed for ${requestKey}:`,
+      error
     );
   }
 
-  return voteDiscussion;
+  return { voteDiscussion, cacheWriteError };
 }
 
 // ============================================================================

--- a/pages/api/discord-thread/_utils.ts
+++ b/pages/api/discord-thread/_utils.ts
@@ -38,8 +38,11 @@ type ThreadIdMapCache = ss.Infer<typeof ThreadIdMapCacheSchema>;
 // How often to do a full rebuild (catches threads missed due to race conditions)
 export const FULL_REBUILD_INTERVAL_MS = 2 * 60 * 60 * 1000; // 2 hours
 
-// How far back to look during a full rebuild (no need to fetch ancient history)
-export const FULL_REBUILD_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
+// How far back to look during a full rebuild. The threadIdMap is preserved
+// across rebuilds, so this primarily affects how much history we capture on a
+// cold cache (Redis reset, new env) — past votes whose threads predate this
+// window won't be resolvable by the discord-thread cache-miss fallback.
+export const FULL_REBUILD_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
 export function shouldDoFullRebuild(
   cachedData: ThreadIdMapCache | null
@@ -171,6 +174,10 @@ export async function setCachedProcessedThread(
 // processed-thread cache. Shared by the warm-discord-threads cron (which warms
 // active+upcoming votes ahead of time) and the discord-thread endpoint's
 // on-demand fallback (which fills cache misses for past votes).
+//
+// The cache write is best-effort: if Redis is degraded we still return the
+// processed thread so the endpoint can serve it to the user. The next request
+// will retry the write.
 export async function fetchAndCacheProcessedThread(
   threadId: string,
   identifier: string,
@@ -186,7 +193,15 @@ export async function fetchAndCacheProcessedThread(
     thread: processedMessages,
   };
 
-  await setCachedProcessedThread(requestKey, voteDiscussion);
+  try {
+    await setCachedProcessedThread(requestKey, voteDiscussion);
+  } catch (cacheError) {
+    console.warn(
+      `[fetchAndCacheProcessedThread] cache write failed for ${requestKey}, returning data without cache:`,
+      cacheError
+    );
+  }
+
   return voteDiscussion;
 }
 

--- a/pages/api/discord-thread/_utils.ts
+++ b/pages/api/discord-thread/_utils.ts
@@ -15,6 +15,7 @@ import {
 } from "lib/discord-utils";
 import { createCacheKey } from "lib/cache-keys";
 import { validateRedisData } from "../_utils/validation";
+import { processRawMessages } from "./_message-processing";
 
 // Cache configuration
 export const THREAD_CACHE_KEY = createCacheKey("discord:thread_cache");
@@ -164,6 +165,29 @@ export async function setCachedProcessedThread(
     throw new Error("Setting processed thread cache failed");
   }
   return result;
+}
+
+// Fetch a thread from Discord, process its messages, and write the result to the
+// processed-thread cache. Shared by the warm-discord-threads cron (which warms
+// active+upcoming votes ahead of time) and the discord-thread endpoint's
+// on-demand fallback (which fills cache misses for past votes).
+export async function fetchAndCacheProcessedThread(
+  threadId: string,
+  identifier: string,
+  time: number,
+  requestKey: string
+): Promise<VoteDiscussionT> {
+  const { messages } = await getDiscordMessagesPaginated(threadId);
+  const processedMessages = processRawMessages(messages);
+
+  const voteDiscussion: VoteDiscussionT = {
+    identifier,
+    time,
+    thread: processedMessages,
+  };
+
+  await setCachedProcessedThread(requestKey, voteDiscussion);
+  return voteDiscussion;
 }
 
 // ============================================================================

--- a/pages/api/discord-thread/index.ts
+++ b/pages/api/discord-thread/index.ts
@@ -50,12 +50,15 @@ export default async function handler(
     // The threadIdMap read is an optimization for finding a live-fetch target,
     // so a Redis read or validation failure is treated as a soft miss (empty
     // thread) rather than letting it 500 the whole request — that would block
-    // uncached past-vote views entirely on transient Redis issues.
+    // uncached past-vote views entirely on transient Redis issues. We still
+    // mark it as a transient failure so the empty response isn't CDN-cached.
     let threadIdMapCache: Awaited<ReturnType<typeof getCachedThreadIdMap>> =
       null;
+    let transientFailure = false;
     try {
       threadIdMapCache = await getCachedThreadIdMap();
     } catch (mapReadError) {
+      transientFailure = true;
       console.error(
         `[discord-thread] threadIdMap read failed for requestKey=${requestKey}, treating as cache miss`,
         mapReadError
@@ -63,13 +66,12 @@ export default async function handler(
     }
     const threadId = threadIdMapCache?.threadIdMap?.[requestKey];
 
-    let fetchFailed = false;
     if (threadId) {
       try {
         console.info(
           `[discord-thread] Cache MISS for requestKey=${requestKey}, live-fetching threadId=${threadId}`
         );
-        const voteDiscussion = await fetchAndCacheProcessedThread(
+        const { voteDiscussion } = await fetchAndCacheProcessedThread(
           threadId,
           identifier,
           time,
@@ -82,7 +84,7 @@ export default async function handler(
       } catch (fetchError) {
         // Fall through to empty response so the UI can still render, but mark
         // the failure so we don't let the CDN cache the empty result.
-        fetchFailed = true;
+        transientFailure = true;
         console.error(
           `[discord-thread] Live fetch failed for requestKey=${requestKey}`,
           fetchError
@@ -100,11 +102,12 @@ export default async function handler(
       thread: [],
     };
 
-    // On transient fetch failure, don't let the CDN cache the empty response —
-    // the next request should get a fresh attempt instead of being served stale
-    // empty for 10 minutes. When there's genuinely no threadId in the map
-    // (vote predates lookback or has no discussion), caching empty is fine.
-    const emptyCacheControl = fetchFailed
+    // On transient failure (Redis read error or Discord fetch error), don't let
+    // the CDN cache the empty response — the next request should get a fresh
+    // attempt instead of being served stale empty for 10 minutes. When there's
+    // genuinely no threadId in the map (vote predates lookback or has no
+    // discussion), caching empty is fine.
+    const emptyCacheControl = transientFailure
       ? "no-store"
       : "public, max-age=0, s-maxage=600";
 

--- a/pages/api/discord-thread/index.ts
+++ b/pages/api/discord-thread/index.ts
@@ -1,7 +1,11 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { VoteDiscussionT, L1Request } from "types";
 import * as ss from "superstruct";
-import { getCachedProcessedThread } from "./_utils";
+import {
+  fetchAndCacheProcessedThread,
+  getCachedProcessedThread,
+  getCachedThreadIdMap,
+} from "./_utils";
 import { makeKey } from "lib/discord-utils";
 import { validateQueryParams } from "../_utils/validation";
 import { resolveDiscordThreadTitle } from "helpers/voting/getVoteMetaData";
@@ -37,10 +41,41 @@ export default async function handler(
         .send(cachedData);
     }
 
-    // No cached data - return empty thread
-    console.info(
-      `[discord-thread] Cache MISS for requestKey=${requestKey}, returning empty thread`
-    );
+    // Cache MISS. The warm-discord-threads cron only processes active and
+    // upcoming votes, so past votes never have entries pre-warmed. Fall back to
+    // looking up the threadId from the cached threadIdMap and fetching from
+    // Discord on demand. The fetched data is written back to the cache so
+    // subsequent reads are fast.
+    const threadIdMapCache = await getCachedThreadIdMap();
+    const threadId = threadIdMapCache?.threadIdMap?.[requestKey];
+
+    if (threadId) {
+      try {
+        console.info(
+          `[discord-thread] Cache MISS for requestKey=${requestKey}, live-fetching threadId=${threadId}`
+        );
+        const voteDiscussion = await fetchAndCacheProcessedThread(
+          threadId,
+          identifier,
+          time,
+          requestKey
+        );
+        return response
+          .setHeader("Cache-Control", "public, max-age=0, s-maxage=600")
+          .status(200)
+          .send(voteDiscussion);
+      } catch (fetchError) {
+        // Fall through to empty response so the UI can still render.
+        console.error(
+          `[discord-thread] Live fetch failed for requestKey=${requestKey}`,
+          fetchError
+        );
+      }
+    } else {
+      console.info(
+        `[discord-thread] Cache MISS for requestKey=${requestKey}, no threadId in map, returning empty thread`
+      );
+    }
 
     const emptyResponse: VoteDiscussionT = {
       identifier,

--- a/pages/api/discord-thread/index.ts
+++ b/pages/api/discord-thread/index.ts
@@ -46,9 +46,24 @@ export default async function handler(
     // looking up the threadId from the cached threadIdMap and fetching from
     // Discord on demand. The fetched data is written back to the cache so
     // subsequent reads are fast.
-    const threadIdMapCache = await getCachedThreadIdMap();
+    //
+    // The threadIdMap read is an optimization for finding a live-fetch target,
+    // so a Redis read or validation failure is treated as a soft miss (empty
+    // thread) rather than letting it 500 the whole request — that would block
+    // uncached past-vote views entirely on transient Redis issues.
+    let threadIdMapCache: Awaited<ReturnType<typeof getCachedThreadIdMap>> =
+      null;
+    try {
+      threadIdMapCache = await getCachedThreadIdMap();
+    } catch (mapReadError) {
+      console.error(
+        `[discord-thread] threadIdMap read failed for requestKey=${requestKey}, treating as cache miss`,
+        mapReadError
+      );
+    }
     const threadId = threadIdMapCache?.threadIdMap?.[requestKey];
 
+    let fetchFailed = false;
     if (threadId) {
       try {
         console.info(
@@ -65,7 +80,9 @@ export default async function handler(
           .status(200)
           .send(voteDiscussion);
       } catch (fetchError) {
-        // Fall through to empty response so the UI can still render.
+        // Fall through to empty response so the UI can still render, but mark
+        // the failure so we don't let the CDN cache the empty result.
+        fetchFailed = true;
         console.error(
           `[discord-thread] Live fetch failed for requestKey=${requestKey}`,
           fetchError
@@ -83,8 +100,16 @@ export default async function handler(
       thread: [],
     };
 
+    // On transient fetch failure, don't let the CDN cache the empty response —
+    // the next request should get a fresh attempt instead of being served stale
+    // empty for 10 minutes. When there's genuinely no threadId in the map
+    // (vote predates lookback or has no discussion), caching empty is fine.
+    const emptyCacheControl = fetchFailed
+      ? "no-store"
+      : "public, max-age=0, s-maxage=600";
+
     return response
-      .setHeader("Cache-Control", "public, max-age=0, s-maxage=600")
+      .setHeader("Cache-Control", emptyCacheControl)
       .status(200)
       .send(emptyResponse);
   } catch (e) {

--- a/pages/api/discord-thread/index.ts
+++ b/pages/api/discord-thread/index.ts
@@ -64,6 +64,14 @@ export default async function handler(
         mapReadError
       );
     }
+
+    // An absent map cache (cold Redis before the cron's first rebuild) is also
+    // transient: a permanent CDN cache of empty would mask the thread once the
+    // cron repopulates moments later.
+    if (!threadIdMapCache) {
+      transientFailure = true;
+    }
+
     const threadId = threadIdMapCache?.threadIdMap?.[requestKey];
 
     if (threadId) {

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,9 @@
     "pages/api/augment-request.ts": {
       "maxDuration": 300
     },
+    "pages/api/discord-thread/index.ts": {
+      "maxDuration": 60
+    },
     "pages/api/update-summary.ts": {
       "maxDuration": 300
     },


### PR DESCRIPTION
## Summary

Resolves [ENG-249](https://linear.app/uma/issue/ENG-249/vote-discussion-and-discussion-summaries-dont-load-on-past-votes): vote discussion and summaries don't load when opening any dispute from `/past-votes`.

### Root cause

The discord-thread overhaul (#430) moved `/api/discord-thread` to read-only Redis cache lookups, with the `warm-discord-threads` cron populating the cache. The cron only processes **active and upcoming** votes (`getActiveVotes` + `getUpcomingVotes`), so past votes always cache-miss → endpoint returns `{ thread: [] }`. The summary panel hits the same wall: `/api/update-summary` calls `/api/discord-thread` internally, sees no comments, and stores nothing.

### Fix

1. **`pages/api/discord-thread/index.ts`** — on cache miss, look up the `requestKey` in the cached `threadIdMap` and live-fetch from Discord. The result is written back through `setCachedProcessedThread` so subsequent reads stay fast. If Discord errors or the threadId isn't in the map, fall through to the existing empty-thread response.
2. **`pages/api/cron/warm-discord-threads.ts`** — preserve `threadIdMap` entries across the 2-hour full rebuild (`existingMap = cached?.threadIdMap ?? {}` instead of wiping on rebuild). The rebuild still refetches the lookback window from scratch to catch threads missed by incremental updates; we just merge into the existing map. Without this, past votes whose threads predate the rolling window can't be resolved even with #1.
3. **`pages/api/discord-thread/_utils.ts`** — extract the shared fetch+process+cache step into `fetchAndCacheProcessedThread`, used by both the cron and the new fallback path.

## Test plan

- [ ] Verify type check, lint, and unit tests pass locally (done — 65 tests pass).
- [ ] In preview, open a past vote from `/past-votes` and confirm:
  - [ ] Discord Comments tab loads messages (first load may take a few seconds while Discord is fetched)
  - [ ] Discord Summary tab triggers generation and eventually renders the AI summary
- [ ] Confirm the same flows still work on `/upcoming-votes` and `/` (active) — both still cache-warmed by the cron, no behavior change.
- [ ] After the next `warm-discord-threads` run, confirm logs show `total cached` increasing rather than resetting on the 2-hour rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)