### PR TITLE
feat: deeplinks to specific votes, with serverless resolution for external dapps

### DIFF
--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -19,10 +19,18 @@ export function Nav({ links }: Props) {
   const isActive = (href: string) => router.pathname === href;
 
   useEffect(() => {
-    router.events.on("routeChangeStart", closePanel);
+    // shallow changes are query-param-only updates (vote deeplinks) and must
+    // not close the panel they describe
+    function closePanelOnNavigation(
+      _url: string,
+      { shallow }: { shallow: boolean }
+    ) {
+      if (!shallow) closePanel();
+    }
+    router.events.on("routeChangeStart", closePanelOnNavigation);
 
     return () => {
-      router.events.off("routeChangeStart", closePanel);
+      router.events.off("routeChangeStart", closePanelOnNavigation);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/components/Pagination/Pagination.tsx
+++ b/components/Pagination/Pagination.tsx
@@ -50,7 +50,7 @@ export function usePagination<Entry>(entries: Entry[], findIndex?: number) {
 
   const getPageNumberOfItem = useCallback(
     function (itemIndex: number | undefined) {
-      if (!itemIndex) return;
+      if (itemIndex === undefined || itemIndex < 0) return;
       const pageNumber = Math.ceil((itemIndex + 1) / resultsPerPage);
 
       return pageNumber;
@@ -88,7 +88,7 @@ export function usePagination<Entry>(entries: Entry[], findIndex?: number) {
   }, [entries, updateEntries]);
 
   useEffect(() => {
-    if (!findIndex || findIndex === -1) return;
+    if (findIndex === undefined || findIndex === -1) return;
 
     const newPageNumber = getPageNumberOfItem(findIndex);
 

--- a/components/VoteDeeplinkHandler/VoteDeeplinkHandler.tsx
+++ b/components/VoteDeeplinkHandler/VoteDeeplinkHandler.tsx
@@ -1,0 +1,8 @@
+import { useVoteDeeplink } from "hooks";
+
+// Must render inside PanelProvider and VotesProvider; hooks cannot run in
+// MyApp itself because the providers are created there.
+export function VoteDeeplinkHandler() {
+  useVoteDeeplink();
+  return null;
+}

--- a/components/Votes/ActiveVotes.tsx
+++ b/components/Votes/ActiveVotes.tsx
@@ -21,7 +21,7 @@ import {
   useVoteTimingContext,
   useWalletContext,
 } from "hooks";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { VoteT } from "types";
 import {
   ButtonInnerWrapper,
@@ -55,7 +55,7 @@ export function ActiveVotes() {
   const { data: stakedBalance } = useStakedBalance(
     isDelegate ? delegatorAddress : address
   );
-  const { openPanel } = usePanelContext();
+  const { openPanel, registerVoteOpener } = usePanelContext();
   const [{ connecting: isConnectingWallet }, connect] = useConnectWallet();
   const { commitVotesMutation, isCommittingVotes } = useCommitVotes(address);
   const { revealVotesMutation, isRevealingVotes } = useRevealVotes(address);
@@ -294,6 +294,15 @@ export function ActiveVotes() {
   function selectVote(value: string | undefined, vote: VoteT) {
     setSelectedVotes((selected) => ({ ...selected, [vote.uniqueKey]: value }));
   }
+
+  // deeplinks open votes through this so the panel gets the same quick-vote
+  // wiring as the row's own more-details action
+  useEffect(() => {
+    return registerVoteOpener((vote, navigableVotes) =>
+      openPanel("vote", vote, { navigableVotes, selectedVotes, selectVote })
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedVotes, openPanel, registerVoteOpener]);
 
   function clearSelectedVote(vote: VoteT) {
     selectVote(undefined, vote);

--- a/components/index.ts
+++ b/components/index.ts
@@ -56,6 +56,7 @@ export { PanelErrorBanner } from "./PanelErrorBanner/PanelErrorBanner";
 export { Tabs } from "./Tabs/Tabs";
 export { Toggle } from "./Toggle/Toggle";
 export { Tooltip } from "./Tooltip/Tooltip";
+export { VoteDeeplinkHandler } from "./VoteDeeplinkHandler/VoteDeeplinkHandler";
 export { VoteHistoryTable } from "./VoteHistoryTable/VoteHistoryTable";
 export { VoteList } from "./VoteList/VoteList";
 export { VoteTableHeadings } from "./VoteList/VoteTableHeadings";

--- a/components/pages/PastVotes.tsx
+++ b/components/pages/PastVotes.tsx
@@ -9,6 +9,7 @@ import {
   usePagination,
 } from "components";
 import {
+  useDeeplinkedVoteIndex,
   usePanelContext,
   useVoteTimingContext,
   useVotesContext,
@@ -28,8 +29,10 @@ export function PastVotes() {
   const { openPanel } = usePanelContext();
   const { address } = useAccountDetails();
   const { delegatorAddress } = useDelegationContext();
+  const deeplinkedVoteIndex = useDeeplinkedVoteIndex(pastVoteList);
   const { showPagination, entriesToShow, ...paginationProps } = usePagination(
-    pastVoteList ?? []
+    pastVoteList ?? [],
+    deeplinkedVoteIndex
   );
 
   // Check if wallet is connected

--- a/components/pages/UpcomingVotes.tsx
+++ b/components/pages/UpcomingVotes.tsx
@@ -9,7 +9,12 @@ import {
   VoteList,
   usePagination,
 } from "components";
-import { usePanelContext, useVoteTimingContext, useVotesContext } from "hooks";
+import {
+  useDeeplinkedVoteIndex,
+  usePanelContext,
+  useVoteTimingContext,
+  useVotesContext,
+} from "hooks";
 import { isUndefined } from "lodash";
 import Image from "next/image";
 import noVotesIndicator from "public/assets/no-votes-indicator.png";
@@ -20,8 +25,10 @@ export function UpcomingVotes() {
   const { upcomingVoteList, upcomingVotesIsLoading } = useVotesContext();
   const { phase, millisecondsUntilPhaseEnds } = useVoteTimingContext();
   const { openPanel } = usePanelContext();
+  const deeplinkedVoteIndex = useDeeplinkedVoteIndex(upcomingVoteList);
   const { showPagination, entriesToShow, ...paginationProps } = usePagination(
-    upcomingVoteList ?? []
+    upcomingVoteList ?? [],
+    deeplinkedVoteIndex
   );
   const hasUpcomingVotes = !!upcomingVoteList && upcomingVoteList?.length > 0;
 

--- a/contexts/PanelContext.tsx
+++ b/contexts/PanelContext.tsx
@@ -8,9 +8,15 @@ import {
 } from "react";
 import { PanelTypeT, SelectedVotesByKeyT, VoteT } from "types";
 
-export function scrollToAndHighlightVote(uniqueKey: string) {
+export function scrollToAndHighlightVote(uniqueKey: string, attempt = 0) {
   const el = document.querySelector(`[data-vote-key="${uniqueKey}"]`);
-  if (!el) return;
+  if (!el) {
+    // deeplinked rows may still be mounting (list render, pagination jump)
+    if (attempt < 10) {
+      setTimeout(() => scrollToAndHighlightVote(uniqueKey, attempt + 1), 200);
+    }
+    return;
+  }
   el.scrollIntoView({ behavior: "smooth", block: "center" });
   el.classList.remove("vote-highlight");
   void (el as HTMLElement).offsetWidth;

--- a/contexts/PanelContext.tsx
+++ b/contexts/PanelContext.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import { PanelTypeT, SelectedVotesByKeyT, VoteT } from "types";
 
-function scrollToAndHighlightVote(uniqueKey: string) {
+export function scrollToAndHighlightVote(uniqueKey: string) {
   const el = document.querySelector(`[data-vote-key="${uniqueKey}"]`);
   if (!el) return;
   el.scrollIntoView({ behavior: "smooth", block: "center" });

--- a/contexts/PanelContext.tsx
+++ b/contexts/PanelContext.tsx
@@ -3,6 +3,7 @@ import {
   ReactNode,
   useCallback,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { PanelTypeT, SelectedVotesByKeyT, VoteT } from "types";
@@ -23,6 +24,8 @@ export type OpenPanelOptions = {
   selectVote?: (value: string | undefined, vote: VoteT) => void;
 };
 
+export type VoteOpener = (vote: VoteT, navigableVotes: VoteT[]) => void;
+
 export interface PanelContextState {
   panelType: PanelTypeT;
   panelContent: VoteT | undefined;
@@ -33,6 +36,8 @@ export interface PanelContextState {
     options?: OpenPanelOptions
   ) => void;
   closePanel: (clearPreviousPanelData?: boolean) => void;
+  openVote: VoteOpener;
+  registerVoteOpener: (opener: VoteOpener) => () => void;
   navigableVotes: VoteT[];
   currentVoteIndex: number;
   goToNextVote: () => void;
@@ -47,6 +52,8 @@ export const defaultPanelContextState: PanelContextState = {
   panelOpen: false,
   openPanel: () => null,
   closePanel: () => null,
+  openVote: () => null,
+  registerVoteOpener: () => () => null,
   navigableVotes: [],
   currentVoteIndex: -1,
   goToNextVote: () => null,
@@ -104,6 +111,29 @@ export function PanelProvider({ children }: { children: ReactNode }) {
       setSelectedVotes(options?.selectedVotes ?? {});
     },
     []
+  );
+
+  // pages with richer panel options (ActiveVotes passes selectedVotes and
+  // selectVote so the panel's quick-vote controls work) register an opener;
+  // deeplinks use it so a shared link opens the same panel a row click would
+  const voteOpenerRef = useRef<VoteOpener | null>(null);
+
+  const registerVoteOpener = useCallback((opener: VoteOpener) => {
+    voteOpenerRef.current = opener;
+    return () => {
+      if (voteOpenerRef.current === opener) voteOpenerRef.current = null;
+    };
+  }, []);
+
+  const openVote = useCallback<VoteOpener>(
+    (vote, navigableVotes) => {
+      if (voteOpenerRef.current) {
+        voteOpenerRef.current(vote, navigableVotes);
+      } else {
+        openPanel("vote", vote, { navigableVotes });
+      }
+    },
+    [openPanel]
   );
 
   const wrappedSelectVote = useCallback(
@@ -172,6 +202,8 @@ export function PanelProvider({ children }: { children: ReactNode }) {
       panelOpen,
       openPanel,
       closePanel,
+      openVote,
+      registerVoteOpener,
       navigableVotes,
       currentVoteIndex,
       goToNextVote,
@@ -182,6 +214,8 @@ export function PanelProvider({ children }: { children: ReactNode }) {
     [
       closePanel,
       openPanel,
+      openVote,
+      registerVoteOpener,
       panelContent,
       panelOpen,
       panelType,

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -25,6 +25,7 @@ export {
   defaultPanelContextState,
   PanelContext,
   PanelProvider,
+  scrollToAndHighlightVote,
 } from "./PanelContext";
 export type { PanelContextState } from "./PanelContext";
 export {

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -3,6 +3,7 @@ export { getIgnoredRequestToBeDelegateAddressesFromStorage } from "./delegation/
 export { calculateOutstandingRewards } from "./rewards/calculateOutstandingRewards";
 export { getCanUnstakeTime } from "./staking/getCanUnstakeTime";
 export { addOpacityToHsl } from "./util/addOpacityToHsl";
+export * from "./util/deeplink";
 export * from "./util/formatNumber";
 export { getEntriesForPage } from "./util/getEntriesForPage";
 export { handleNotifications } from "./util/handleNotifications";

--- a/helpers/util/deeplink.ts
+++ b/helpers/util/deeplink.ts
@@ -1,0 +1,90 @@
+import { ParsedUrlQuery } from "querystring";
+import { ActivityStatusT } from "types";
+
+// The voter dapp supports two deeplink forms, both as query params on any page:
+// 1. `?vote=<uniqueKey>` — canonical form, written to the URL bar whenever a
+//    vote panel is open, so copying the address bar shares the open vote.
+// 2. `?identifier=<string|bytes32Hex>&time=<unixSeconds>&ancillaryData=<0xHex>` —
+//    external form for other dapps (oracle dapp, explorer) that know the price
+//    request's on-chain fields but not our uniqueKey format. These are resolved
+//    to a uniqueKey via /api/resolve-deeplink, which also tolerates being given
+//    the L2-side ancillary data of a bridged request.
+export const voteDeeplinkQueryParam = "vote";
+export const externalDeeplinkQueryParams = [
+  "identifier",
+  "time",
+  "ancillaryData",
+] as const;
+
+export type ExternalVoteDeeplink = {
+  identifier: string;
+  time: number;
+  ancillaryData?: string;
+};
+
+export type ParsedVoteDeeplink =
+  | { form: "uniqueKey"; uniqueKey: string }
+  | ({ form: "external" } & ExternalVoteDeeplink);
+
+function getSingleParam(query: ParsedUrlQuery, key: string) {
+  const value = query[key];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function parseVoteDeeplink(
+  query: ParsedUrlQuery
+): ParsedVoteDeeplink | undefined {
+  const uniqueKey = getSingleParam(query, voteDeeplinkQueryParam);
+  if (uniqueKey) return { form: "uniqueKey", uniqueKey };
+
+  const identifier = getSingleParam(query, "identifier");
+  const time = Number(getSingleParam(query, "time"));
+  if (!identifier || !Number.isInteger(time) || time <= 0) return undefined;
+
+  return {
+    form: "external",
+    identifier,
+    time,
+    ancillaryData: getSingleParam(query, "ancillaryData"),
+  };
+}
+
+export type ResolvedVoteDeeplink = {
+  uniqueKey: string;
+  activityStatus: ActivityStatusT;
+};
+
+export const pathForActivityStatus: Record<ActivityStatusT, string> = {
+  active: "/",
+  upcoming: "/upcoming-votes",
+  past: "/past-votes",
+};
+
+/**
+ * Builds a URL that opens the voter dapp with the details panel for a specific
+ * price request. This is the canonical link-builder for other dapps (oracle
+ * dapp, explorer) — copy it as-is, it has no dependencies.
+ *
+ * @param identifier decoded identifier ("YES_OR_NO_QUERY") or bytes32 hex
+ * @param time request timestamp in unix seconds
+ * @param ancillaryData 0x-prefixed hex; the DVM (mainnet) ancillary data if you
+ *   have it, but the L2/oracle-side data of a bridged request also resolves
+ * @param baseUrl defaults to production; pass e.g. "https://testnet.vote.uma.xyz"
+ */
+export function makeVoterDappDeeplink({
+  identifier,
+  time,
+  ancillaryData,
+  baseUrl = "https://vote.uma.xyz",
+}: {
+  identifier: string;
+  time: number | string;
+  ancillaryData?: string;
+  baseUrl?: string;
+}): string {
+  const params = new URLSearchParams({ identifier, time: String(time) });
+  if (ancillaryData && ancillaryData !== "0x") {
+    params.set("ancillaryData", ancillaryData);
+  }
+  return `${baseUrl}/?${params.toString()}`;
+}

--- a/helpers/util/deeplink.ts
+++ b/helpers/util/deeplink.ts
@@ -4,22 +4,26 @@ import { ActivityStatusT } from "types";
 // The voter dapp supports two deeplink forms, both as query params on any page:
 // 1. `?vote=<uniqueKey>` — canonical form, written to the URL bar whenever a
 //    vote panel is open, so copying the address bar shares the open vote.
-// 2. `?identifier=<string|bytes32Hex>&time=<unixSeconds>&ancillaryData=<0xHex>` —
+// 2. `?identifier=<string|bytes32Hex>&time=<unixSeconds>&ancillaryDataHash=<0xHash>` —
 //    external form for other dapps (oracle dapp, explorer) that know the price
-//    request's on-chain fields but not our uniqueKey format. These are resolved
-//    to a uniqueKey via /api/resolve-deeplink, which also tolerates being given
-//    the L2-side ancillary data of a bridged request.
+//    request's on-chain fields but not our uniqueKey format. The hash is
+//    keccak256 of whichever ancillary data version the caller holds (raw
+//    request data, stamped, or DVM-side); /api/resolve-deeplink matches it
+//    against every variant it can reconstruct. Full `ancillaryData` is also
+//    accepted, but ancillary data is often far too long for a URL.
 export const voteDeeplinkQueryParam = "vote";
 export const externalDeeplinkQueryParams = [
   "identifier",
   "time",
   "ancillaryData",
+  "ancillaryDataHash",
 ] as const;
 
 export type ExternalVoteDeeplink = {
   identifier: string;
   time: number;
   ancillaryData?: string;
+  ancillaryDataHash?: string;
 };
 
 export type ParsedVoteDeeplink =
@@ -46,6 +50,7 @@ export function parseVoteDeeplink(
     identifier,
     time,
     ancillaryData: getSingleParam(query, "ancillaryData"),
+    ancillaryDataHash: getSingleParam(query, "ancillaryDataHash"),
   };
 }
 
@@ -67,23 +72,32 @@ export const pathForActivityStatus: Record<ActivityStatusT, string> = {
  *
  * @param identifier decoded identifier ("YES_OR_NO_QUERY") or bytes32 hex
  * @param time request timestamp in unix seconds
- * @param ancillaryData 0x-prefixed hex; the DVM (mainnet) ancillary data if you
- *   have it, but the L2/oracle-side data of a bridged request also resolves
+ * @param ancillaryDataHash keccak256 of the request's ancillary data, e.g.
+ *   `ethers.utils.keccak256(request.ancillaryData)`. Hash whichever version
+ *   you have — the raw request data, the oracle-stamped data, or the DVM-side
+ *   data all resolve. Strongly recommended: identifier+time alone is
+ *   ambiguous when several requests share a timestamp.
+ * @param ancillaryData full 0x-hex ancillary data; only use when it is short,
+ *   URLs have length limits
  * @param baseUrl defaults to production; pass e.g. "https://testnet.vote.uma.xyz"
  */
 export function makeVoterDappDeeplink({
   identifier,
   time,
+  ancillaryDataHash,
   ancillaryData,
   baseUrl = "https://vote.uma.xyz",
 }: {
   identifier: string;
   time: number | string;
+  ancillaryDataHash?: string;
   ancillaryData?: string;
   baseUrl?: string;
 }): string {
   const params = new URLSearchParams({ identifier, time: String(time) });
-  if (ancillaryData && ancillaryData !== "0x") {
+  if (ancillaryDataHash) {
+    params.set("ancillaryDataHash", ancillaryDataHash);
+  } else if (ancillaryData && ancillaryData !== "0x") {
     params.set("ancillaryData", ancillaryData);
   }
   return `${baseUrl}/?${params.toString()}`;

--- a/helpers/util/deeplink.ts
+++ b/helpers/util/deeplink.ts
@@ -97,7 +97,9 @@ export function makeVoterDappDeeplink({
   const params = new URLSearchParams({ identifier, time: String(time) });
   if (ancillaryDataHash) {
     params.set("ancillaryDataHash", ancillaryDataHash);
-  } else if (ancillaryData && ancillaryData !== "0x") {
+  } else if (ancillaryData) {
+    // keep "0x" — blank ancillary data still narrows resolution to a direct
+    // uniqueKey lookup when several requests share identifier and time
     params.set("ancillaryData", ancillaryData);
   }
   return `${baseUrl}/?${params.toString()}`;

--- a/hooks/helpers/useDeeplinkedVoteIndex.ts
+++ b/hooks/helpers/useDeeplinkedVoteIndex.ts
@@ -1,0 +1,39 @@
+import { voteDeeplinkQueryParam } from "helpers/util/deeplink";
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useRef } from "react";
+import { VoteT } from "types";
+
+/**
+ * Index of the vote a `?vote=` deeplink points to within the given list, for
+ * driving `usePagination(votes, findIndex)` to the vote's page. Reported once
+ * per key — afterwards it returns undefined so the user can page freely while
+ * the panel (and its URL param) stays open.
+ */
+export function useDeeplinkedVoteIndex(votes: VoteT[] | undefined) {
+  const router = useRouter();
+  const appliedKeyRef = useRef<string>();
+  const value = router.query[voteDeeplinkQueryParam];
+  const targetKey = router.isReady
+    ? Array.isArray(value)
+      ? value[0]
+      : value
+    : undefined;
+
+  const index = useMemo(() => {
+    if (!targetKey || appliedKeyRef.current === targetKey || !votes?.length) {
+      return undefined;
+    }
+    const found = votes.findIndex(({ uniqueKey }) => uniqueKey === targetKey);
+    return found === -1 ? undefined : found;
+  }, [targetKey, votes]);
+
+  useEffect(() => {
+    if (!targetKey) {
+      appliedKeyRef.current = undefined;
+    } else if (index !== undefined) {
+      appliedKeyRef.current = targetKey;
+    }
+  }, [index, targetKey]);
+
+  return index;
+}

--- a/hooks/helpers/useVoteDeeplink.ts
+++ b/hooks/helpers/useVoteDeeplink.ts
@@ -43,7 +43,7 @@ function notifyVoteNotFound() {
  */
 export function useVoteDeeplink() {
   const router = useRouter();
-  const { panelType, panelContent, panelOpen, openPanel, closePanel } =
+  const { panelType, panelContent, panelOpen, openVote, closePanel } =
     usePanelContext();
   const {
     voteListsByActivityStatus,
@@ -143,7 +143,8 @@ export function useVoteDeeplink() {
 
     for (const status of activityStatuses) {
       const votes = voteListsByActivityStatus[status];
-      const vote = votes?.find(({ uniqueKey }) => uniqueKey === targetKey);
+      if (!votes) continue;
+      const vote = votes.find(({ uniqueKey }) => uniqueKey === targetKey);
       if (!vote) continue;
 
       const pathname = pathForActivityStatus[status];
@@ -154,7 +155,7 @@ export function useVoteDeeplink() {
         return;
       }
       handledKeyRef.current = targetKey;
-      openPanel("vote", vote, { navigableVotes: votes });
+      openVote(vote, votes);
       scrollToAndHighlightVote(targetKey);
       return;
     }

--- a/hooks/helpers/useVoteDeeplink.ts
+++ b/hooks/helpers/useVoteDeeplink.ts
@@ -92,7 +92,9 @@ export function useVoteDeeplink() {
         identifier: external.identifier,
         time: String(external.time),
       });
-      if (external.ancillaryData) {
+      if (external.ancillaryDataHash) {
+        params.set("ancillaryDataHash", external.ancillaryDataHash);
+      } else if (external.ancillaryData) {
         params.set("ancillaryData", external.ancillaryData);
       }
       const response = await fetch(

--- a/hooks/helpers/useVoteDeeplink.ts
+++ b/hooks/helpers/useVoteDeeplink.ts
@@ -1,0 +1,228 @@
+import { useQuery } from "@tanstack/react-query";
+import { scrollToAndHighlightVote } from "contexts";
+import { emitErrorEvent } from "helpers";
+import {
+  externalDeeplinkQueryParams,
+  parseVoteDeeplink,
+  pathForActivityStatus,
+  ResolvedVoteDeeplink,
+  voteDeeplinkQueryParam,
+} from "helpers/util/deeplink";
+import { usePanelContext } from "hooks/contexts/usePanelContext";
+import { useVotesContext } from "hooks/contexts/useVotesContext";
+import { useRouter } from "next/router";
+import { ParsedUrlQuery } from "querystring";
+import { useEffect, useRef } from "react";
+import { ActivityStatusT } from "types";
+
+const activityStatuses: ActivityStatusT[] = ["active", "upcoming", "past"];
+
+function getVoteParam(query: ParsedUrlQuery) {
+  const value = query[voteDeeplinkQueryParam];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function notifyVoteNotFound() {
+  emitErrorEvent({
+    message: "Unable to find the vote this link points to.",
+    pendingId: "vote-deeplink-error",
+  });
+}
+
+/**
+ * Two-way sync between the URL and the vote details panel:
+ * - inbound `?vote=` / `?identifier=&time=&ancillaryData=` params open the
+ *   panel on the correct page once vote data is available
+ * - an open vote panel writes `?vote=<uniqueKey>` to the address bar (shallow,
+ *   so the panel survives), making the URL itself the shareable deeplink
+ *
+ * The URL-sync effect acts on TRANSITIONS (panel just opened/closed, param
+ * just disappeared), never on plain state. Effects in one commit see sibling
+ * state updates and router changes with a delay, so state-based conditions
+ * here misfire and fight each other (open panel <-> strip param loops).
+ */
+export function useVoteDeeplink() {
+  const router = useRouter();
+  const { panelType, panelContent, panelOpen, openPanel, closePanel } =
+    usePanelContext();
+  const {
+    voteListsByActivityStatus,
+    activeVotesIsLoading,
+    upcomingVotesIsLoading,
+    pastVotesIsLoading,
+  } = useVotesContext();
+
+  const parsed = router.isReady ? parseVoteDeeplink(router.query) : undefined;
+  const external = parsed?.form === "external" ? parsed : undefined;
+  const targetKey = parsed?.form === "uniqueKey" ? parsed.uniqueKey : undefined;
+
+  // the key we already acted on, so the open-effect runs once per inbound link
+  const handledKeyRef = useRef<string>();
+  // previous values, so the URL-sync effect can detect transitions
+  const prevOpenKeyRef = useRef<string>();
+  const prevParamRef = useRef<string>();
+  // during a real page navigation we must not fire shallow replaces to clean
+  // up params — they would abort the navigation, and the destination route
+  // doesn't carry the param anyway
+  const navigatingRef = useRef(false);
+
+  useEffect(() => {
+    function handleStart(_url: string, { shallow }: { shallow: boolean }) {
+      if (!shallow) navigatingRef.current = true;
+    }
+    function handleSettled() {
+      navigatingRef.current = false;
+    }
+    router.events.on("routeChangeStart", handleStart);
+    router.events.on("routeChangeComplete", handleSettled);
+    router.events.on("routeChangeError", handleSettled);
+    return () => {
+      router.events.off("routeChangeStart", handleStart);
+      router.events.off("routeChangeComplete", handleSettled);
+      router.events.off("routeChangeError", handleSettled);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const { data: resolved, isError: resolveFailed } = useQuery({
+    queryKey: ["resolveDeeplink", external],
+    queryFn: async (): Promise<ResolvedVoteDeeplink> => {
+      if (!external) throw new Error("no deeplink params");
+      const params = new URLSearchParams({
+        identifier: external.identifier,
+        time: String(external.time),
+      });
+      if (external.ancillaryData) {
+        params.set("ancillaryData", external.ancillaryData);
+      }
+      const response = await fetch(
+        `/api/resolve-deeplink?${params.toString()}`
+      );
+      if (!response.ok) throw new Error("Deeplink resolution failed");
+      return (await response.json()) as ResolvedVoteDeeplink;
+    },
+    enabled: !!external,
+    staleTime: Infinity,
+    retry: 1,
+  });
+
+  // rewrite external params to the canonical `?vote=` form on the right page
+  useEffect(() => {
+    if (!external) return;
+    if (resolveFailed) {
+      notifyVoteNotFound();
+      return;
+    }
+    if (!resolved) return;
+    const pathname = pathForActivityStatus[resolved.activityStatus];
+    const query = { ...router.query };
+    externalDeeplinkQueryParams.forEach((param) => delete query[param]);
+    query[voteDeeplinkQueryParam] = resolved.uniqueKey;
+    void router.replace({ pathname, query }, undefined, {
+      shallow: pathname === router.pathname,
+      scroll: false,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [external?.identifier, external?.time, resolved, resolveFailed]);
+
+  // inbound `?vote=<uniqueKey>`: find the vote, switch pages if needed, open
+  useEffect(() => {
+    if (!targetKey || handledKeyRef.current === targetKey) return;
+
+    if (
+      panelOpen &&
+      panelType === "vote" &&
+      panelContent?.uniqueKey === targetKey
+    ) {
+      // the panel wrote this param itself, nothing to do
+      handledKeyRef.current = targetKey;
+      return;
+    }
+
+    for (const status of activityStatuses) {
+      const votes = voteListsByActivityStatus[status];
+      const vote = votes?.find(({ uniqueKey }) => uniqueKey === targetKey);
+      if (!vote) continue;
+
+      const pathname = pathForActivityStatus[status];
+      if (router.pathname !== pathname) {
+        void router.replace({ pathname, query: router.query }, undefined, {
+          scroll: false,
+        });
+        return;
+      }
+      handledKeyRef.current = targetKey;
+      openPanel("vote", vote, { navigableVotes: votes });
+      scrollToAndHighlightVote(targetKey);
+      return;
+    }
+
+    const stillLoading =
+      activeVotesIsLoading || upcomingVotesIsLoading || pastVotesIsLoading;
+    if (!stillLoading) {
+      handledKeyRef.current = targetKey;
+      notifyVoteNotFound();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    targetKey,
+    router.pathname,
+    panelOpen,
+    panelType,
+    panelContent,
+    voteListsByActivityStatus,
+    activeVotesIsLoading,
+    upcomingVotesIsLoading,
+    pastVotesIsLoading,
+  ]);
+
+  // keep the URL in sync with the panel, reacting only to transitions
+  useEffect(() => {
+    if (!router.isReady) return;
+    const param = getVoteParam(router.query);
+    const openKey =
+      panelOpen && panelType === "vote" ? panelContent?.uniqueKey : undefined;
+    const prevOpenKey = prevOpenKeyRef.current;
+    const prevParam = prevParamRef.current;
+    prevOpenKeyRef.current = openKey;
+    prevParamRef.current = param;
+
+    // panel just opened or switched to another vote -> write the param;
+    // push (not replace) so the browser back button closes the panel
+    if (openKey && openKey !== prevOpenKey) {
+      handledKeyRef.current = openKey;
+      if (param !== openKey) {
+        const query = { ...router.query };
+        externalDeeplinkQueryParams.forEach((key) => delete query[key]);
+        query[voteDeeplinkQueryParam] = openKey;
+        void router.push({ pathname: router.pathname, query }, undefined, {
+          shallow: true,
+          scroll: false,
+        });
+      }
+      return;
+    }
+
+    // panel just closed -> remove the param
+    if (!openKey && prevOpenKey) {
+      handledKeyRef.current = undefined;
+      if (param && !navigatingRef.current) {
+        const query = { ...router.query };
+        delete query[voteDeeplinkQueryParam];
+        void router.replace({ pathname: router.pathname, query }, undefined, {
+          shallow: true,
+          scroll: false,
+        });
+      }
+      return;
+    }
+
+    // param just disappeared while the panel is open (back button) -> close
+    if (openKey && !param && prevParam) {
+      handledKeyRef.current = undefined;
+      prevOpenKeyRef.current = undefined;
+      closePanel(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [panelOpen, panelType, panelContent, router.isReady, router.query]);
+}

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -6,6 +6,7 @@ export { usePanelContext } from "./contexts/usePanelContext";
 export { useVoteTimingContext } from "./contexts/useVoteTimingContext";
 export { useVotesContext } from "./contexts/useVotesContext";
 export { useWalletContext } from "./contexts/useWalletContext";
+export { useDeeplinkedVoteIndex } from "./helpers/useDeeplinkedVoteIndex";
 export { useHandleDecimalInput } from "./helpers/useHandleDecimalInput";
 export { useHandleError } from "./helpers/useHandleError";
 export { useInitializeVoteTiming } from "./helpers/useInitializeVoteTiming";

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -15,6 +15,7 @@ export { useMounted } from "./helpers/useMounted";
 export { usePanelWidth } from "./helpers/usePanelWidth";
 export { usePersistedVotes } from "./helpers/usePersistedVotes";
 export { useSign } from "./helpers/useSign";
+export { useVoteDeeplink } from "./helpers/useVoteDeeplink";
 export { useVotePanelKeyboard } from "./helpers/useVotePanelKeyboard";
 export { useWindowSize } from "./helpers/useWindowSize";
 export { useAcceptReceivedRequestToBeDelegate } from "./mutations/delegation/useAcceptReceivedRequestToBeDelegate";

--- a/lib/l2-ancillary-data.ts
+++ b/lib/l2-ancillary-data.ts
@@ -66,7 +66,7 @@ export interface ResolveAncillaryDataResult {
   resolvedAncillaryData: string;
 }
 
-function extractMaybeAncillaryDataFields(decodedAncillaryData: string) {
+export function extractMaybeAncillaryDataFields(decodedAncillaryData: string) {
   const pattern = new RegExp(
     "^" +
       "ancillaryDataHash:(\\w+),\\s*" +
@@ -99,7 +99,7 @@ function mergeAncillaryData(
   return encodeHexString(merged);
 }
 
-async function fetchAncillaryDataFromSpoke(args: {
+export async function fetchAncillaryDataFromSpoke(args: {
   parentRequestId: BytesLike;
   childOracle: string;
   childChainId: number;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { GlobalStyle, Notifications, Panel } from "components";
+import {
+  GlobalStyle,
+  Notifications,
+  Panel,
+  VoteDeeplinkHandler,
+} from "components";
 import {
   ContractsProvider,
   DelegationProvider,
@@ -33,6 +38,7 @@ function MyApp({ Component, pageProps }: AppProps) {
                       <GlobalStyle />
                       <Component {...pageProps} />
                       <Panel />
+                      <VoteDeeplinkHandler />
                       <Notifications />
                       {config.gaTag && <GoogleAnalytics gaId={config.gaTag} />}
                     </PanelProvider>

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -24,7 +24,10 @@ const RequestParams = ss.union([
   ss.object({
     identifier: ss.string(),
     time: ss.coerce(ss.integer(), ss.string(), (value) => Number(value)),
-    ancillaryData: ss.optional(ss.pattern(ss.string(), /^0x[0-9a-fA-F]*$/)),
+    ancillaryData: ss.optional(
+      // even-length so keccak256 cannot throw on odd-length hex
+      ss.pattern(ss.string(), /^0x([0-9a-fA-F]{2})*$/)
+    ),
     ancillaryDataHash: ss.optional(Bytes32Hash),
   }),
 ]);
@@ -248,17 +251,25 @@ async function resolveEntity(
   }
 
   const candidates = await findCandidatesByDetails(decodedIdentifier, time);
-  if (ancillaryDataHash) {
-    const byHash = await pickByAncillaryDataHash(
-      candidates,
-      decodedIdentifier,
-      ancillaryDataHash
-    );
-    if (byHash) return byHash;
-  }
   if (ancillaryData && ancillaryData !== "0x") {
     const byData = pickByFullAncillaryData(candidates, ancillaryData);
     if (byData) return byData;
+  }
+  // full ancillary data degrades to its hash so both forms resolve the same
+  // requests — the hash matcher covers bridged variants that need the child
+  // chain's event data
+  const hash =
+    ancillaryDataHash ??
+    (ancillaryData && ancillaryData !== "0x"
+      ? keccak256(ancillaryData.toLowerCase())
+      : undefined);
+  if (hash) {
+    const byHash = await pickByAncillaryDataHash(
+      candidates,
+      decodedIdentifier,
+      hash
+    );
+    if (byHash) return byHash;
   }
   return candidates.length === 1 ? candidates[0] : undefined;
 }

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -1,7 +1,12 @@
-import { utils } from "ethers";
 import { gql, request as gqlRequest } from "graphql-request";
-import { decodeHexString } from "helpers/web3/decodeHexString";
+import { decodeHexString, encodeHexString } from "helpers/web3/decodeHexString";
 import { makeUniqueKeyForVote } from "helpers/voting/makeUniqueKeyForVote";
+import {
+  extractMaybeAncillaryDataFields,
+  fetchAncillaryDataFromSpoke,
+} from "lib/l2-ancillary-data";
+import { defaultAbiCoder, keccak256 } from "ethers/lib/utils";
+import { formatBytes32String } from "helpers/web3/ethers";
 import { NextApiRequest, NextApiResponse } from "next";
 import * as ss from "superstruct";
 import { ActivityStatusT } from "types";
@@ -12,12 +17,15 @@ import { validateQueryParams } from "./_utils/validation";
 const phaseLength = Number(process.env.NEXT_PUBLIC_PHASE_LENGTH || 86400);
 const roundLength = phaseLength * 2;
 
+const Bytes32Hash = ss.pattern(ss.string(), /^0x[0-9a-fA-F]{64}$/);
+
 const RequestParams = ss.union([
   ss.object({ vote: ss.string() }),
   ss.object({
     identifier: ss.string(),
     time: ss.coerce(ss.integer(), ss.string(), (value) => Number(value)),
     ancillaryData: ss.optional(ss.pattern(ss.string(), /^0x[0-9a-fA-F]*$/)),
+    ancillaryDataHash: ss.optional(Bytes32Hash),
   }),
 ]);
 
@@ -60,10 +68,9 @@ async function findByUniqueKey(uniqueKey: string) {
   return result.priceRequest;
 }
 
-async function findByDetails(
+async function findCandidatesByDetails(
   decodedIdentifier: string,
-  time: number,
-  ancillaryData: string | undefined
+  time: number
 ) {
   const query = gql`
     ${priceRequestFields}
@@ -73,14 +80,16 @@ async function findByDetails(
       }
     }
   `;
-  const { priceRequests: candidates } = await gqlRequest<{
+  const { priceRequests } = await gqlRequest<{
     priceRequests: PriceRequestEntity[];
   }>(VoteSubgraphURL, query, { identifier: decodedIdentifier, time });
+  return priceRequests;
+}
 
-  if (!ancillaryData || ancillaryData === "0x") {
-    return candidates.length === 1 ? candidates[0] : undefined;
-  }
-
+function pickByFullAncillaryData(
+  candidates: PriceRequestEntity[],
+  ancillaryData: string
+) {
   const normalized = ancillaryData.toLowerCase();
   const exact = candidates.find(
     (candidate) => candidate.ancillaryData?.toLowerCase() === normalized
@@ -98,7 +107,7 @@ async function findByDetails(
   // Requests bridged via AncillaryDataCompression replace the data with
   // `ancillaryDataHash:<keccak256(childData)>,childBlockNumber:...`, so match
   // the hash of the provided data against the compressed form.
-  const providedDataHash = utils.keccak256(normalized).slice(2);
+  const providedDataHash = keccak256(normalized).slice(2);
   const compressed = candidates.filter((candidate) =>
     decodeAncillaryDataSafe(candidate.ancillaryData)?.startsWith(
       `ancillaryDataHash:${providedDataHash},`
@@ -106,7 +115,24 @@ async function findByDetails(
   );
   if (compressed.length === 1) return compressed[0];
 
-  return candidates.length === 1 ? candidates[0] : undefined;
+  return undefined;
+}
+
+const OO_REQUESTER_STAMP = encodeHexString(",ooRequester:").slice(2);
+
+// The stamp is appended as the final key-value pair, so stripping from its
+// last occurrence recovers the pre-stamp bytes.
+function stripOoRequesterStamp(dataHex: string) {
+  const index = dataHex.toLowerCase().lastIndexOf(OO_REQUESTER_STAMP);
+  return index === -1 ? undefined : dataHex.slice(0, index);
+}
+
+function hashesOfHex(dataHex: string | undefined) {
+  if (!dataHex || dataHex === "0x") return [];
+  const hashes = [keccak256(dataHex)];
+  const stripped = stripOoRequesterStamp(dataHex);
+  if (stripped && stripped !== "0x") hashes.push(keccak256(stripped));
+  return hashes;
 }
 
 function decodeAncillaryDataSafe(ancillaryData: string | null) {
@@ -116,6 +142,74 @@ function decodeAncillaryDataSafe(ancillaryData: string | null) {
   } catch {
     return undefined;
   }
+}
+
+// Callers hash whichever ancillary data version they hold, so compare against
+// every variant reconstructable for this candidate: the DVM-side data, the
+// pre-stamp form of it, the compressed hash reference, and (via the bridge
+// event) the child-side data and its pre-stamp form.
+async function candidateMatchesHash(
+  candidate: PriceRequestEntity,
+  decodedIdentifier: string,
+  hash: string
+): Promise<boolean> {
+  const mainnetData = candidate.ancillaryData ?? "0x";
+  const normalizedHash = hash.toLowerCase();
+
+  if (
+    hashesOfHex(mainnetData).some((h) => h.toLowerCase() === normalizedHash)
+  ) {
+    return true;
+  }
+
+  const decoded = decodeAncillaryDataSafe(mainnetData);
+  if (!decoded) return false;
+  const { ancillaryDataHash, childOracle, childChainId, childBlockNumber } =
+    extractMaybeAncillaryDataFields(decoded);
+  if (!ancillaryDataHash || !childOracle || !childChainId || !childBlockNumber)
+    return false;
+
+  // hash of the stamped child data is embedded in the compressed form
+  if (`0x${ancillaryDataHash.toLowerCase()}` === normalizedHash) return true;
+
+  try {
+    const childData = await fetchAncillaryDataFromSpoke({
+      parentRequestId: keccak256(
+        defaultAbiCoder.encode(
+          ["bytes32", "uint256", "bytes"],
+          [formatBytes32String(decodedIdentifier), candidate.time, mainnetData]
+        )
+      ),
+      childOracle: `0x${childOracle}`,
+      childChainId: Number(childChainId),
+      childBlockNumber: Number(childBlockNumber),
+    });
+    return hashesOfHex(childData).some(
+      (h) => h.toLowerCase() === normalizedHash
+    );
+  } catch (error) {
+    console.warn("Unable to fetch child ancillary data for hash match", {
+      candidate: candidate.id,
+      cause: error,
+    });
+    return false;
+  }
+}
+
+async function pickByAncillaryDataHash(
+  candidates: PriceRequestEntity[],
+  decodedIdentifier: string,
+  hash: string
+) {
+  const matches = (
+    await Promise.all(
+      candidates.map(async (candidate) => ({
+        candidate,
+        matched: await candidateMatchesHash(candidate, decodedIdentifier, hash),
+      }))
+    )
+  ).filter(({ matched }) => matched);
+  return matches.length === 1 ? matches[0].candidate : undefined;
 }
 
 // The subgraph identifier id is the decoded string ("YES_OR_NO_QUERY"), but
@@ -134,6 +228,41 @@ function getActivityStatus(entity: PriceRequestEntity): ActivityStatusT {
   return latestRoundId > currentRoundId ? "upcoming" : "active";
 }
 
+async function resolveEntity(
+  params: ss.Infer<typeof RequestParams>
+): Promise<PriceRequestEntity | null | undefined> {
+  if ("vote" in params) return findByUniqueKey(params.vote);
+
+  const decodedIdentifier = normalizeIdentifier(params.identifier);
+  const { time, ancillaryData, ancillaryDataHash } = params;
+
+  // when the caller's data or hash corresponds to the DVM-side data, the
+  // uniqueKey is directly constructible — single cheap lookup
+  const directHash = ancillaryDataHash ?? undefined;
+  if (ancillaryData || directHash) {
+    const uniqueKey = ancillaryData
+      ? makeUniqueKeyForVote(decodedIdentifier, time, ancillaryData)
+      : `${decodedIdentifier}-${time}-${directHash?.toLowerCase() ?? ""}`;
+    const direct = await findByUniqueKey(uniqueKey);
+    if (direct) return direct;
+  }
+
+  const candidates = await findCandidatesByDetails(decodedIdentifier, time);
+  if (ancillaryDataHash) {
+    const byHash = await pickByAncillaryDataHash(
+      candidates,
+      decodedIdentifier,
+      ancillaryDataHash
+    );
+    if (byHash) return byHash;
+  }
+  if (ancillaryData && ancillaryData !== "0x") {
+    const byData = pickByFullAncillaryData(candidates, ancillaryData);
+    if (byData) return byData;
+  }
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
 export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
@@ -143,27 +272,7 @@ export default async function handler(
       throw new HttpError({ statusCode: 405 });
     }
     const params = validateQueryParams(request.query, RequestParams);
-
-    let entity: PriceRequestEntity | null | undefined;
-    if ("vote" in params) {
-      entity = await findByUniqueKey(params.vote);
-    } else {
-      const decodedIdentifier = normalizeIdentifier(params.identifier);
-      if (params.ancillaryData) {
-        entity = await findByUniqueKey(
-          makeUniqueKeyForVote(
-            decodedIdentifier,
-            params.time,
-            params.ancillaryData
-          )
-        );
-      }
-      entity ??= await findByDetails(
-        decodedIdentifier,
-        params.time,
-        params.ancillaryData
-      );
-    }
+    const entity = await resolveEntity(params);
 
     if (!entity || entity.isDeleted) {
       throw new HttpError({ statusCode: 404, msg: "Vote not found" });

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -124,11 +124,17 @@ function pickByFullAncillaryData(
   if (exact) return exact;
 
   // Requests reaching the DVM from an oracle contract have the original
-  // ancillary data "stamped" (suffixed with ooRequester/childChainId), so the
-  // requesting side's data is a byte-prefix of what the DVM stores.
-  const stamped = candidates.filter((candidate) =>
-    candidate.ancillaryData?.toLowerCase().startsWith(normalized)
-  );
+  // ancillary data "stamped", so the requesting side's data is a byte-prefix
+  // of what the DVM stores. Requiring the remainder to be the stamp prevents
+  // an unrelated same-batch request that merely begins with the same bytes
+  // from stealing the match.
+  const stamped = candidates.filter((candidate) => {
+    const data = candidate.ancillaryData?.toLowerCase();
+    return (
+      data?.startsWith(normalized) &&
+      data.slice(normalized.length).startsWith(OO_REQUESTER_STAMP)
+    );
+  });
   if (stamped.length === 1) return stamped[0];
 
   // Requests bridged via AncillaryDataCompression replace the data with

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -71,22 +71,46 @@ async function findByUniqueKey(uniqueKey: string) {
   return result.priceRequest;
 }
 
+// paginated like fetchAllDocuments so large same-timestamp batches cannot
+// truncate the candidate set before matching
 async function findCandidatesByDetails(
   decodedIdentifier: string,
   time: number
 ) {
   const query = gql`
     ${priceRequestFields}
-    query resolveDeeplinkSearch($identifier: String!, $time: BigInt!) {
-      priceRequests(where: { identifier: $identifier, time: $time }) {
+    query resolveDeeplinkSearch(
+      $identifier: String!
+      $time: BigInt!
+      $skip: Int!
+      $limit: Int!
+    ) {
+      priceRequests(
+        where: { identifier: $identifier, time: $time }
+        first: $limit
+        skip: $skip
+      ) {
         ...DeeplinkFields
       }
     }
   `;
-  const { priceRequests } = await gqlRequest<{
-    priceRequests: PriceRequestEntity[];
-  }>(VoteSubgraphURL, query, { identifier: decodedIdentifier, time });
-  return priceRequests;
+  const pageSize = 1000;
+  let allCandidates: PriceRequestEntity[] = [];
+  let page: PriceRequestEntity[];
+  let skip = 0;
+  do {
+    ({ priceRequests: page } = await gqlRequest<{
+      priceRequests: PriceRequestEntity[];
+    }>(VoteSubgraphURL, query, {
+      identifier: decodedIdentifier,
+      time,
+      skip,
+      limit: pageSize,
+    }));
+    allCandidates = allCandidates.concat(page);
+    skip += pageSize;
+  } while (page.length === pageSize);
+  return allCandidates;
 }
 
 function pickByFullAncillaryData(

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -163,8 +163,11 @@ function stripOoRequesterStamp(dataHex: string) {
 function hashesOfHex(dataHex: string | undefined) {
   if (!dataHex || dataHex === "0x") return [];
   const hashes = [keccak256(dataHex)];
+  // a stripped value of "0x" is still meaningful: an OO request with blank
+  // caller ancillary data is stamped to just `,ooRequester:<addr>`, and links
+  // built from the raw request bytes hash the empty data
   const stripped = stripOoRequesterStamp(dataHex);
-  if (stripped && stripped !== "0x") hashes.push(keccak256(stripped));
+  if (stripped) hashes.push(keccak256(stripped));
   return hashes;
 }
 
@@ -287,12 +290,10 @@ async function resolveEntity(
   }
   // full ancillary data degrades to its hash so both forms resolve the same
   // requests — the hash matcher covers bridged variants that need the child
-  // chain's event data
+  // chain's event data, and blank data ("0x") matches stamped-blank requests
   const hash =
     ancillaryDataHash ??
-    (ancillaryData && ancillaryData !== "0x"
-      ? keccak256(ancillaryData.toLowerCase())
-      : undefined);
+    (ancillaryData ? keccak256(ancillaryData.toLowerCase()) : undefined);
   if (hash) {
     const byHash = await pickByAncillaryDataHash(
       candidates,

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -1,0 +1,183 @@
+import { utils } from "ethers";
+import { gql, request as gqlRequest } from "graphql-request";
+import { decodeHexString } from "helpers/web3/decodeHexString";
+import { makeUniqueKeyForVote } from "helpers/voting/makeUniqueKeyForVote";
+import { NextApiRequest, NextApiResponse } from "next";
+import * as ss from "superstruct";
+import { ActivityStatusT } from "types";
+import { VoteSubgraphURL } from "./_common";
+import { handleApiError, HttpError } from "./_utils/errors";
+import { validateQueryParams } from "./_utils/validation";
+
+const phaseLength = Number(process.env.NEXT_PUBLIC_PHASE_LENGTH || 86400);
+const roundLength = phaseLength * 2;
+
+const RequestParams = ss.union([
+  ss.object({ vote: ss.string() }),
+  ss.object({
+    identifier: ss.string(),
+    time: ss.coerce(ss.integer(), ss.string(), (value) => Number(value)),
+    ancillaryData: ss.optional(ss.pattern(ss.string(), /^0x[0-9a-fA-F]*$/)),
+  }),
+]);
+
+type PriceRequestEntity = {
+  id: string;
+  isResolved: boolean;
+  isDeleted: boolean;
+  time: string;
+  ancillaryData: string | null;
+  latestRound: { roundId: string } | null;
+};
+
+const priceRequestFields = gql`
+  fragment DeeplinkFields on PriceRequest {
+    id
+    isResolved
+    isDeleted
+    time
+    ancillaryData
+    latestRound {
+      roundId
+    }
+  }
+`;
+
+async function findByUniqueKey(uniqueKey: string) {
+  const query = gql`
+    ${priceRequestFields}
+    query resolveDeeplink($id: ID!) {
+      priceRequest(id: $id) {
+        ...DeeplinkFields
+      }
+    }
+  `;
+  const result = await gqlRequest<{ priceRequest: PriceRequestEntity | null }>(
+    VoteSubgraphURL,
+    query,
+    { id: uniqueKey }
+  );
+  return result.priceRequest;
+}
+
+async function findByDetails(
+  decodedIdentifier: string,
+  time: number,
+  ancillaryData: string | undefined
+) {
+  const query = gql`
+    ${priceRequestFields}
+    query resolveDeeplinkSearch($identifier: String!, $time: BigInt!) {
+      priceRequests(where: { identifier: $identifier, time: $time }) {
+        ...DeeplinkFields
+      }
+    }
+  `;
+  const { priceRequests: candidates } = await gqlRequest<{
+    priceRequests: PriceRequestEntity[];
+  }>(VoteSubgraphURL, query, { identifier: decodedIdentifier, time });
+
+  if (!ancillaryData || ancillaryData === "0x") {
+    return candidates.length === 1 ? candidates[0] : undefined;
+  }
+
+  const normalized = ancillaryData.toLowerCase();
+  const exact = candidates.find(
+    (candidate) => candidate.ancillaryData?.toLowerCase() === normalized
+  );
+  if (exact) return exact;
+
+  // Requests reaching the DVM from an oracle contract have the original
+  // ancillary data "stamped" (suffixed with ooRequester/childChainId), so the
+  // requesting side's data is a byte-prefix of what the DVM stores.
+  const stamped = candidates.filter((candidate) =>
+    candidate.ancillaryData?.toLowerCase().startsWith(normalized)
+  );
+  if (stamped.length === 1) return stamped[0];
+
+  // Requests bridged via AncillaryDataCompression replace the data with
+  // `ancillaryDataHash:<keccak256(childData)>,childBlockNumber:...`, so match
+  // the hash of the provided data against the compressed form.
+  const providedDataHash = utils.keccak256(normalized).slice(2);
+  const compressed = candidates.filter((candidate) =>
+    decodeAncillaryDataSafe(candidate.ancillaryData)?.startsWith(
+      `ancillaryDataHash:${providedDataHash},`
+    )
+  );
+  if (compressed.length === 1) return compressed[0];
+
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
+function decodeAncillaryDataSafe(ancillaryData: string | null) {
+  if (!ancillaryData) return undefined;
+  try {
+    return decodeHexString(ancillaryData);
+  } catch {
+    return undefined;
+  }
+}
+
+// The subgraph identifier id is the decoded string ("YES_OR_NO_QUERY"), but
+// callers may pass the on-chain bytes32 form instead.
+function normalizeIdentifier(identifier: string) {
+  if (/^0x[0-9a-fA-F]{64}$/.test(identifier)) {
+    return decodeHexString(identifier);
+  }
+  return identifier;
+}
+
+function getActivityStatus(entity: PriceRequestEntity): ActivityStatusT {
+  if (entity.isResolved) return "past";
+  const currentRoundId = Math.floor(Date.now() / 1000 / roundLength);
+  const latestRoundId = Number(entity.latestRound?.roundId ?? 0);
+  return latestRoundId > currentRoundId ? "upcoming" : "active";
+}
+
+export default async function handler(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  try {
+    if (request.method !== "GET") {
+      throw new HttpError({ statusCode: 405 });
+    }
+    const params = validateQueryParams(request.query, RequestParams);
+
+    let entity: PriceRequestEntity | null | undefined;
+    if ("vote" in params) {
+      entity = await findByUniqueKey(params.vote);
+    } else {
+      const decodedIdentifier = normalizeIdentifier(params.identifier);
+      if (params.ancillaryData) {
+        entity = await findByUniqueKey(
+          makeUniqueKeyForVote(
+            decodedIdentifier,
+            params.time,
+            params.ancillaryData
+          )
+        );
+      }
+      entity ??= await findByDetails(
+        decodedIdentifier,
+        params.time,
+        params.ancillaryData
+      );
+    }
+
+    if (!entity || entity.isDeleted) {
+      throw new HttpError({ statusCode: 404, msg: "Vote not found" });
+    }
+
+    const activityStatus = getActivityStatus(entity);
+    response.setHeader(
+      "Cache-Control",
+      activityStatus === "past"
+        ? "public, s-maxage=31536000, stale-while-revalidate=86400"
+        : "public, s-maxage=60, stale-while-revalidate=300"
+    );
+    response.status(200).json({ uniqueKey: entity.id, activityStatus });
+  } catch (error) {
+    handleApiError(error, response);
+  }
+}

--- a/tests/helpers/deeplink.test.ts
+++ b/tests/helpers/deeplink.test.ts
@@ -66,7 +66,9 @@ describe("makeVoterDappDeeplink", () => {
     );
   });
 
-  it("omits empty ancillary data and respects baseUrl", () => {
+  // blank ancillary data ("0x") must survive: it enables a direct uniqueKey
+  // lookup when several requests share identifier and time
+  it("keeps blank ancillary data and respects baseUrl", () => {
     expect(
       makeVoterDappDeeplink({
         identifier:
@@ -76,7 +78,7 @@ describe("makeVoterDappDeeplink", () => {
         baseUrl: "https://testnet.vote.uma.xyz",
       })
     ).toBe(
-      "https://testnet.vote.uma.xyz/?identifier=0x5945535f4f525f4e4f5f51554552590000000000000000000000000000000000&time=1751900000"
+      "https://testnet.vote.uma.xyz/?identifier=0x5945535f4f525f4e4f5f51554552590000000000000000000000000000000000&time=1751900000&ancillaryData=0x"
     );
   });
 });

--- a/tests/helpers/deeplink.test.ts
+++ b/tests/helpers/deeplink.test.ts
@@ -1,0 +1,77 @@
+import {
+  makeVoterDappDeeplink,
+  parseVoteDeeplink,
+} from "helpers/util/deeplink";
+import { describe, expect, it } from "vitest";
+
+const uniqueKey =
+  "YES_OR_NO_QUERY-1751900000-0x40e832d2323085fa42bd2f76a41ef993ffdbe4f6a06e938ce1a9a2a2c45ae7fa";
+
+describe("parseVoteDeeplink", () => {
+  it("prefers the canonical uniqueKey form", () => {
+    expect(
+      parseVoteDeeplink({ vote: uniqueKey, identifier: "ignored" })
+    ).toEqual({ form: "uniqueKey", uniqueKey });
+  });
+
+  it("parses the external form", () => {
+    expect(
+      parseVoteDeeplink({
+        identifier: "YES_OR_NO_QUERY",
+        time: "1751900000",
+        ancillaryData: "0xabcd",
+      })
+    ).toEqual({
+      form: "external",
+      identifier: "YES_OR_NO_QUERY",
+      time: 1751900000,
+      ancillaryData: "0xabcd",
+    });
+  });
+
+  // next/router repeats a param as an array when it appears twice
+  it("takes the first value of repeated params", () => {
+    expect(parseVoteDeeplink({ vote: [uniqueKey, "other"] })).toEqual({
+      form: "uniqueKey",
+      uniqueKey,
+    });
+  });
+
+  it("returns undefined for unrelated or malformed queries", () => {
+    expect(parseVoteDeeplink({})).toBeUndefined();
+    expect(
+      parseVoteDeeplink({ identifier: "YES_OR_NO_QUERY" })
+    ).toBeUndefined();
+    expect(
+      parseVoteDeeplink({ identifier: "YES_OR_NO_QUERY", time: "not-a-number" })
+    ).toBeUndefined();
+  });
+});
+
+describe("makeVoterDappDeeplink", () => {
+  it("builds a production link with encoded params", () => {
+    expect(
+      makeVoterDappDeeplink({
+        identifier: "YES_OR_NO_QUERY",
+        time: 1751900000,
+        ancillaryData: "0xabcd",
+      })
+    ).toBe(
+      "https://vote.uma.xyz/?identifier=YES_OR_NO_QUERY&time=1751900000&ancillaryData=0xabcd"
+    );
+  });
+
+  it("omits empty ancillary data and respects baseUrl", () => {
+    expect(
+      makeVoterDappDeeplink({
+        identifier:
+          "0x5945535f4f525f4e4f5f51554552590000000000000000000000000000000000",
+        time: "1751900000",
+        ancillaryData: "0x",
+        baseUrl: "https://testnet.vote.uma.xyz",
+      })
+    ).toBe(
+      "https://testnet.vote.uma.xyz/?identifier=0x5945535f4f525f4e4f5f51554552590000000000000000000000000000000000&time=1751900000"
+    );
+  });
+});

--- a/tests/helpers/deeplink.test.ts
+++ b/tests/helpers/deeplink.test.ts
@@ -19,13 +19,16 @@ describe("parseVoteDeeplink", () => {
       parseVoteDeeplink({
         identifier: "YES_OR_NO_QUERY",
         time: "1751900000",
-        ancillaryData: "0xabcd",
+        ancillaryDataHash:
+          "0x40e832d2323085fa42bd2f76a41ef993ffdbe4f6a06e938ce1a9a2a2c45ae7fa",
       })
     ).toEqual({
       form: "external",
       identifier: "YES_OR_NO_QUERY",
       time: 1751900000,
-      ancillaryData: "0xabcd",
+      ancillaryData: undefined,
+      ancillaryDataHash:
+        "0x40e832d2323085fa42bd2f76a41ef993ffdbe4f6a06e938ce1a9a2a2c45ae7fa",
     });
   });
 
@@ -49,15 +52,17 @@ describe("parseVoteDeeplink", () => {
 });
 
 describe("makeVoterDappDeeplink", () => {
-  it("builds a production link with encoded params", () => {
+  it("builds a production link, preferring the hash over full data", () => {
     expect(
       makeVoterDappDeeplink({
         identifier: "YES_OR_NO_QUERY",
         time: 1751900000,
+        ancillaryDataHash:
+          "0x40e832d2323085fa42bd2f76a41ef993ffdbe4f6a06e938ce1a9a2a2c45ae7fa",
         ancillaryData: "0xabcd",
       })
     ).toBe(
-      "https://vote.uma.xyz/?identifier=YES_OR_NO_QUERY&time=1751900000&ancillaryData=0xabcd"
+      "https://vote.uma.xyz/?identifier=YES_OR_NO_QUERY&time=1751900000&ancillaryDataHash=0x40e832d2323085fa42bd2f76a41ef993ffdbe4f6a06e938ce1a9a2a2c45ae7fa"
     );
   });
 


### PR DESCRIPTION
## What

Adds deeplinking to specific votes, mirroring the oracle dapp's pattern where the address bar is the shareable link.

Two URL forms work on any page:

- **Canonical**: `?vote=<uniqueKey>` — written to the URL whenever a vote panel is open (opened, next/prev, closed, back button all stay in sync via shallow routing).
- **External**: `?identifier=<string|bytes32>&time=<unixSeconds>&ancillaryDataHash=<keccak256>` — for the oracle dapp and the new explorer dapp. Ancillary data is often kilobytes (too long for a URL), so callers pass its keccak256 hash instead; full `ancillaryData` is still accepted when short.

Inbound links find the vote, redirect to the correct page (`/`, `/upcoming-votes`, `/past-votes`), open the details panel with prev/next navigation, and scroll-highlight the row. Unresolvable links surface a notification.

### Link builder for external dapps

`makeVoterDappDeeplink({ identifier, time, ancillaryDataHash })` in `helpers/util/deeplink.ts` is the canonical dependency-free builder — copy it as-is. The hash is `keccak256(request.ancillaryData)`, of **whichever version the caller holds**: raw request data, oracle-stamped, or DVM-side all resolve.

## How

- **`pages/api/resolve-deeplink.ts`**: resolves external params to `{ uniqueKey, activityStatus }`. The votingV2 subgraph's `PriceRequest.id` is constructed identically to the frontend `uniqueKey`, so DVM-side hashes are a direct id lookup. Otherwise candidates are fetched by identifier+time and the hash is compared against every reconstructable variant: the DVM data, its pre-`ooRequester`-stamp form, the `ancillaryDataHash:` embedded in compressed (bridged) data, and — via the `PriceRequestBridged` event on the child chain — the child data and its pre-stamp form. Verified this disambiguates 8 Polymarket requests sharing one timestamp in ~2s. Settled votes get `s-maxage=31536000`, unresolved 60s.
- **`hooks/helpers/useVoteDeeplink.ts`** (mounted via `VoteDeeplinkHandler` in `_app`): URL↔panel sync. The sync effect reacts to *transitions* (panel just opened/closed, param just disappeared) rather than raw state — effects in one commit see sibling state updates with a delay, and state-based conditions loop (open panel ↔ strip param).
- **`Nav.tsx`**: skip the close-panel-on-route-change handler for shallow (query-only) updates.
- **`lib/l2-ancillary-data.ts`**: export two existing helpers for the resolver's child-data fetch.

## Review notes

- Verified end-to-end against a production build (`next build && next start`): hash-form resolution (mainnet / stamped / raw hashes, real Polygon bridge events) → page redirect → canonical rewrite → panel open; row-click/next-arrow/close/back-button URL sync; active vs upcoming vs past classification against live round data.
- If a hash matches nothing but identifier+time is unambiguous (single candidate), the resolver falls back to that candidate — deliberate forgiveness for future stamping formats.
- Heads-up for manual testing: `next dev` on this app never flips `router.isReady` when *any* query param is present (pre-existing, reproducible on master with `?foo=bar`; production and vote.uma.xyz are fine). Test deeplinks against a production build.
- Pre-existing bug noticed in passing: `pages/api/_utils/errors.ts` `handleApiError` lacks a `return` after the `HttpError` branch, so every handled error also attempts a second 500 response. Being fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)