### PR TITLE
feat: show vote results for previous rolls in vote panel

### DIFF
--- a/components/Panel/VotePanel/RollResults.tsx
+++ b/components/Panel/VotePanel/RollResults.tsx
@@ -1,0 +1,95 @@
+import { Tabs } from "components";
+import { mobileAndUnder } from "constant";
+import { useVoteTimingContext } from "hooks";
+import styled from "styled-components";
+import { RollResultT, VoteT } from "types";
+import { PanelSectionText } from "../styles";
+import { Result } from "./Result";
+
+export function getPastRolls(
+  resultsPerRoll: RollResultT[] | undefined,
+  currentRoundId: number
+) {
+  return resultsPerRoll?.filter((roll) => roll.roundId < currentRoundId) ?? [];
+}
+
+interface Props {
+  content: VoteT;
+  proposedPrice: string | undefined;
+}
+
+// Shows one sub-tab of results per roll for votes that have rolled to a new
+// voting round without resolving. Sub-tabs are labelled "Roll #0", "Roll #1",
+// ... in the order the rounds were voted on. The current roll only gets a
+// sub-tab once its results are visible, ie during the reveal phase.
+export function RollResults({ content, proposedPrice }: Props) {
+  const { roundId: currentRoundId, phase } = useVoteTimingContext();
+  const { resultsPerRoll, decodedIdentifier, options } = content;
+
+  const pastRolls = getPastRolls(resultsPerRoll, currentRoundId);
+  const currentRoll = resultsPerRoll?.find(
+    (roll) => roll.roundId === currentRoundId
+  );
+
+  function makeRollContent(roll: RollResultT | undefined) {
+    if (!roll?.results.length) {
+      return (
+        <NoResultsMessage>
+          No votes have been revealed in this roll.
+        </NoResultsMessage>
+      );
+    }
+    return (
+      <Result
+        decodedIdentifier={decodedIdentifier}
+        participation={roll.participation}
+        results={roll.results}
+        options={options}
+        proposedPrice={proposedPrice}
+      />
+    );
+  }
+
+  const tabs = pastRolls.map((roll, index) => ({
+    title: `Roll #${index}`,
+    content: makeRollContent(roll),
+  }));
+
+  // votes revealed in the current roll are only visible during the reveal phase
+  if (phase === "reveal") {
+    tabs.push({
+      title: `Roll #${pastRolls.length}`,
+      content: makeRollContent(currentRoll),
+    });
+  }
+
+  return (
+    <Wrapper>
+      <Tabs tabs={tabs} defaultValue={tabs[tabs.length - 1]?.title} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  margin-top: 10px;
+
+  [role="tablist"] {
+    height: 35px;
+    gap: 30px;
+    background: transparent;
+    border-bottom: 1px solid var(--grey-100);
+
+    @media ${mobileAndUnder} {
+      gap: 15px;
+    }
+  }
+`;
+
+const NoResultsMessage = styled(PanelSectionText)`
+  margin-top: 20px;
+  padding-inline: 30px;
+
+  @media ${mobileAndUnder} {
+    padding-inline: 10px;
+  }
+`;

--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -19,6 +19,7 @@ import { PanelTitle } from "../PanelTitle";
 import { Details } from "./Details";
 import { Discussion } from "./Discussion";
 import { Result } from "./Result";
+import { getPastRolls, RollResults } from "./RollResults";
 import { VotePanelVoteInput } from "./VotePanelVoteInput";
 import { DiscussionSummary } from "components";
 import { usePolymarketBulletins } from "hooks";
@@ -39,6 +40,7 @@ export function VotePanel({ content }: Props) {
     origin,
     participation,
     results,
+    resultsPerRoll,
     isGovernance,
     options,
     decodedAncillaryData,
@@ -58,7 +60,7 @@ export function VotePanel({ content }: Props) {
     panelType,
   } = usePanelContext();
 
-  const { phase } = useVoteTimingContext();
+  const { phase, roundId } = useVoteTimingContext();
   const isCommitPhase = phase === "commit";
 
   const hasNavigation = navigableVotes.length > 1;
@@ -139,6 +141,10 @@ export function VotePanel({ content }: Props) {
 
   function makeTabs() {
     const hasResults = Boolean(results?.length);
+    // votes that have rolled show results for every roll in a dedicated
+    // "Results" tab during both commit and reveal phases. votes on their
+    // first roll (roll #0) keep the regular single-round "Result" tab.
+    const hasRolledResults = getPastRolls(resultsPerRoll, roundId).length > 0;
 
     const tabsAllEnvironments = [
       {
@@ -177,7 +183,17 @@ export function VotePanel({ content }: Props) {
 
     // add result tab if there are results
     // and make it the first tab
-    if (hasResults) {
+    if (hasRolledResults) {
+      tabs.unshift({
+        title: "Results",
+        content: (
+          <RollResults
+            content={content}
+            proposedPrice={augmentedVoteData?.proposedPrice}
+          />
+        ),
+      });
+    } else if (hasResults) {
       tabs.unshift({
         title: "Result",
         content: (
@@ -194,7 +210,11 @@ export function VotePanel({ content }: Props) {
 
     // Check if selected tab exists in current tabs
     const tabTitles = tabs.map((tab) => tab.title);
-    const defaultTab = hasResults ? "Result" : "Details";
+    const defaultTab = hasRolledResults
+      ? "Results"
+      : hasResults
+      ? "Result"
+      : "Details";
 
     // If selectedTab doesn't exist in current tabs, use default
     const currentTab =

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -232,6 +232,9 @@ export function VotesProvider({ children }: { children: ReactNode }) {
         ...vote,
         // prefer active vote results first, this will either exist or not, if not we can just fall back to the default vote results
         results: activeVoteResultsByKey?.[uniqueKey]?.results ?? vote?.results,
+        resultsPerRoll:
+          activeVoteResultsByKey?.[uniqueKey]?.resultsPerRoll ??
+          vote?.resultsPerRoll,
         participation:
           activeVoteResultsByKey?.[uniqueKey]?.participation ??
           vote?.participation,

--- a/graph/queries/getActiveVoteResults.ts
+++ b/graph/queries/getActiveVoteResults.ts
@@ -3,6 +3,7 @@ import request, { gql } from "graphql-request";
 import { formatBytes32String, makePriceRequestsByKey } from "helpers";
 import {
   PastVotesQuery,
+  PriceRequestRoundQuery,
   RevealedVotesByAddress,
   VoteParticipationT,
   PriceRequestT,
@@ -13,6 +14,31 @@ import { utils, BigNumber } from "ethers";
 import { resolveAncillaryDataForRequests } from "helpers/voting/resolveAncillaryData";
 
 const { graphEndpoint } = config;
+
+function makeRoundResults(round: PriceRequestRoundQuery) {
+  const totalTokensVotedWith = Number(round.totalVotesRevealed);
+
+  // for v1 this data is missing so we need to dynamically check this
+  const totalTokensCommitted = round.totalTokensCommitted
+    ? Number(round.totalTokensCommitted)
+    : undefined;
+
+  const participation = {
+    uniqueCommitAddresses: round.committedVotes.length,
+    uniqueRevealAddresses: round.revealedVotes.length,
+    totalTokensVotedWith,
+    totalTokensCommitted,
+    minAgreementRequirement: Number(round.minAgreementRequirement),
+    minParticipationRequirement: Number(round.minParticipationRequirement),
+  };
+
+  const results = round.groups.map(({ price, totalVoteAmount }) => ({
+    vote: price,
+    tokensVotedWith: Number(totalVoteAmount),
+  }));
+
+  return { participation, results };
+}
 
 export async function getActiveVoteResults(): Promise<
   Record<UniqueKeyT, PriceRequestT & VoteParticipationT & VoteResultsT>
@@ -55,6 +81,27 @@ export async function getActiveVoteResults(): Promise<
             price
           }
         }
+        rounds(orderBy: roundId, orderDirection: asc, first: 100) {
+          roundId
+          totalVotesRevealed
+          minAgreementRequirement
+          minParticipationRequirement
+          totalTokensCommitted
+          groups {
+            price
+            totalVoteAmount
+          }
+          committedVotes(first: 1000) {
+            id
+          }
+          revealedVotes(first: 1000) {
+            id
+            voter {
+              address
+            }
+            price
+          }
+        }
       }
     }
   `;
@@ -68,31 +115,17 @@ export async function getActiveVoteResults(): Promise<
       ancillaryData,
       resolvedPriceRequestIndex,
       latestRound,
+      rounds,
     }) => {
       const identifier = formatBytes32String(id);
       const correctVote = price;
-      const totalTokensVotedWith = Number(latestRound.totalVotesRevealed);
+      const { participation, results } = makeRoundResults(latestRound);
 
-      // for v1 this data is missing so we need to dynamically check this
-      const totalTokensCommitted = latestRound.totalTokensCommitted
-        ? Number(latestRound.totalTokensCommitted)
-        : undefined;
-
-      const participation = {
-        uniqueCommitAddresses: latestRound.committedVotes.length,
-        uniqueRevealAddresses: latestRound.revealedVotes.length,
-        totalTokensVotedWith,
-        totalTokensCommitted,
-        minAgreementRequirement: Number(latestRound.minAgreementRequirement),
-        minParticipationRequirement: Number(
-          latestRound.minParticipationRequirement
-        ),
-      };
-
-      const results = latestRound.groups.map(({ price, totalVoteAmount }) => ({
-        vote: price,
-        tokensVotedWith: Number(totalVoteAmount),
+      const resultsPerRoll = rounds?.map((round) => ({
+        roundId: Number(round.roundId),
+        ...makeRoundResults(round),
       }));
+
       const init: RevealedVotesByAddress = {};
       const revealedVoteByAddress = latestRound.revealedVotes.reduce(
         (result, vote) => {
@@ -110,6 +143,7 @@ export async function getActiveVoteResults(): Promise<
         isV1: false,
         participation,
         results,
+        resultsPerRoll,
         revealedVoteByAddress,
       };
     }

--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -69,6 +69,7 @@ function formatPriceRequest(
       priceRequest?.participation?.minParticipationRequirement || 0,
   };
   const results = priceRequest.results;
+  const resultsPerRoll = priceRequest.resultsPerRoll;
   const uniqueKey = makeUniqueKeyForVote(
     decodedIdentifier,
     time,
@@ -93,6 +94,7 @@ function formatPriceRequest(
     correctVote,
     participation,
     results,
+    resultsPerRoll,
     uniqueKey,
     isV1,
     isGovernance,

--- a/types/queries.ts
+++ b/types/queries.ts
@@ -1,3 +1,24 @@
+export type PriceRequestRoundQuery = {
+  totalVotesRevealed: string;
+  minAgreementRequirement: string;
+  minParticipationRequirement: string;
+  totalTokensCommitted?: string;
+  groups: {
+    price: string;
+    totalVoteAmount: string;
+  }[];
+  committedVotes: {
+    id: string;
+  }[];
+  revealedVotes: {
+    id: string;
+    voter: {
+      address: string;
+    };
+    price: string;
+  }[];
+};
+
 export type PastVotesQuery = {
   priceRequests: {
     identifier: {
@@ -7,26 +28,8 @@ export type PastVotesQuery = {
     price: string;
     ancillaryData: string;
     resolvedPriceRequestIndex: string;
-    latestRound: {
-      totalVotesRevealed: string;
-      minAgreementRequirement: string;
-      minParticipationRequirement: string;
-      totalTokensCommitted?: string;
-      groups: {
-        price: string;
-        totalVoteAmount: string;
-      }[];
-      committedVotes: {
-        id: string;
-      }[];
-      revealedVotes: {
-        id: string;
-        voter: {
-          address: string;
-        };
-        price: string;
-      }[];
-    };
+    latestRound: PriceRequestRoundQuery;
+    rounds?: (PriceRequestRoundQuery & { roundId: string })[];
     committedVotes: {
       id: string;
     }[];

--- a/types/voting.ts
+++ b/types/voting.ts
@@ -54,8 +54,17 @@ export type ResultsT = {
   tokensVotedWith: number;
 }[];
 
+export type RollResultT = {
+  roundId: number;
+  results: ResultsT;
+  participation: ParticipationT;
+};
+
 export type VoteResultsT = {
   results?: ResultsT;
+  // per-round results for requests that have rolled, ordered by round id
+  // ascending; index 0 is the first round the request was voted on (roll #0)
+  resultsPerRoll?: RollResultT[];
 };
 
 export type RevealedVotesByAddress = Record<string, string>;
@@ -69,6 +78,7 @@ export type RawPriceRequestDataT = {
   correctVote?: string;
   participation?: ParticipationT;
   results?: ResultsT;
+  resultsPerRoll?: RollResultT[];
   isV1?: boolean;
   rollCount?: number;
   isGovernance?: boolean;


### PR DESCRIPTION
## Motivation

When a vote rolls to a new voting round without resolving, the vote panel sidebar only shows results for the most recent round — and once anyone commits in the new round, no results at all during the commit phase. Voters have no way to see how previous rolls voted.

Requested by Lee in Slack.

## Changes

- **Rolled votes get a "Results" tab, visible during both commit and reveal phases.** It contains one sub-tab per roll, titled `Roll #0`, `Roll #1`, … in voting order. Each sub-tab renders the exact same layout as the existing single-round result view (donut chart, legend, quorum/consensus progress, participation stats).
- **The current roll's sub-tab only appears during the reveal phase**, since results aren't visible while commits are still being gathered. If nothing has been revealed yet, the sub-tab shows an empty-state message instead of an empty chart.
- **Votes that resolve in Roll #0 (the common case) are unchanged**: single "Result" tab, same gating as before. Past/resolved votes are also unchanged.
- **Data source:** the same voting-v2 subgraph query already used for active vote results (`getActiveVoteResults`), extended to fetch `rounds(orderBy: roundId, orderDirection: asc)` per unresolved price request instead of only `latestRound`. The round→results/participation mapping is factored into a shared `makeRoundResults` helper, so the existing `latestRound` path behaves identically.

## Implementation notes

- `resultsPerRoll` (`{ roundId, results, participation }[]`, ascending) is added to `VoteResultsT` and flows through `makePriceRequestsByKey` → `VotesContext` like the existing `results` field. It's only populated for active votes, which keeps every other consumer of `results` untouched.
- Roll numbering = position in the ascending round list; past rolls are rounds with `roundId < currentRoundId` from `useVoteTimingContext`. The subgraph creates a round entity when a request is added and on first commit of each round, so roll #0 exists even if no one voted in it (it then renders the empty-state message).
- The sub-tabs reuse the existing Radix `Tabs` component with a restyled (smaller, underlined) tab list; default selection is the most recent roll.

## Testing

- `tsc --noEmit`, `next lint`, `vitest` (65 tests), and prettier all pass.
- New GraphQL document parse-validated; `rounds`/`roundId`/`groups` fields confirmed against `packages/votingV2/schema.graphql` in UMAprotocol/subgraphs.
- Not yet verified against the production subgraph endpoint (requires the gateway API key) — worth a quick smoke test on the Vercel preview with a rolled vote (there are currently four rolled votes live in round 10319, e.g. the Peruvian-election Polymarket disputes, which show Roll #0 results from round 10318).

🤖 Generated with [Claude Code](https://claude.com/claude-code)