### PR TITLE
fix: return early in handleApiError after sending HttpError response

### DIFF
--- a/pages/api/_utils/__tests__/errors.test.ts
+++ b/pages/api/_utils/__tests__/errors.test.ts
@@ -1,0 +1,41 @@
+import { NextApiResponse } from "next";
+import { describe, expect, it, vi } from "vitest";
+import { handleApiError, HttpError } from "../errors";
+
+function makeMockResponse() {
+  const json = vi.fn();
+  const status = vi.fn().mockReturnValue({ json });
+  return { response: { status } as unknown as NextApiResponse, status, json };
+}
+
+describe("handleApiError", () => {
+  it("responds once with the HttpError status and does not fall through to 500", () => {
+    const { response, status, json } = makeMockResponse();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    handleApiError(new HttpError({ statusCode: 404 }), response);
+
+    expect(status).toHaveBeenCalledTimes(1);
+    expect(status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledWith({
+      error: "Not Found",
+      status: 404,
+      statusText: "Not Found",
+    });
+  });
+
+  it("responds with 500 for unexpected errors", () => {
+    const { response, status, json } = makeMockResponse();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    handleApiError(new Error("boom"), response);
+
+    expect(status).toHaveBeenCalledTimes(1);
+    expect(status).toHaveBeenCalledWith(500);
+    expect(json).toHaveBeenCalledWith({
+      error: "boom",
+      statusText: "Internal Server Error",
+    });
+  });
+});

--- a/pages/api/_utils/errors.ts
+++ b/pages/api/_utils/errors.ts
@@ -59,6 +59,7 @@ export function handleApiError(
       statusText: error.statusText,
     });
     response.status(error.statusCode).json(error.toJSON());
+    return;
   }
 
   console.error("Unexpected API error:", {


### PR DESCRIPTION
> Supersedes #472 — same commit, recreated with Droplet as author (requested by @gsteenkamp89 in Slack).

## What changed

`handleApiError()` in `pages/api/_utils/errors.ts` was missing a `return` after the `instanceof HttpError` branch, so every handled HTTP error fell through to the fallback path, which:

- logged the error a second time as "Unexpected API error" (mislabeling handled 4xx/5xx errors as unexpected 500s in the logs), and
- called `response.status(500).json(...)` after the response had already been sent, producing `ERR_HTTP_HEADERS_SENT` warnings in serverless logs.

This PR adds an early `return` after the `HttpError` response is sent, plus a minimal unit test (`pages/api/_utils/__tests__/errors.test.ts`) covering both paths:

- an `HttpError` sends exactly one response with its status code (fails on the old code — `status` was called twice)
- a plain `Error` still takes the 500 fallback path

## Notes for reviewers

No behavior change for clients — the first response was always the one that reached them. This only fixes the duplicate send attempt and the misleading log entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
