### PR TITLE
Split max APR banner into staking + voting-correctly components

### DIFF
--- a/components/Banner/Banner.tsx
+++ b/components/Banner/Banner.tsx
@@ -4,12 +4,14 @@ import styled from "styled-components";
 
 interface Props {
   children: ReactNode;
+  subtitle?: ReactNode;
 }
-export function Banner({ children }: Props) {
+export function Banner({ children, subtitle }: Props) {
   return (
     <OuterWrapper>
       <InnerWrapper>
         <Text>{children}</Text>
+        {subtitle && <Subtitle>{subtitle}</Subtitle>}
       </InnerWrapper>
     </OuterWrapper>
   );
@@ -21,12 +23,14 @@ const OuterWrapper = styled.div`
 
 const InnerWrapper = styled.div`
   max-width: var(--page-width);
-  height: var(--banner-height);
+  min-height: var(--banner-height);
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  padding-block: 12px;
   padding-left: var(--page-padding);
   @media ${tabletAndUnder} {
-    padding: 0;
+    padding-inline: 0;
   }
   margin-inline: auto;
 `;
@@ -34,4 +38,11 @@ const InnerWrapper = styled.div`
 const Text = styled.h1`
   color: var(--white);
   font: var(--header-lg);
+`;
+
+const Subtitle = styled.p`
+  color: var(--white);
+  font: var(--text-md);
+  margin-top: 6px;
+  opacity: 0.85;
 `;

--- a/helpers/config.ts
+++ b/helpers/config.ts
@@ -24,6 +24,8 @@ const Env = ss.object({
   NEXT_PUBLIC_SIGNING_MESSAGE: ss.optional(ss.string()),
   NEXT_PUBLIC_CHAIN_ID: ss.optional(ss.string()),
   NEXT_PUBLIC_OVERRIDE_APR: ss.optional(ss.string()),
+  NEXT_PUBLIC_STAKING_APR_MAX: ss.optional(ss.string()),
+  NEXT_PUBLIC_VOTING_APR_MAX: ss.optional(ss.string()),
   NEXT_PUBLIC_DESIGNATED_VOTING_FACTORY_V1_ADDRESS: ss.optional(ss.string()),
   NEXT_PUBLIC_PHASE_LENGTH: ss.optional(ss.string()),
   NEXT_PUBLIC_MAILCHIMP_URL: ss.optional(ss.string()),
@@ -68,6 +70,8 @@ export const env = ss.create(
       process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN,
     NEXT_PUBLIC_CHAIN_ID: process.env.NEXT_PUBLIC_CHAIN_ID,
     NEXT_PUBLIC_OVERRIDE_APR: process.env.NEXT_PUBLIC_OVERRIDE_APR,
+    NEXT_PUBLIC_STAKING_APR_MAX: process.env.NEXT_PUBLIC_STAKING_APR_MAX,
+    NEXT_PUBLIC_VOTING_APR_MAX: process.env.NEXT_PUBLIC_VOTING_APR_MAX,
     NEXT_PUBLIC_DESIGNATED_VOTING_FACTORY_V1_ADDRESS:
       process.env.NEXT_PUBLIC_DESIGNATED_VOTING_FACTORY_V1_ADDRESS,
     NEXT_PUBLIC_PHASE_LENGTH: process.env.NEXT_PUBLIC_PHASE_LENGTH,
@@ -114,6 +118,8 @@ const AppConfig = ss.object({
   graphV2Enabled: ss.defaulted(ss.boolean(), false),
   contentfulEnabled: ss.defaulted(ss.boolean(), false),
   overrideApr: ss.optional(ss.string()),
+  stakingAprMax: ss.optional(ss.string()),
+  votingAprMax: ss.optional(ss.string()),
   designatedVotingFactoryV1Address: ss.string(),
   phaseLength: ss.number(),
   mailchimpUrl: ss.optional(ss.string()),
@@ -158,6 +164,8 @@ export const appConfig = ss.create(
       !!env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN &&
       !!env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID,
     overrideApr: env.NEXT_PUBLIC_OVERRIDE_APR,
+    stakingAprMax: env.NEXT_PUBLIC_STAKING_APR_MAX,
+    votingAprMax: env.NEXT_PUBLIC_VOTING_APR_MAX,
     designatedVotingFactoryV1Address:
       env.NEXT_PUBLIC_DESIGNATED_VOTING_FACTORY_V1_ADDRESS ??
       getDesignatedVotingFactoryAddress(

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import {
 } from "components";
 import { Strong } from "components/pages/styles";
 import { truncateDecimals } from "helpers";
+import { config } from "helpers/config";
 import { useGlobals } from "hooks";
 import { isUndefined } from "lodash";
 import type { NextPage } from "next";
@@ -16,15 +17,43 @@ import type { NextPage } from "next";
 const VotePage: NextPage = () => {
   const { data: globals } = useGlobals();
   const { annualPercentageReturn } = globals || {};
+  const { stakingAprMax, votingAprMax } = config;
+
+  const stakingAprMaxNumber = Number(stakingAprMax);
+  const votingAprMaxNumber = Number(votingAprMax);
+  const hasAprBreakdown =
+    stakingAprMax !== undefined &&
+    votingAprMax !== undefined &&
+    Number.isFinite(stakingAprMaxNumber) &&
+    Number.isFinite(votingAprMaxNumber);
+  const totalAprMax = hasAprBreakdown
+    ? stakingAprMaxNumber + votingAprMaxNumber
+    : undefined;
+
   return (
     <Layout title="UMA | Voting dApp">
-      <Banner>
+      <Banner
+        subtitle={
+          hasAprBreakdown && (
+            <>
+              Up to <Strong>{truncateDecimals(stakingAprMaxNumber, 1)}%</Strong>{" "}
+              from staking your UMA &amp; up to{" "}
+              <Strong>{truncateDecimals(votingAprMaxNumber, 1)}%</Strong> from
+              voting correctly.
+            </>
+          )
+        }
+      >
         Stake, vote &amp; earn up to{" "}
-        <Loader isLoading={isUndefined(annualPercentageReturn)}>
-          <Strong>
-            {truncateDecimals(annualPercentageReturn || 0, 0)}% APR
-          </Strong>
-        </Loader>
+        {hasAprBreakdown ? (
+          <Strong>{truncateDecimals(totalAprMax ?? 0, 0)}% APR</Strong>
+        ) : (
+          <Loader isLoading={isUndefined(annualPercentageReturn)}>
+            <Strong>
+              {truncateDecimals(annualPercentageReturn || 0, 0)}% APR
+            </Strong>
+          </Loader>
+        )}
       </Banner>
       <PageOuterWrapper>
         <HowItWorks />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,11 +19,13 @@ const VotePage: NextPage = () => {
   const { annualPercentageReturn } = globals || {};
   const { stakingAprMax, votingAprMax } = config;
 
-  const stakingAprMaxNumber = Number(stakingAprMax);
-  const votingAprMaxNumber = Number(votingAprMax);
+  const stakingAprMaxTrimmed = stakingAprMax?.trim();
+  const votingAprMaxTrimmed = votingAprMax?.trim();
+  const stakingAprMaxNumber = Number(stakingAprMaxTrimmed);
+  const votingAprMaxNumber = Number(votingAprMaxTrimmed);
   const hasAprBreakdown =
-    stakingAprMax !== undefined &&
-    votingAprMax !== undefined &&
+    !!stakingAprMaxTrimmed &&
+    !!votingAprMaxTrimmed &&
     Number.isFinite(stakingAprMaxNumber) &&
     Number.isFinite(votingAprMaxNumber);
   const totalAprMax = hasAprBreakdown

--- a/stories/Pages/VotePage/Banner.stories.tsx
+++ b/stories/Pages/VotePage/Banner.stories.tsx
@@ -12,3 +12,10 @@ export const Default = Template.bind({});
 Default.args = {
   children: "Stake, vote & earn up to 30% APY",
 };
+
+export const WithSubtitle = Template.bind({});
+WithSubtitle.args = {
+  children: "Stake, vote & earn up to 20% APR",
+  subtitle:
+    "Up to 10% from staking your UMA & up to 10% from voting correctly.",
+};


### PR DESCRIPTION
## Summary
- Adds optional `NEXT_PUBLIC_STAKING_APR_MAX` and `NEXT_PUBLIC_VOTING_APR_MAX` env vars. When both are set, the homepage banner advertises the maximum APR from pure staking and from voting correctly separately, plus the sum as the headline number — so visitors can see how the "up to 20% APR" claim breaks down between emission-based staking yield and the slashing-based reward for correct voting.
- Falls back to the existing single-number display (using subgraph `annualPercentageReturn`) when either env var is unset, so no behavior change until the env vars are populated in Vercel.
- Banner gains an optional `subtitle` prop used for the breakdown line; story added for the new variant.

Suggested values: set `NEXT_PUBLIC_STAKING_APR_MAX` and `NEXT_PUBLIC_VOTING_APR_MAX` in Vercel to whatever the protocol's theoretical maxes are (e.g., `10` and `10` if the marketed 20% is split evenly). Their sum becomes the headline number.

Requested by Nikolas in Slack — feedback that the headline 20% doesn't communicate which portion comes from staking vs. voting correctly.

## Test plan
- [ ] Local dev with both env vars set (e.g. `10` + `10`) shows headline `20% APR` and subtitle `Up to 10% from staking your UMA & up to 10% from voting correctly.`
- [ ] Local dev with env vars unset shows the existing single-number banner powered by the subgraph
- [ ] Storybook: the new `WithSubtitle` Banner story renders cleanly on the default + tablet/mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)