### PR TITLE
fix: mobile Quick vote option doesn't fully select (ACX-4985)

### DIFF
--- a/components/Panel/VotePanel/VotePanelVoteInput.tsx
+++ b/components/Panel/VotePanel/VotePanelVoteInput.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import styled from "styled-components";
 import { DropdownItemT, VoteT } from "types";
 import { mobileAndUnder } from "constant";
@@ -9,12 +10,24 @@ interface Props {
   onSelectVote: (value: string | undefined, vote: VoteT) => void;
 }
 
+// Suppresses the synthesized `click` that some mobile browsers fire alongside
+// the real tap, which previously toggled the selection right back off.
+const DOUBLE_FIRE_WINDOW_MS = 300;
+
 export function VotePanelVoteInput({
   vote,
   selectedValue,
   onSelectVote,
 }: Props) {
   const options = vote.options;
+  const lastTapAtRef = useRef(0);
+
+  function handleSelect(value: string) {
+    const now = Date.now();
+    if (now - lastTapAtRef.current < DOUBLE_FIRE_WINDOW_MS) return;
+    lastTapAtRef.current = now;
+    onSelectVote(value, vote);
+  }
 
   if (!options || options.length === 0) {
     return (
@@ -37,14 +50,7 @@ export function VotePanelVoteInput({
             <OptionButton
               key={option.value.toString()}
               $isSelected={selectedValue === option.value.toString()}
-              onClick={() =>
-                onSelectVote(
-                  selectedValue === option.value.toString()
-                    ? undefined
-                    : option.value.toString(),
-                  vote
-                )
-              }
+              onClick={() => handleSelect(option.value.toString())}
             >
               P{index + 1}
             </OptionButton>
@@ -115,7 +121,13 @@ const OptionButton = styled.button<{ $isSelected: boolean }>`
   cursor: pointer;
   transition: all 150ms;
 
-  &:hover {
+  @media (hover: hover) {
+    &:hover {
+      border-color: var(--red-500);
+    }
+  }
+
+  &:active {
     border-color: var(--red-500);
   }
 `;

--- a/components/Panel/VotePanel/VotePanelVoteInput.tsx
+++ b/components/Panel/VotePanel/VotePanelVoteInput.tsx
@@ -11,7 +11,8 @@ interface Props {
 }
 
 // Suppresses the synthesized `click` that some mobile browsers fire alongside
-// the real tap, which previously toggled the selection right back off.
+// the real tap on the same element. Scoped per-value so rapid switching
+// between options (e.g. P1 → P2) is not dropped.
 const DOUBLE_FIRE_WINDOW_MS = 300;
 
 export function VotePanelVoteInput({
@@ -20,12 +21,15 @@ export function VotePanelVoteInput({
   onSelectVote,
 }: Props) {
   const options = vote.options;
-  const lastTapAtRef = useRef(0);
+  const lastTapRef = useRef<{ value: string; at: number } | null>(null);
 
   function handleSelect(value: string) {
     const now = Date.now();
-    if (now - lastTapAtRef.current < DOUBLE_FIRE_WINDOW_MS) return;
-    lastTapAtRef.current = now;
+    const last = lastTapRef.current;
+    if (last && last.value === value && now - last.at < DOUBLE_FIRE_WINDOW_MS) {
+      return;
+    }
+    lastTapRef.current = { value, at: now };
     onSelectVote(value, vote);
   }
 


### PR DESCRIPTION
## Summary

Fixes [ACX-4985](https://linear.app/uma/issue/ACX-4985/mobile-vote-option-doesnt-fully-select-outline-only-no-fill): on mobile, tapping a Quick vote option in `VotePanelVoteInput` only showed a colored outline (no fill), and tapping away left nothing selected.

Two root causes, both in `components/Panel/VotePanel/VotePanelVoteInput.tsx`:

1. **Phantom outline.** `:hover` only changed the border color and mobile browsers sticky-fire `:hover` after a tap, producing the "outline only, no fill" state until the user tapped elsewhere. Gated `:hover` behind `@media (hover: hover)` and added `:active` for tap feedback.
2. **Tap deselects itself.** `onClick` toggled the value to `undefined` when it was already selected, so the synthesized second `click` event some mobile browsers fire alongside the real tap would deselect what had just been selected. Switched to idempotent select-only and added a 300 ms `useRef`-based double-fire guard. Clearing the selection still works via the main vote list's clear control.

## Test plan

- [ ] On a real iOS device: open an active vote → tap an option → tap away → option stays filled/selected.
- [ ] On a real Android device: same flow.
- [ ] Desktop: hover styling still shows the red border on mouse-over; click still selects.
- [ ] Tapping the currently-selected option no longer clears it (use the main vote list's clear control to deselect).