### PR TITLE
fix: don't mark tiny applied rewards as PENDING in vote history

### DIFF
--- a/components/VoteHistoryTable/VoteHistoryTableRow.tsx
+++ b/components/VoteHistoryTable/VoteHistoryTableRow.tsx
@@ -14,25 +14,25 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
     resolvedPriceRequestIndex,
     voteHistory: { voted, correctness, staking, slashAmount },
   } = vote;
+  // slashAmount is exactly zero until the voter's slashing trackers are updated
+  // on-chain; a nonzero amount that merely truncates to zero at display
+  // precision has already been applied and must not be shown as pending
+  const isBelowDisplayPrecision =
+    !slashAmount.isZero() &&
+    ["0", "-0"].includes(formatNumberForDisplay(slashAmount));
   const formattedSlashAmount = makeFormattedSlashAmount();
   const scoreColor = getScoreColor();
 
   function makeFormattedSlashAmount() {
-    const formattedSlashAmount = formatNumberForDisplay(slashAmount);
-    if (
-      staking &&
-      (formattedSlashAmount === "0" || formattedSlashAmount === "-0")
-    )
-      return "pending";
-    if (formattedSlashAmount === "-0") return "0";
-    return formattedSlashAmount;
+    if (staking && slashAmount.isZero()) return "pending";
+    if (isBelowDisplayPrecision) return slashAmount.gt(0) ? "<0.01" : ">-0.01";
+    return formatNumberForDisplay(slashAmount);
   }
 
   function getScoreColor() {
     if (formattedSlashAmount === "pending") return black;
-    if (formattedSlashAmount === "0") return black;
-    if (formattedSlashAmount.startsWith("-")) return red500;
-    return green;
+    if (slashAmount.isZero()) return black;
+    return slashAmount.lt(0) ? red500 : green;
   }
 
   const pendingEarningsTooltip =
@@ -70,6 +70,10 @@ export function VoteHistoryTableRow({ vote, onVoteClicked }: Props) {
         {formattedSlashAmount === "pending" ? (
           <Tooltip label={pendingEarningsTooltip}>
             <PendingChip>Pending</PendingChip>
+          </Tooltip>
+        ) : isBelowDisplayPrecision ? (
+          <Tooltip label={formatNumberForDisplay(slashAmount, { decimals: 6 })}>
+            <span>{formattedSlashAmount}</span>
           </Tooltip>
         ) : (
           formattedSlashAmount


### PR DESCRIPTION
## Problem

The Earnings column in the voting-history table shows a **PENDING** chip for votes whose rewards have already been applied on-chain, whenever the amount is under the 2-decimal display floor.

`makeFormattedSlashAmount` decided "pending" off the *formatted* string (`staking && formatted === "0" || "-0"`). `formatNumberForDisplay` truncates to 2 decimals, so a real applied reward of e.g. +0.0006 UMA formats to "0" and the row renders PENDING — permanently, since the amount never changes again.

Reported by a voter (Slack, 2026-06-06): history showed interleaved rows — wrong votes displaying -0.03 while correct votes (#3369, #3370, #3371, #3377) showed PENDING. Genuinely-unapplied earnings can't interleave: `_updateAccountSlashingTrackers` walks a monotonic `nextIndexToProcess` cursor, so if a newer request is applied every older one is too.

Verified on-chain via `requestSlashingTrackers` on mainnet VotingV2 (`0x0043...34ac`): with the voter's ~30 UMA stake, correct-vote earnings on those requests are +0.000598–0.000975 UMA — real, applied, and 100x below the display floor.

## Fix

- Decide "pending" from the raw BigNumber: only an **exactly zero** `slashAmount` (with `staking`) means the voter's slashing trackers haven't been applied yet.
- Nonzero amounts that truncate to zero at 2 decimals render as `<0.01` / `>-0.01`, with the precise value (6 decimals) in a tooltip.
- Score color now derives from the BigNumber sign, so tiny negatives stay red.

No subgraph or contract changes needed — the indexed data was always correct.

## Testing

- `tsc --noEmit` clean, `yarn lint` clean for this file, `yarn test` 65/65 passing.
- Verified display logic against the incident's on-chain values (0.000601 / 0.000975 → `<0.01`; exact zero + staking → PENDING; -0.03 unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)