### PR TITLE
feat: deeplinks to specific votes, with serverless resolution for external dapps

### DIFF
--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -19,10 +19,18 @@ export function Nav({ links }: Props) {
   const isActive = (href: string) => router.pathname === href;
 
   useEffect(() => {
-    router.events.on("routeChangeStart", closePanel);
+    // shallow changes are query-param-only updates (vote deeplinks) and must
+    // not close the panel they describe
+    function closePanelOnNavigation(
+      _url: string,
+      { shallow }: { shallow: boolean }
+    ) {
+      if (!shallow) closePanel();
+    }
+    router.events.on("routeChangeStart", closePanelOnNavigation);
 
     return () => {
-      router.events.off("routeChangeStart", closePanel);
+      router.events.off("routeChangeStart", closePanelOnNavigation);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/components/Nav/Nav.tsx
+++ b/components/Nav/Nav.tsx
@@ -20,12 +20,14 @@ export function Nav({ links }: Props) {
 
   useEffect(() => {
     // shallow changes are query-param-only updates (vote deeplinks) and must
-    // not close the panel they describe
+    // not close the panel they describe. Real navigations clear the whole
+    // panel stack (closePanel(true)) — popping just the top entry would leave
+    // stacked panels (e.g. history under a vote) to resurface on the next page
     function closePanelOnNavigation(
       _url: string,
       { shallow }: { shallow: boolean }
     ) {
-      if (!shallow) closePanel();
+      if (!shallow) closePanel(true);
     }
     router.events.on("routeChangeStart", closePanelOnNavigation);
 

--- a/components/Pagination/Pagination.tsx
+++ b/components/Pagination/Pagination.tsx
@@ -50,7 +50,7 @@ export function usePagination<Entry>(entries: Entry[], findIndex?: number) {
 
   const getPageNumberOfItem = useCallback(
     function (itemIndex: number | undefined) {
-      if (!itemIndex) return;
+      if (itemIndex === undefined || itemIndex < 0) return;
       const pageNumber = Math.ceil((itemIndex + 1) / resultsPerPage);
 
       return pageNumber;
@@ -88,7 +88,7 @@ export function usePagination<Entry>(entries: Entry[], findIndex?: number) {
   }, [entries, updateEntries]);
 
   useEffect(() => {
-    if (!findIndex || findIndex === -1) return;
+    if (findIndex === undefined || findIndex === -1) return;
 
     const newPageNumber = getPageNumberOfItem(findIndex);
 

--- a/components/Panel/Panel.tsx
+++ b/components/Panel/Panel.tsx
@@ -1,5 +1,5 @@
 import { black, white } from "constant";
-import { usePanelContext, usePanelWidth } from "hooks";
+import { usePanelContext, usePanelWidth, useVoteUrl } from "hooks";
 import Close from "public/assets/icons/close.svg";
 import { CSSProperties, useEffect, useRef } from "react";
 import { FocusOn } from "react-focus-on";
@@ -17,8 +17,19 @@ import { VotePanelWithLazyLoad } from "./VotePanel/VotePanelWithLazyLoad";
 export function Panel() {
   const { panelType, panelContent, panelOpen, closePanel, currentVoteIndex } =
     usePanelContext();
+  const { closeVote } = useVoteUrl();
   const panelWidth = usePanelWidth();
   const contentRef = useRef<HTMLDivElement | null>(null);
+
+  // vote panels are driven by the URL: dismissing one removes its `?vote=`
+  // param and the deeplink handler closes the panel in response
+  function dismissPanel() {
+    if (panelType === "vote") {
+      closeVote();
+    } else {
+      closePanel();
+    }
+  }
 
   const transitions = useTransition(panelOpen, {
     from: { opacity: 0 },
@@ -61,7 +72,7 @@ export function Panel() {
         ({ opacity }, isOpen) =>
           isOpen && (
             <Overlay
-              onClick={() => closePanel()}
+              onClick={() => dismissPanel()}
               style={{
                 backgroundColor: opacity.to(
                   (value) => `hsla(280, 4%, 15%, ${value})`
@@ -72,8 +83,8 @@ export function Panel() {
       )}
       <FocusOn
         enabled={panelOpen}
-        onClickOutside={() => closePanel()}
-        onEscapeKey={() => closePanel()}
+        onClickOutside={() => dismissPanel()}
+        onEscapeKey={() => dismissPanel()}
         preventScrollOnFocus={true}
       >
         <Content
@@ -89,7 +100,7 @@ export function Panel() {
         >
           {getPanelComponent()}
           <CloseButton
-            onClick={() => closePanel()}
+            onClick={() => dismissPanel()}
             style={
               {
                 "--fill": closeButtonColor,

--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -2,6 +2,7 @@ import removeMarkdown from "remove-markdown";
 import { useCallback, useRef, useState } from "react";
 
 import { Tabs } from "components";
+import { scrollToAndHighlightVote } from "contexts";
 import { config, decodeHexString, getClaimTitle } from "helpers";
 import { getOptimisticGovernorTitle } from "helpers/voting/optimisticGovernor";
 import {
@@ -9,6 +10,8 @@ import {
   useVoteDiscussion,
   useAssertionClaim,
   useAugmentedVoteData,
+  useVoteSelectionContext,
+  useVotesContext,
   useVoteTimingContext,
   useVotePanelKeyboard,
 } from "hooks";
@@ -52,11 +55,11 @@ export function VotePanel({ content }: Props) {
     currentVoteIndex,
     goToNextVote,
     goToPrevVote,
-    selectVote,
-    selectedVotes,
     panelOpen,
     panelType,
   } = usePanelContext();
+  const { selectedVotes, selectVote } = useVoteSelectionContext();
+  const { activeVoteList } = useVotesContext();
 
   const { phase } = useVoteTimingContext();
   const isCommitPhase = phase === "commit";
@@ -65,7 +68,20 @@ export function VotePanel({ content }: Props) {
   const canGoPrev = currentVoteIndex > 0;
   const canGoNext = currentVoteIndex < navigableVotes.length - 1;
 
-  const showVoteInput = isCommitPhase && selectVote !== undefined;
+  // quick-vote controls only make sense for votes that are actually
+  // committable right now, i.e. in the current round's active list
+  const isActiveVote = activeVoteList?.some(
+    (vote) => vote.uniqueKey === content.uniqueKey
+  );
+  const showVoteInput = isCommitPhase && isActiveVote;
+
+  const handleSelectVote = useCallback(
+    (value: string | undefined, vote: VoteT) => {
+      selectVote(value, vote);
+      scrollToAndHighlightVote(vote.uniqueKey);
+    },
+    [selectVote]
+  );
 
   const prevButtonRef = useRef<HTMLButtonElement>(null);
   const nextButtonRef = useRef<HTMLButtonElement>(null);
@@ -95,7 +111,7 @@ export function VotePanel({ content }: Props) {
     canGoNext,
     options: content.options,
     currentVote: content,
-    selectVote,
+    selectVote: showVoteInput ? handleSelectVote : undefined,
   });
 
   const [selectedTab, setSelectedTab] = useState<string | undefined>();
@@ -248,7 +264,7 @@ export function VotePanel({ content }: Props) {
         <VotePanelVoteInput
           vote={content}
           selectedValue={selectedVotes[content.uniqueKey]}
-          onSelectVote={selectVote}
+          onSelectVote={handleSelectVote}
         />
       )}
       {makeTabs()}

--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -1,5 +1,5 @@
 import removeMarkdown from "remove-markdown";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Tabs } from "components";
 import { config, decodeHexString, getClaimTitle } from "helpers";
@@ -50,8 +50,13 @@ export function VotePanel({ content }: Props) {
     ancillaryDataL2,
   } = content;
 
-  const { navigableVotes, currentVoteIndex, panelOpen, panelType, requestVoteScroll } =
-    usePanelContext();
+  const {
+    navigableVotes,
+    currentVoteIndex,
+    panelOpen,
+    panelType,
+    requestVoteScroll,
+  } = usePanelContext();
   const { selectedVotes, selectVote } = useVoteSelectionContext();
   const { activeVoteList } = useVotesContext();
   const { switchVote } = useVoteUrl();
@@ -89,18 +94,41 @@ export function VotePanel({ content }: Props) {
   }
 
   // the arrows navigate by rewriting `?vote=`; the deeplink handler swaps
-  // the panel content in response
+  // the panel content in response. That round-trip means currentVoteIndex
+  // lags behind rapid presses (key repeat, double click), so track the
+  // in-flight target and advance from it — otherwise consecutive presses
+  // recompute the same target and collapse into a single step
+  const pendingNavKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (pendingNavKeyRef.current === content.uniqueKey) {
+      pendingNavKeyRef.current = null;
+    }
+  }, [content.uniqueKey]);
+
+  const navigateBy = useCallback(
+    (offset: number) => {
+      const pendingIndex = pendingNavKeyRef.current
+        ? navigableVotes.findIndex(
+            (vote) => vote.uniqueKey === pendingNavKeyRef.current
+          )
+        : -1;
+      const baseIndex = pendingIndex >= 0 ? pendingIndex : currentVoteIndex;
+      const target = navigableVotes[baseIndex + offset];
+      if (!target) return false;
+      pendingNavKeyRef.current = target.uniqueKey;
+      switchVote(target.uniqueKey);
+      return true;
+    },
+    [navigableVotes, currentVoteIndex, switchVote]
+  );
+
   const handlePrev = useCallback(() => {
-    const target = navigableVotes[currentVoteIndex - 1];
-    if (target) switchVote(target.uniqueKey);
-    flashButton(prevButtonRef.current);
-  }, [navigableVotes, currentVoteIndex, switchVote]);
+    if (navigateBy(-1)) flashButton(prevButtonRef.current);
+  }, [navigateBy]);
 
   const handleNext = useCallback(() => {
-    const target = navigableVotes[currentVoteIndex + 1];
-    if (target) switchVote(target.uniqueKey);
-    flashButton(nextButtonRef.current);
-  }, [navigableVotes, currentVoteIndex, switchVote]);
+    if (navigateBy(1)) flashButton(nextButtonRef.current);
+  }, [navigateBy]);
 
   useVotePanelKeyboard({
     isActive: panelOpen && panelType === "vote",

--- a/components/Panel/VotePanel/VotePanel.tsx
+++ b/components/Panel/VotePanel/VotePanel.tsx
@@ -2,7 +2,6 @@ import removeMarkdown from "remove-markdown";
 import { useCallback, useRef, useState } from "react";
 
 import { Tabs } from "components";
-import { scrollToAndHighlightVote } from "contexts";
 import { config, decodeHexString, getClaimTitle } from "helpers";
 import { getOptimisticGovernorTitle } from "helpers/voting/optimisticGovernor";
 import {
@@ -14,6 +13,7 @@ import {
   useVotesContext,
   useVoteTimingContext,
   useVotePanelKeyboard,
+  useVoteUrl,
 } from "hooks";
 import { useOptimisticGovernorData } from "hooks/queries/votes/useOptimisticGovernorData";
 import { VoteT } from "types";
@@ -50,16 +50,11 @@ export function VotePanel({ content }: Props) {
     ancillaryDataL2,
   } = content;
 
-  const {
-    navigableVotes,
-    currentVoteIndex,
-    goToNextVote,
-    goToPrevVote,
-    panelOpen,
-    panelType,
-  } = usePanelContext();
+  const { navigableVotes, currentVoteIndex, panelOpen, panelType, requestVoteScroll } =
+    usePanelContext();
   const { selectedVotes, selectVote } = useVoteSelectionContext();
   const { activeVoteList } = useVotesContext();
+  const { switchVote } = useVoteUrl();
 
   const { phase } = useVoteTimingContext();
   const isCommitPhase = phase === "commit";
@@ -78,9 +73,9 @@ export function VotePanel({ content }: Props) {
   const handleSelectVote = useCallback(
     (value: string | undefined, vote: VoteT) => {
       selectVote(value, vote);
-      scrollToAndHighlightVote(vote.uniqueKey);
+      requestVoteScroll(vote.uniqueKey);
     },
-    [selectVote]
+    [selectVote, requestVoteScroll]
   );
 
   const prevButtonRef = useRef<HTMLButtonElement>(null);
@@ -93,15 +88,19 @@ export function VotePanel({ content }: Props) {
     el.classList.add("nav-flash");
   }
 
+  // the arrows navigate by rewriting `?vote=`; the deeplink handler swaps
+  // the panel content in response
   const handlePrev = useCallback(() => {
-    goToPrevVote();
+    const target = navigableVotes[currentVoteIndex - 1];
+    if (target) switchVote(target.uniqueKey);
     flashButton(prevButtonRef.current);
-  }, [goToPrevVote]);
+  }, [navigableVotes, currentVoteIndex, switchVote]);
 
   const handleNext = useCallback(() => {
-    goToNextVote();
+    const target = navigableVotes[currentVoteIndex + 1];
+    if (target) switchVote(target.uniqueKey);
     flashButton(nextButtonRef.current);
-  }, [goToNextVote]);
+  }, [navigableVotes, currentVoteIndex, switchVote]);
 
   useVotePanelKeyboard({
     isActive: panelOpen && panelType === "vote",

--- a/components/VoteDeeplinkHandler/VoteDeeplinkHandler.tsx
+++ b/components/VoteDeeplinkHandler/VoteDeeplinkHandler.tsx
@@ -1,0 +1,8 @@
+import { useVoteDeeplink } from "hooks";
+
+// Must render inside PanelProvider and VotesProvider; hooks cannot run in
+// MyApp itself because the providers are created there.
+export function VoteDeeplinkHandler() {
+  useVoteDeeplink();
+  return null;
+}

--- a/components/VoteHistoryTable/VoteHistoryTable.tsx
+++ b/components/VoteHistoryTable/VoteHistoryTable.tsx
@@ -1,4 +1,4 @@
-import { usePanelContext } from "hooks";
+import { useVoteUrl } from "hooks";
 import styled from "styled-components";
 import { VoteT } from "types";
 import { VoteHistoryTableRow } from "./VoteHistoryTableRow";
@@ -7,7 +7,7 @@ interface Props {
   votes: VoteT[];
 }
 export function VoteHistoryTable({ votes }: Props) {
-  const { openPanel } = usePanelContext();
+  const { openVote } = useVoteUrl();
   const headings = ["Vote", "Staking", "Voted", "Correctness", "Earnings"];
 
   return (
@@ -27,7 +27,7 @@ export function VoteHistoryTable({ votes }: Props) {
             vote={vote}
             key={vote.uniqueKey}
             onVoteClicked={() => {
-              openPanel("vote", vote);
+              openVote(vote.uniqueKey);
             }}
           />
         ))}

--- a/components/VoteList/useVoteListItem.tsx
+++ b/components/VoteList/useVoteListItem.tsx
@@ -6,10 +6,12 @@ import {
   getClaimTitle,
 } from "helpers";
 import { config } from "helpers/config";
+import { scrollToAndHighlightVote } from "helpers/util/scrollToVote";
 import {
   useAccountDetails,
   useAssertionClaim,
   useDelegationContext,
+  usePanelContext,
   useVotesContext,
   useWalletContext,
 } from "hooks";
@@ -39,6 +41,17 @@ export function useVoteListItem({
   moreDetailsAction,
   isDirty = false,
 }: VoteListItemProps) {
+  const { voteScrollTarget, clearVoteScroll } = usePanelContext();
+
+  // consume a pending scroll-and-highlight request once this row is actually
+  // mounted — it may render a beat after the request (page redirect,
+  // pagination jump), which is why the requester doesn't touch the DOM itself
+  useEffect(() => {
+    if (voteScrollTarget !== vote.uniqueKey) return;
+    scrollToAndHighlightVote(vote.uniqueKey);
+    clearVoteScroll();
+  }, [voteScrollTarget, vote.uniqueKey, clearVoteScroll]);
+
   const [isCustomInput, setIsCustomInput] = useState(false);
   const multipleInputProps = useMultipleValuesVote({
     vote,

--- a/components/Votes/ActiveVotes.tsx
+++ b/components/Votes/ActiveVotes.tsx
@@ -14,14 +14,14 @@ import {
   useContractsContext,
   useDelegationContext,
   usePanelContext,
-  usePersistedVotes,
   useRevealVotes,
   useStakedBalance,
+  useVoteSelectionContext,
   useVotesContext,
   useVoteTimingContext,
   useWalletContext,
 } from "hooks";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { VoteT } from "types";
 import {
   ButtonInnerWrapper,
@@ -55,11 +55,12 @@ export function ActiveVotes() {
   const { data: stakedBalance } = useStakedBalance(
     isDelegate ? delegatorAddress : address
   );
-  const { openPanel, registerVoteOpener } = usePanelContext();
+  const { openPanel } = usePanelContext();
   const [{ connecting: isConnectingWallet }, connect] = useConnectWallet();
   const { commitVotesMutation, isCommittingVotes } = useCommitVotes(address);
   const { revealVotesMutation, isRevealingVotes } = useRevealVotes(address);
-  const [selectedVotes, setSelectedVotes] = usePersistedVotes(roundId);
+  const { selectedVotes, selectVote, setSelectedVotes } =
+    useVoteSelectionContext();
   const [dirtyInputs, setDirtyInput] = useState<boolean[]>([]);
 
   function isDirty(): boolean {
@@ -291,19 +292,6 @@ export function ActiveVotes() {
     );
   }
 
-  function selectVote(value: string | undefined, vote: VoteT) {
-    setSelectedVotes((selected) => ({ ...selected, [vote.uniqueKey]: value }));
-  }
-
-  // deeplinks open votes through this so the panel gets the same quick-vote
-  // wiring as the row's own more-details action
-  useEffect(() => {
-    return registerVoteOpener((vote, navigableVotes) =>
-      openPanel("vote", vote, { navigableVotes, selectedVotes, selectVote })
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedVotes, openPanel, registerVoteOpener]);
-
   function clearSelectedVote(vote: VoteT) {
     selectVote(undefined, vote);
   }
@@ -316,11 +304,7 @@ export function ActiveVotes() {
     clearVote: () => clearSelectedVote(vote),
     activityStatus: "active" as const,
     moreDetailsAction: () =>
-      openPanel("vote", vote, {
-        navigableVotes: activeVoteList,
-        selectedVotes,
-        selectVote,
-      }),
+      openPanel("vote", vote, { navigableVotes: activeVoteList }),
     key: vote.uniqueKey,
     isDirty: dirtyInputs[index],
     setDirty: (dirty: boolean) =>

--- a/components/Votes/ActiveVotes.tsx
+++ b/components/Votes/ActiveVotes.tsx
@@ -13,12 +13,12 @@ import {
   useCommitVotes,
   useContractsContext,
   useDelegationContext,
-  usePanelContext,
   useRevealVotes,
   useStakedBalance,
   useVoteSelectionContext,
   useVotesContext,
   useVoteTimingContext,
+  useVoteUrl,
   useWalletContext,
 } from "hooks";
 import { useState } from "react";
@@ -55,7 +55,7 @@ export function ActiveVotes() {
   const { data: stakedBalance } = useStakedBalance(
     isDelegate ? delegatorAddress : address
   );
-  const { openPanel } = usePanelContext();
+  const { openVote } = useVoteUrl();
   const [{ connecting: isConnectingWallet }, connect] = useConnectWallet();
   const { commitVotesMutation, isCommittingVotes } = useCommitVotes(address);
   const { revealVotesMutation, isRevealingVotes } = useRevealVotes(address);
@@ -303,8 +303,7 @@ export function ActiveVotes() {
     selectVote: (value: string | undefined) => selectVote(value, vote),
     clearVote: () => clearSelectedVote(vote),
     activityStatus: "active" as const,
-    moreDetailsAction: () =>
-      openPanel("vote", vote, { navigableVotes: activeVoteList }),
+    moreDetailsAction: () => openVote(vote.uniqueKey),
     key: vote.uniqueKey,
     isDirty: dirtyInputs[index],
     setDirty: (dirty: boolean) =>

--- a/components/Votes/ActiveVotes.tsx
+++ b/components/Votes/ActiveVotes.tsx
@@ -21,7 +21,7 @@ import {
   useVoteTimingContext,
   useWalletContext,
 } from "hooks";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { VoteT } from "types";
 import {
   ButtonInnerWrapper,
@@ -55,7 +55,7 @@ export function ActiveVotes() {
   const { data: stakedBalance } = useStakedBalance(
     isDelegate ? delegatorAddress : address
   );
-  const { openPanel } = usePanelContext();
+  const { openPanel, registerVoteOpener } = usePanelContext();
   const [{ connecting: isConnectingWallet }, connect] = useConnectWallet();
   const { commitVotesMutation, isCommittingVotes } = useCommitVotes(address);
   const { revealVotesMutation, isRevealingVotes } = useRevealVotes(address);
@@ -294,6 +294,15 @@ export function ActiveVotes() {
   function selectVote(value: string | undefined, vote: VoteT) {
     setSelectedVotes((selected) => ({ ...selected, [vote.uniqueKey]: value }));
   }
+
+  // deeplinks open votes through this so the panel gets the same quick-vote
+  // wiring as the row's own more-details action
+  useEffect(() => {
+    return registerVoteOpener((vote, navigableVotes) =>
+      openPanel("vote", vote, { navigableVotes, selectedVotes, selectVote })
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedVotes, openPanel, registerVoteOpener]);
 
   function clearSelectedVote(vote: VoteT) {
     selectVote(undefined, vote);

--- a/components/Votes/PastVotes.tsx
+++ b/components/Votes/PastVotes.tsx
@@ -1,8 +1,8 @@
 import { Button, VoteList } from "components";
 import {
-  usePanelContext,
   useVoteTimingContext,
   useVotesContext,
+  useVoteUrl,
   useAccountDetails,
   useDelegationContext,
 } from "hooks";
@@ -18,7 +18,7 @@ import { VoteT } from "types";
 
 export function PastVotes() {
   const { pastVoteList = [] } = useVotesContext();
-  const { openPanel } = usePanelContext();
+  const { openVote } = useVoteUrl();
   const { phase } = useVoteTimingContext();
   const { address } = useAccountDetails();
   const { delegatorAddress } = useDelegationContext();
@@ -73,14 +73,14 @@ export function PastVotes() {
         vote: updatedVote,
         phase: phase,
         activityStatus: "past" as const,
-        moreDetailsAction: () => openPanel("vote", vote),
+        moreDetailsAction: () => openVote(vote.uniqueKey),
       };
     });
   }, [
     recentVotes,
     userVoteDetails,
     phase,
-    openPanel,
+    openVote,
     isWalletConnected,
     userVotesLoading,
   ]);

--- a/components/Votes/UpcomingVotes.tsx
+++ b/components/Votes/UpcomingVotes.tsx
@@ -1,10 +1,10 @@
 import { Pagination, usePagination, VoteList, VoteTimeline } from "components";
-import { usePanelContext, useVotesContext, useVoteTimingContext } from "hooks";
+import { useVotesContext, useVoteTimingContext, useVoteUrl } from "hooks";
 import { Divider, PaginationWrapper, Title, VotesTableWrapper } from "./style";
 
 export function UpcomingVotes() {
   const { upcomingVoteList, activityStatus } = useVotesContext();
-  const { openPanel } = usePanelContext();
+  const { openVote } = useVoteUrl();
   const { phase } = useVoteTimingContext();
   const { showPagination, entriesToShow, ...paginationProps } = usePagination(
     upcomingVoteList ?? []
@@ -14,7 +14,7 @@ export function UpcomingVotes() {
     activityStatus: "upcoming" as const,
     vote,
     phase,
-    moreDetailsAction: () => openPanel("vote", vote),
+    moreDetailsAction: () => openVote(vote.uniqueKey),
   }));
 
   return (

--- a/components/Votes/UpcomingVotes.tsx
+++ b/components/Votes/UpcomingVotes.tsx
@@ -1,13 +1,20 @@
 import { Pagination, usePagination, VoteList, VoteTimeline } from "components";
-import { useVotesContext, useVoteTimingContext, useVoteUrl } from "hooks";
+import {
+  useDeeplinkedVoteIndex,
+  useVotesContext,
+  useVoteTimingContext,
+  useVoteUrl,
+} from "hooks";
 import { Divider, PaginationWrapper, Title, VotesTableWrapper } from "./style";
 
 export function UpcomingVotes() {
   const { upcomingVoteList, activityStatus } = useVotesContext();
   const { openVote } = useVoteUrl();
   const { phase } = useVoteTimingContext();
+  const deeplinkedVoteIndex = useDeeplinkedVoteIndex(upcomingVoteList);
   const { showPagination, entriesToShow, ...paginationProps } = usePagination(
-    upcomingVoteList ?? []
+    upcomingVoteList ?? [],
+    deeplinkedVoteIndex
   );
 
   const data = entriesToShow.map((vote) => ({

--- a/components/index.ts
+++ b/components/index.ts
@@ -56,6 +56,7 @@ export { PanelErrorBanner } from "./PanelErrorBanner/PanelErrorBanner";
 export { Tabs } from "./Tabs/Tabs";
 export { Toggle } from "./Toggle/Toggle";
 export { Tooltip } from "./Tooltip/Tooltip";
+export { VoteDeeplinkHandler } from "./VoteDeeplinkHandler/VoteDeeplinkHandler";
 export { VoteHistoryTable } from "./VoteHistoryTable/VoteHistoryTable";
 export { VoteList } from "./VoteList/VoteList";
 export { VoteTableHeadings } from "./VoteList/VoteTableHeadings";

--- a/components/pages/PastVotes.tsx
+++ b/components/pages/PastVotes.tsx
@@ -10,9 +10,9 @@ import {
 } from "components";
 import {
   useDeeplinkedVoteIndex,
-  usePanelContext,
   useVoteTimingContext,
   useVotesContext,
+  useVoteUrl,
   useAccountDetails,
   useDelegationContext,
 } from "hooks";
@@ -26,7 +26,7 @@ import { VoteT } from "types";
 export function PastVotes() {
   const { pastVoteList, pastVotesIsLoading } = useVotesContext();
   const { phase } = useVoteTimingContext();
-  const { openPanel } = usePanelContext();
+  const { openVote } = useVoteUrl();
   const { address } = useAccountDetails();
   const { delegatorAddress } = useDelegationContext();
   const deeplinkedVoteIndex = useDeeplinkedVoteIndex(pastVoteList);
@@ -82,14 +82,14 @@ export function PastVotes() {
         activityStatus: "past" as const,
         vote: updatedVote,
         phase,
-        moreDetailsAction: () => openPanel("vote", vote),
+        moreDetailsAction: () => openVote(vote.uniqueKey),
       };
     });
   }, [
     entriesToShow,
     userVoteDetails,
     phase,
-    openPanel,
+    openVote,
     isWalletConnected,
     userVotesLoading,
   ]);

--- a/components/pages/PastVotes.tsx
+++ b/components/pages/PastVotes.tsx
@@ -9,6 +9,7 @@ import {
   usePagination,
 } from "components";
 import {
+  useDeeplinkedVoteIndex,
   usePanelContext,
   useVoteTimingContext,
   useVotesContext,
@@ -28,8 +29,10 @@ export function PastVotes() {
   const { openPanel } = usePanelContext();
   const { address } = useAccountDetails();
   const { delegatorAddress } = useDelegationContext();
+  const deeplinkedVoteIndex = useDeeplinkedVoteIndex(pastVoteList);
   const { showPagination, entriesToShow, ...paginationProps } = usePagination(
-    pastVoteList ?? []
+    pastVoteList ?? [],
+    deeplinkedVoteIndex
   );
 
   // Check if wallet is connected

--- a/components/pages/UpcomingVotes.tsx
+++ b/components/pages/UpcomingVotes.tsx
@@ -9,7 +9,12 @@ import {
   VoteList,
   usePagination,
 } from "components";
-import { usePanelContext, useVoteTimingContext, useVotesContext } from "hooks";
+import {
+  useDeeplinkedVoteIndex,
+  usePanelContext,
+  useVoteTimingContext,
+  useVotesContext,
+} from "hooks";
 import { isUndefined } from "lodash";
 import Image from "next/image";
 import noVotesIndicator from "public/assets/no-votes-indicator.png";
@@ -20,8 +25,10 @@ export function UpcomingVotes() {
   const { upcomingVoteList, upcomingVotesIsLoading } = useVotesContext();
   const { phase, millisecondsUntilPhaseEnds } = useVoteTimingContext();
   const { openPanel } = usePanelContext();
+  const deeplinkedVoteIndex = useDeeplinkedVoteIndex(upcomingVoteList);
   const { showPagination, entriesToShow, ...paginationProps } = usePagination(
-    upcomingVoteList ?? []
+    upcomingVoteList ?? [],
+    deeplinkedVoteIndex
   );
   const hasUpcomingVotes = !!upcomingVoteList && upcomingVoteList?.length > 0;
 

--- a/components/pages/UpcomingVotes.tsx
+++ b/components/pages/UpcomingVotes.tsx
@@ -11,9 +11,9 @@ import {
 } from "components";
 import {
   useDeeplinkedVoteIndex,
-  usePanelContext,
   useVoteTimingContext,
   useVotesContext,
+  useVoteUrl,
 } from "hooks";
 import { isUndefined } from "lodash";
 import Image from "next/image";
@@ -24,7 +24,7 @@ import { LoadingSpinnerWrapper } from "./styles";
 export function UpcomingVotes() {
   const { upcomingVoteList, upcomingVotesIsLoading } = useVotesContext();
   const { phase, millisecondsUntilPhaseEnds } = useVoteTimingContext();
-  const { openPanel } = usePanelContext();
+  const { openVote } = useVoteUrl();
   const deeplinkedVoteIndex = useDeeplinkedVoteIndex(upcomingVoteList);
   const { showPagination, entriesToShow, ...paginationProps } = usePagination(
     upcomingVoteList ?? [],
@@ -36,7 +36,7 @@ export function UpcomingVotes() {
     activityStatus: "upcoming" as const,
     vote,
     phase,
-    moreDetailsAction: () => openPanel("vote", vote),
+    moreDetailsAction: () => openVote(vote.uniqueKey),
   }));
 
   const isLoading = upcomingVotesIsLoading || isUndefined(upcomingVoteList);

--- a/contexts/DelegationContext.tsx
+++ b/contexts/DelegationContext.tsx
@@ -32,6 +32,7 @@ import {
   createContext,
   useCallback,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { DelegationEventT, DelegationStatusT } from "types";
@@ -171,7 +172,13 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
   const { data: stakerDetails } = useStakerDetails(address);
   const { delegate } = stakerDetails ?? {};
   const { votingWriter } = useContractsContext();
-  const { closePanel } = usePanelContext();
+  const { closePanel, panelOpen, panelType } = usePanelContext();
+  // sendRequestToBeDelegate's success handler fires when the tx mines,
+  // possibly minutes after the click — consult the panel state at THAT
+  // moment (latest-value ref), not the state captured with the callback, so
+  // it never closes a panel (e.g. a vote panel) the user has since opened
+  const delegationPanelShowingRef = useRef(false);
+  delegationPanelShowingRef.current = panelOpen && panelType === "delegation";
   const pendingReceivedRequestsToBeDelegate =
     getPendingReceivedRequestsToBeDelegate();
   const hasPendingReceivedRequestsToBeDelegate =
@@ -331,7 +338,7 @@ export function DelegationProvider({ children }: { children: ReactNode }) {
         },
         {
           onSuccess: () => {
-            closePanel();
+            if (delegationPanelShowingRef.current) closePanel();
           },
         }
       );

--- a/contexts/PanelContext.tsx
+++ b/contexts/PanelContext.tsx
@@ -8,9 +8,15 @@ import {
 } from "react";
 import { PanelTypeT, SelectedVotesByKeyT, VoteT } from "types";
 
-export function scrollToAndHighlightVote(uniqueKey: string) {
+export function scrollToAndHighlightVote(uniqueKey: string, attempt = 0) {
   const el = document.querySelector(`[data-vote-key="${uniqueKey}"]`);
-  if (!el) return;
+  if (!el) {
+    // deeplinked rows may still be mounting (list render, pagination jump)
+    if (attempt < 10) {
+      setTimeout(() => scrollToAndHighlightVote(uniqueKey, attempt + 1), 200);
+    }
+    return;
+  }
   el.scrollIntoView({ behavior: "smooth", block: "center" });
   el.classList.remove("vote-highlight");
   void (el as HTMLElement).offsetWidth;

--- a/contexts/PanelContext.tsx
+++ b/contexts/PanelContext.tsx
@@ -3,10 +3,9 @@ import {
   ReactNode,
   useCallback,
   useMemo,
-  useRef,
   useState,
 } from "react";
-import { PanelTypeT, SelectedVotesByKeyT, VoteT } from "types";
+import { PanelTypeT, VoteT } from "types";
 
 export function scrollToAndHighlightVote(uniqueKey: string, attempt = 0) {
   const el = document.querySelector(`[data-vote-key="${uniqueKey}"]`);
@@ -26,8 +25,6 @@ export function scrollToAndHighlightVote(uniqueKey: string, attempt = 0) {
 
 export type OpenPanelOptions = {
   navigableVotes?: VoteT[];
-  selectedVotes?: SelectedVotesByKeyT;
-  selectVote?: (value: string | undefined, vote: VoteT) => void;
 };
 
 export type VoteOpener = (vote: VoteT, navigableVotes: VoteT[]) => void;
@@ -43,13 +40,10 @@ export interface PanelContextState {
   ) => void;
   closePanel: (clearPreviousPanelData?: boolean) => void;
   openVote: VoteOpener;
-  registerVoteOpener: (opener: VoteOpener) => () => void;
   navigableVotes: VoteT[];
   currentVoteIndex: number;
   goToNextVote: () => void;
   goToPrevVote: () => void;
-  selectVote: ((value: string | undefined, vote: VoteT) => void) | undefined;
-  selectedVotes: SelectedVotesByKeyT;
 }
 
 export const defaultPanelContextState: PanelContextState = {
@@ -59,13 +53,10 @@ export const defaultPanelContextState: PanelContextState = {
   openPanel: () => null,
   closePanel: () => null,
   openVote: () => null,
-  registerVoteOpener: () => () => null,
   navigableVotes: [],
   currentVoteIndex: -1,
   goToNextVote: () => null,
   goToPrevVote: () => null,
-  selectVote: undefined,
-  selectedVotes: {},
 };
 
 export const PanelContext = createContext<PanelContextState>(
@@ -81,10 +72,6 @@ export function PanelProvider({ children }: { children: ReactNode }) {
   >([]);
   const [navigableVotes, setNavigableVotes] = useState<VoteT[]>([]);
   const [currentVoteIndex, setCurrentVoteIndex] = useState(-1);
-  const [selectVoteFn, setSelectVoteFn] = useState<
-    ((value: string | undefined, vote: VoteT) => void) | undefined
-  >();
-  const [selectedVotes, setSelectedVotes] = useState<SelectedVotesByKeyT>({});
 
   const openPanel = useCallback(
     (
@@ -107,48 +94,15 @@ export function PanelProvider({ children }: { children: ReactNode }) {
         setNavigableVotes([]);
         setCurrentVoteIndex(-1);
       }
-
-      if (options?.selectVote) {
-        setSelectVoteFn(() => options.selectVote);
-      } else {
-        setSelectVoteFn(undefined);
-      }
-
-      setSelectedVotes(options?.selectedVotes ?? {});
     },
     []
   );
 
-  // pages with richer panel options (ActiveVotes passes selectedVotes and
-  // selectVote so the panel's quick-vote controls work) register an opener;
-  // deeplinks use it so a shared link opens the same panel a row click would
-  const voteOpenerRef = useRef<VoteOpener | null>(null);
-
-  const registerVoteOpener = useCallback((opener: VoteOpener) => {
-    voteOpenerRef.current = opener;
-    return () => {
-      if (voteOpenerRef.current === opener) voteOpenerRef.current = null;
-    };
-  }, []);
-
   const openVote = useCallback<VoteOpener>(
     (vote, navigableVotes) => {
-      if (voteOpenerRef.current) {
-        voteOpenerRef.current(vote, navigableVotes);
-      } else {
-        openPanel("vote", vote, { navigableVotes });
-      }
+      openPanel("vote", vote, { navigableVotes });
     },
     [openPanel]
-  );
-
-  const wrappedSelectVote = useCallback(
-    (value: string | undefined, vote: VoteT) => {
-      selectVoteFn?.(value, vote);
-      setSelectedVotes((prev) => ({ ...prev, [vote.uniqueKey]: value }));
-      scrollToAndHighlightVote(vote.uniqueKey);
-    },
-    [selectVoteFn]
   );
 
   const goToNextVote = useCallback(() => {
@@ -209,19 +163,15 @@ export function PanelProvider({ children }: { children: ReactNode }) {
       openPanel,
       closePanel,
       openVote,
-      registerVoteOpener,
       navigableVotes,
       currentVoteIndex,
       goToNextVote,
       goToPrevVote,
-      selectVote: selectVoteFn ? wrappedSelectVote : undefined,
-      selectedVotes,
     }),
     [
       closePanel,
       openPanel,
       openVote,
-      registerVoteOpener,
       panelContent,
       panelOpen,
       panelType,
@@ -229,9 +179,6 @@ export function PanelProvider({ children }: { children: ReactNode }) {
       currentVoteIndex,
       goToNextVote,
       goToPrevVote,
-      selectVoteFn,
-      wrappedSelectVote,
-      selectedVotes,
     ]
   );
 

--- a/contexts/PanelContext.tsx
+++ b/contexts/PanelContext.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import { PanelTypeT, SelectedVotesByKeyT, VoteT } from "types";
 
-function scrollToAndHighlightVote(uniqueKey: string) {
+export function scrollToAndHighlightVote(uniqueKey: string) {
   const el = document.querySelector(`[data-vote-key="${uniqueKey}"]`);
   if (!el) return;
   el.scrollIntoView({ behavior: "smooth", block: "center" });

--- a/contexts/PanelContext.tsx
+++ b/contexts/PanelContext.tsx
@@ -1,33 +1,25 @@
 import {
   createContext,
+  MutableRefObject,
   ReactNode,
   useCallback,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { PanelTypeT, VoteT } from "types";
-
-export function scrollToAndHighlightVote(uniqueKey: string, attempt = 0) {
-  const el = document.querySelector(`[data-vote-key="${uniqueKey}"]`);
-  if (!el) {
-    // deeplinked rows may still be mounting (list render, pagination jump)
-    if (attempt < 10) {
-      setTimeout(() => scrollToAndHighlightVote(uniqueKey, attempt + 1), 200);
-    }
-    return;
-  }
-  el.scrollIntoView({ behavior: "smooth", block: "center" });
-  el.classList.remove("vote-highlight");
-  void (el as HTMLElement).offsetWidth;
-  el.classList.add("vote-highlight");
-  setTimeout(() => el.classList.remove("vote-highlight"), 1500);
-}
 
 export type OpenPanelOptions = {
   navigableVotes?: VoteT[];
 };
 
-export type VoteOpener = (vote: VoteT, navigableVotes: VoteT[]) => void;
+// A URL write our own UI initiated (row click, panel arrows). The deeplink
+// handler uses it to tell in-app opens apart from inbound navigations —
+// inbound ones land on the vote's page and highlight its row.
+export type ExpectedVoteOpen = {
+  key: string;
+  scroll: boolean;
+};
 
 export interface PanelContextState {
   panelType: PanelTypeT;
@@ -39,11 +31,13 @@ export interface PanelContextState {
     options?: OpenPanelOptions
   ) => void;
   closePanel: (clearPreviousPanelData?: boolean) => void;
-  openVote: VoteOpener;
+  showVote: (vote: VoteT, navigableVotes: VoteT[]) => void;
   navigableVotes: VoteT[];
   currentVoteIndex: number;
-  goToNextVote: () => void;
-  goToPrevVote: () => void;
+  expectedVoteRef: MutableRefObject<ExpectedVoteOpen | undefined>;
+  voteScrollTarget: string | undefined;
+  requestVoteScroll: (uniqueKey: string) => void;
+  clearVoteScroll: () => void;
 }
 
 export const defaultPanelContextState: PanelContextState = {
@@ -52,11 +46,13 @@ export const defaultPanelContextState: PanelContextState = {
   panelOpen: false,
   openPanel: () => null,
   closePanel: () => null,
-  openVote: () => null,
+  showVote: () => null,
   navigableVotes: [],
   currentVoteIndex: -1,
-  goToNextVote: () => null,
-  goToPrevVote: () => null,
+  expectedVoteRef: { current: undefined },
+  voteScrollTarget: undefined,
+  requestVoteScroll: () => null,
+  clearVoteScroll: () => null,
 };
 
 export const PanelContext = createContext<PanelContextState>(
@@ -72,6 +68,20 @@ export function PanelProvider({ children }: { children: ReactNode }) {
   >([]);
   const [navigableVotes, setNavigableVotes] = useState<VoteT[]>([]);
   const [currentVoteIndex, setCurrentVoteIndex] = useState(-1);
+
+  const expectedVoteRef = useRef<ExpectedVoteOpen | undefined>();
+
+  // Which row should scroll into view and flash. State (not a direct DOM
+  // call) so the row itself consumes it in an effect once it is actually
+  // mounted — the row may still be rendering when the request is made
+  // (page redirect, pagination jump).
+  const [voteScrollTarget, setVoteScrollTarget] = useState<string>();
+  const requestVoteScroll = useCallback((uniqueKey: string) => {
+    setVoteScrollTarget(uniqueKey);
+  }, []);
+  const clearVoteScroll = useCallback(() => {
+    setVoteScrollTarget(undefined);
+  }, []);
 
   const openPanel = useCallback(
     (
@@ -98,30 +108,23 @@ export function PanelProvider({ children }: { children: ReactNode }) {
     []
   );
 
-  const openVote = useCallback<VoteOpener>(
-    (vote, navigableVotes) => {
-      openPanel("vote", vote, { navigableVotes });
-    },
-    [openPanel]
-  );
-
-  const goToNextVote = useCallback(() => {
-    if (currentVoteIndex < navigableVotes.length - 1) {
-      const nextIndex = currentVoteIndex + 1;
-      setCurrentVoteIndex(nextIndex);
-      setPanelContent(navigableVotes[nextIndex]);
-      scrollToAndHighlightVote(navigableVotes[nextIndex].uniqueKey);
-    }
-  }, [currentVoteIndex, navigableVotes]);
-
-  const goToPrevVote = useCallback(() => {
-    if (currentVoteIndex > 0) {
-      const prevIndex = currentVoteIndex - 1;
-      setCurrentVoteIndex(prevIndex);
-      setPanelContent(navigableVotes[prevIndex]);
-      scrollToAndHighlightVote(navigableVotes[prevIndex].uniqueKey);
-    }
-  }, [currentVoteIndex, navigableVotes]);
+  // Vote-to-vote transitions (panel arrows, another row clicked, back and
+  // forward between votes) replace the stack top instead of pushing, so
+  // closing the panel doesn't walk back through every vote viewed.
+  const showVote = useCallback((vote: VoteT, votes: VoteT[]) => {
+    setPanelType("vote");
+    setPanelContent(vote);
+    setPanelOpen(true);
+    setNavigableVotes(votes);
+    const index = votes.findIndex((v) => v.uniqueKey === vote.uniqueKey);
+    setCurrentVoteIndex(index >= 0 ? index : 0);
+    setPreviousPanelData((prev) => {
+      const top = prev[prev.length - 1];
+      const entry = { panelType: "vote" as const, panelContent: vote };
+      if (top?.panelType === "vote") return [...prev.slice(0, -1), entry];
+      return [...prev, entry];
+    });
+  }, []);
 
   const closePanel = useCallback(
     (clearPreviousPanelData = false) => {
@@ -162,23 +165,26 @@ export function PanelProvider({ children }: { children: ReactNode }) {
       panelOpen,
       openPanel,
       closePanel,
-      openVote,
+      showVote,
       navigableVotes,
       currentVoteIndex,
-      goToNextVote,
-      goToPrevVote,
+      expectedVoteRef,
+      voteScrollTarget,
+      requestVoteScroll,
+      clearVoteScroll,
     }),
     [
       closePanel,
       openPanel,
-      openVote,
+      showVote,
       panelContent,
       panelOpen,
       panelType,
       navigableVotes,
       currentVoteIndex,
-      goToNextVote,
-      goToPrevVote,
+      voteScrollTarget,
+      requestVoteScroll,
+      clearVoteScroll,
     ]
   );
 

--- a/contexts/PanelContext.tsx
+++ b/contexts/PanelContext.tsx
@@ -3,6 +3,7 @@ import {
   ReactNode,
   useCallback,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { PanelTypeT, SelectedVotesByKeyT, VoteT } from "types";
@@ -23,6 +24,8 @@ export type OpenPanelOptions = {
   selectVote?: (value: string | undefined, vote: VoteT) => void;
 };
 
+export type VoteOpener = (vote: VoteT, navigableVotes: VoteT[]) => void;
+
 export interface PanelContextState {
   panelType: PanelTypeT;
   panelContent: VoteT | undefined;
@@ -33,6 +36,8 @@ export interface PanelContextState {
     options?: OpenPanelOptions
   ) => void;
   closePanel: (clearPreviousPanelData?: boolean) => void;
+  openVote: VoteOpener;
+  registerVoteOpener: (opener: VoteOpener) => () => void;
   navigableVotes: VoteT[];
   currentVoteIndex: number;
   goToNextVote: () => void;
@@ -47,6 +52,8 @@ export const defaultPanelContextState: PanelContextState = {
   panelOpen: false,
   openPanel: () => null,
   closePanel: () => null,
+  openVote: () => null,
+  registerVoteOpener: () => () => null,
   navigableVotes: [],
   currentVoteIndex: -1,
   goToNextVote: () => null,
@@ -104,6 +111,29 @@ export function PanelProvider({ children }: { children: ReactNode }) {
       setSelectedVotes(options?.selectedVotes ?? {});
     },
     []
+  );
+
+  // pages with richer panel options (ActiveVotes passes selectedVotes and
+  // selectVote so the panel's quick-vote controls work) register an opener;
+  // deeplinks use it so a shared link opens the same panel a row click would
+  const voteOpenerRef = useRef<VoteOpener | null>(null);
+
+  const registerVoteOpener = useCallback((opener: VoteOpener) => {
+    voteOpenerRef.current = opener;
+    return () => {
+      if (voteOpenerRef.current === opener) voteOpenerRef.current = null;
+    };
+  }, []);
+
+  const openVote = useCallback<VoteOpener>(
+    (vote, navigableVotes) => {
+      if (voteOpenerRef.current) {
+        voteOpenerRef.current(vote, navigableVotes);
+      } else {
+        openPanel("vote", vote, { navigableVotes });
+      }
+    },
+    [openPanel]
   );
 
   const wrappedSelectVote = useCallback(
@@ -172,6 +202,8 @@ export function PanelProvider({ children }: { children: ReactNode }) {
       panelOpen,
       openPanel,
       closePanel,
+      openVote,
+      registerVoteOpener,
       navigableVotes,
       currentVoteIndex,
       goToNextVote,
@@ -182,6 +214,8 @@ export function PanelProvider({ children }: { children: ReactNode }) {
     [
       closePanel,
       openPanel,
+      openVote,
+      registerVoteOpener,
       panelContent,
       panelOpen,
       panelType,

--- a/contexts/VoteSelectionContext.tsx
+++ b/contexts/VoteSelectionContext.tsx
@@ -1,0 +1,58 @@
+import {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useCallback,
+  useContext,
+  useMemo,
+} from "react";
+import { usePersistedVotes } from "hooks/helpers/usePersistedVotes";
+import { SelectedVotesByKeyT, VoteT } from "types";
+import { VoteTimingContext } from "./VoteTimingContext";
+
+export interface VoteSelectionContextState {
+  selectedVotes: SelectedVotesByKeyT;
+  selectVote: (value: string | undefined, vote: VoteT) => void;
+  setSelectedVotes: Dispatch<SetStateAction<SelectedVotesByKeyT>>;
+}
+
+export const defaultVoteSelectionContextState: VoteSelectionContextState = {
+  selectedVotes: {},
+  selectVote: () => null,
+  setSelectedVotes: () => null,
+};
+
+export const VoteSelectionContext = createContext<VoteSelectionContextState>(
+  defaultVoteSelectionContextState
+);
+
+// The current round's quick-vote selections, persisted per round. One shared
+// store read by the active-votes list and the vote panel alike, so the
+// panel's quick-vote controls work identically however it was opened (row
+// click, deeplink, history) without threading callbacks through openPanel.
+export function VoteSelectionProvider({ children }: { children: ReactNode }) {
+  const { roundId } = useContext(VoteTimingContext);
+  const [selectedVotes, setSelectedVotes] = usePersistedVotes(roundId);
+
+  const selectVote = useCallback(
+    (value: string | undefined, vote: VoteT) => {
+      setSelectedVotes((selected) => ({
+        ...selected,
+        [vote.uniqueKey]: value,
+      }));
+    },
+    [setSelectedVotes]
+  );
+
+  const value = useMemo(
+    () => ({ selectedVotes, selectVote, setSelectedVotes }),
+    [selectedVotes, selectVote, setSelectedVotes]
+  );
+
+  return (
+    <VoteSelectionContext.Provider value={value}>
+      {children}
+    </VoteSelectionContext.Provider>
+  );
+}

--- a/contexts/VotesContext.tsx
+++ b/contexts/VotesContext.tsx
@@ -57,6 +57,12 @@ export interface VotesContextState {
   activeVotesIsLoading: boolean;
   upcomingVotesIsLoading: boolean;
   pastVotesIsLoading: boolean;
+  // false when a list query is disabled (wrong chain, graph off) — unlike
+  // isLoading, which react-query v4 reports as true forever for a disabled
+  // query with no data. Consumers waiting for lists to settle must use these.
+  activeVotesIsInitialLoading: boolean;
+  upcomingVotesIsInitialLoading: boolean;
+  pastVotesIsInitialLoading: boolean;
   contentfulDataIsLoading: boolean;
   committedVotesIsLoading: boolean;
   committedVotesByCallerIsLoading: boolean;
@@ -93,6 +99,9 @@ export const defaultVotesContextState: VotesContextState = {
   activeVotesIsLoading: false,
   upcomingVotesIsLoading: false,
   pastVotesIsLoading: false,
+  activeVotesIsInitialLoading: false,
+  upcomingVotesIsInitialLoading: false,
+  pastVotesIsInitialLoading: false,
   contentfulDataIsLoading: false,
   committedVotesIsLoading: false,
   committedVotesByCallerIsLoading: false,
@@ -113,12 +122,21 @@ export function VotesProvider({ children }: { children: ReactNode }) {
   const userOrDelegatorAddress = isDelegate ? delegatorAddress : userAddress;
   const { data: designatedVotingV1Address } =
     useDesignatedVotingV1Address(userAddress);
-  const { data: activeVotesByKey, isLoading: activeVotesIsLoading } =
-    useActiveVotes();
-  const { data: upcomingVotesByKey, isLoading: upcomingVotesIsLoading } =
-    useUpcomingVotes();
-  const { data: pastVotesByKey, isLoading: pastVotesIsLoading } =
-    usePastVotes();
+  const {
+    data: activeVotesByKey,
+    isLoading: activeVotesIsLoading,
+    isInitialLoading: activeVotesIsInitialLoading,
+  } = useActiveVotes();
+  const {
+    data: upcomingVotesByKey,
+    isLoading: upcomingVotesIsLoading,
+    isInitialLoading: upcomingVotesIsInitialLoading,
+  } = useUpcomingVotes();
+  const {
+    data: pastVotesByKey,
+    isLoading: pastVotesIsLoading,
+    isInitialLoading: pastVotesIsInitialLoading,
+  } = usePastVotes();
   const { data: contentfulData, isLoading: contentfulDataIsLoading } =
     useContentfulData();
   const { data: committedVotes, isLoading: committedVotesIsLoading } =
@@ -318,6 +336,9 @@ export function VotesProvider({ children }: { children: ReactNode }) {
       activeVotesIsLoading,
       upcomingVotesIsLoading,
       pastVotesIsLoading,
+      activeVotesIsInitialLoading,
+      upcomingVotesIsInitialLoading,
+      pastVotesIsInitialLoading,
       contentfulDataIsLoading,
       committedVotesIsLoading,
       committedVotesByCallerIsLoading,
@@ -330,6 +351,9 @@ export function VotesProvider({ children }: { children: ReactNode }) {
       activeVoteList,
       activeVotesByKey,
       activeVotesIsLoading,
+      activeVotesIsInitialLoading,
+      upcomingVotesIsInitialLoading,
+      pastVotesIsInitialLoading,
       activityStatus,
       committedVotes,
       committedVotesByCallerIsLoading,

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -25,7 +25,6 @@ export {
   defaultPanelContextState,
   PanelContext,
   PanelProvider,
-  scrollToAndHighlightVote,
 } from "./PanelContext";
 export type { PanelContextState } from "./PanelContext";
 export {

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -29,6 +29,12 @@ export {
 } from "./PanelContext";
 export type { PanelContextState } from "./PanelContext";
 export {
+  defaultVoteSelectionContextState,
+  VoteSelectionContext,
+  VoteSelectionProvider,
+} from "./VoteSelectionContext";
+export type { VoteSelectionContextState } from "./VoteSelectionContext";
+export {
   defaultVotesContextState,
   VotesContext,
   VotesProvider,

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -25,6 +25,7 @@ export {
   defaultPanelContextState,
   PanelContext,
   PanelProvider,
+  scrollToAndHighlightVote,
 } from "./PanelContext";
 export type { PanelContextState } from "./PanelContext";
 export {

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -3,6 +3,7 @@ export { getIgnoredRequestToBeDelegateAddressesFromStorage } from "./delegation/
 export { calculateOutstandingRewards } from "./rewards/calculateOutstandingRewards";
 export { getCanUnstakeTime } from "./staking/getCanUnstakeTime";
 export { addOpacityToHsl } from "./util/addOpacityToHsl";
+export * from "./util/deeplink";
 export * from "./util/formatNumber";
 export { getEntriesForPage } from "./util/getEntriesForPage";
 export { handleNotifications } from "./util/handleNotifications";

--- a/helpers/util/deeplink.ts
+++ b/helpers/util/deeplink.ts
@@ -1,0 +1,90 @@
+import { ParsedUrlQuery } from "querystring";
+import { ActivityStatusT } from "types";
+
+// The voter dapp supports two deeplink forms, both as query params on any page:
+// 1. `?vote=<uniqueKey>` — canonical form, written to the URL bar whenever a
+//    vote panel is open, so copying the address bar shares the open vote.
+// 2. `?identifier=<string|bytes32Hex>&time=<unixSeconds>&ancillaryData=<0xHex>` —
+//    external form for other dapps (oracle dapp, explorer) that know the price
+//    request's on-chain fields but not our uniqueKey format. These are resolved
+//    to a uniqueKey via /api/resolve-deeplink, which also tolerates being given
+//    the L2-side ancillary data of a bridged request.
+export const voteDeeplinkQueryParam = "vote";
+export const externalDeeplinkQueryParams = [
+  "identifier",
+  "time",
+  "ancillaryData",
+] as const;
+
+export type ExternalVoteDeeplink = {
+  identifier: string;
+  time: number;
+  ancillaryData?: string;
+};
+
+export type ParsedVoteDeeplink =
+  | { form: "uniqueKey"; uniqueKey: string }
+  | ({ form: "external" } & ExternalVoteDeeplink);
+
+function getSingleParam(query: ParsedUrlQuery, key: string) {
+  const value = query[key];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function parseVoteDeeplink(
+  query: ParsedUrlQuery
+): ParsedVoteDeeplink | undefined {
+  const uniqueKey = getSingleParam(query, voteDeeplinkQueryParam);
+  if (uniqueKey) return { form: "uniqueKey", uniqueKey };
+
+  const identifier = getSingleParam(query, "identifier");
+  const time = Number(getSingleParam(query, "time"));
+  if (!identifier || !Number.isInteger(time) || time <= 0) return undefined;
+
+  return {
+    form: "external",
+    identifier,
+    time,
+    ancillaryData: getSingleParam(query, "ancillaryData"),
+  };
+}
+
+export type ResolvedVoteDeeplink = {
+  uniqueKey: string;
+  activityStatus: ActivityStatusT;
+};
+
+export const pathForActivityStatus: Record<ActivityStatusT, string> = {
+  active: "/",
+  upcoming: "/upcoming-votes",
+  past: "/past-votes",
+};
+
+/**
+ * Builds a URL that opens the voter dapp with the details panel for a specific
+ * price request. This is the canonical link-builder for other dapps (oracle
+ * dapp, explorer) — copy it as-is, it has no dependencies.
+ *
+ * @param identifier decoded identifier ("YES_OR_NO_QUERY") or bytes32 hex
+ * @param time request timestamp in unix seconds
+ * @param ancillaryData 0x-prefixed hex; the DVM (mainnet) ancillary data if you
+ *   have it, but the L2/oracle-side data of a bridged request also resolves
+ * @param baseUrl defaults to production; pass e.g. "https://testnet.vote.uma.xyz"
+ */
+export function makeVoterDappDeeplink({
+  identifier,
+  time,
+  ancillaryData,
+  baseUrl = "https://vote.uma.xyz",
+}: {
+  identifier: string;
+  time: number | string;
+  ancillaryData?: string;
+  baseUrl?: string;
+}): string {
+  const params = new URLSearchParams({ identifier, time: String(time) });
+  if (ancillaryData && ancillaryData !== "0x") {
+    params.set("ancillaryData", ancillaryData);
+  }
+  return `${baseUrl}/?${params.toString()}`;
+}

--- a/helpers/util/deeplink.ts
+++ b/helpers/util/deeplink.ts
@@ -1,5 +1,5 @@
 import { ParsedUrlQuery } from "querystring";
-import { ActivityStatusT } from "types";
+import { ActivityStatusT, RawPriceRequestDataT } from "types";
 
 // The voter dapp supports two deeplink forms, both as query params on any page:
 // 1. `?vote=<uniqueKey>` — canonical form, written to the URL bar whenever a
@@ -59,9 +59,18 @@ export function parseVoteDeeplink(
   };
 }
 
+// the raw price request as the resolver serializes it (JSON-safe time,
+// ancillaryDataL2 already resolved server-side)
+export type ResolvedVoteRequestT = Omit<RawPriceRequestDataT, "time"> & {
+  time: number;
+};
+
 export type ResolvedVoteDeeplink = {
   uniqueKey: string;
   activityStatus: ActivityStatusT;
+  // present so the panel can render the vote before the app's vote lists
+  // finish loading; older cached responses may lack it
+  request?: ResolvedVoteRequestT;
 };
 
 export const pathForActivityStatus: Record<ActivityStatusT, string> = {

--- a/helpers/util/deeplink.ts
+++ b/helpers/util/deeplink.ts
@@ -35,6 +35,11 @@ function getSingleParam(query: ParsedUrlQuery, key: string) {
   return Array.isArray(value) ? value[0] : value;
 }
 
+// next/router repeats a param as an array when it appears twice
+export function getVoteDeeplinkParam(query: ParsedUrlQuery) {
+  return getSingleParam(query, voteDeeplinkQueryParam);
+}
+
 export function parseVoteDeeplink(
   query: ParsedUrlQuery
 ): ParsedVoteDeeplink | undefined {

--- a/helpers/util/deeplink.ts
+++ b/helpers/util/deeplink.ts
@@ -4,22 +4,26 @@ import { ActivityStatusT } from "types";
 // The voter dapp supports two deeplink forms, both as query params on any page:
 // 1. `?vote=<uniqueKey>` — canonical form, written to the URL bar whenever a
 //    vote panel is open, so copying the address bar shares the open vote.
-// 2. `?identifier=<string|bytes32Hex>&time=<unixSeconds>&ancillaryData=<0xHex>` —
+// 2. `?identifier=<string|bytes32Hex>&time=<unixSeconds>&ancillaryDataHash=<0xHash>` —
 //    external form for other dapps (oracle dapp, explorer) that know the price
-//    request's on-chain fields but not our uniqueKey format. These are resolved
-//    to a uniqueKey via /api/resolve-deeplink, which also tolerates being given
-//    the L2-side ancillary data of a bridged request.
+//    request's on-chain fields but not our uniqueKey format. The hash is
+//    keccak256 of whichever ancillary data version the caller holds (raw
+//    request data, stamped, or DVM-side); /api/resolve-deeplink matches it
+//    against every variant it can reconstruct. Full `ancillaryData` is also
+//    accepted, but ancillary data is often far too long for a URL.
 export const voteDeeplinkQueryParam = "vote";
 export const externalDeeplinkQueryParams = [
   "identifier",
   "time",
   "ancillaryData",
+  "ancillaryDataHash",
 ] as const;
 
 export type ExternalVoteDeeplink = {
   identifier: string;
   time: number;
   ancillaryData?: string;
+  ancillaryDataHash?: string;
 };
 
 export type ParsedVoteDeeplink =
@@ -46,6 +50,7 @@ export function parseVoteDeeplink(
     identifier,
     time,
     ancillaryData: getSingleParam(query, "ancillaryData"),
+    ancillaryDataHash: getSingleParam(query, "ancillaryDataHash"),
   };
 }
 
@@ -67,23 +72,32 @@ export const pathForActivityStatus: Record<ActivityStatusT, string> = {
  *
  * @param identifier decoded identifier ("YES_OR_NO_QUERY") or bytes32 hex
  * @param time request timestamp in unix seconds
- * @param ancillaryData 0x-prefixed hex; the DVM (mainnet) ancillary data if you
- *   have it, but the L2/oracle-side data of a bridged request also resolves
+ * @param ancillaryDataHash keccak256 of the request's ancillary data, e.g.
+ *   `ethers.utils.keccak256(request.ancillaryData)`. Hash whichever version
+ *   you have — the raw request data, the oracle-stamped data, or the DVM-side
+ *   data all resolve. Strongly recommended: identifier+time alone is
+ *   ambiguous when several requests share a timestamp.
+ * @param ancillaryData full 0x-hex ancillary data; only use when it is short,
+ *   URLs have length limits
  * @param baseUrl defaults to production; pass e.g. "https://testnet.vote.uma.xyz"
  */
 export function makeVoterDappDeeplink({
   identifier,
   time,
+  ancillaryDataHash,
   ancillaryData,
   baseUrl = "https://vote.uma.xyz",
 }: {
   identifier: string;
   time: number | string;
+  ancillaryDataHash?: string;
   ancillaryData?: string;
   baseUrl?: string;
 }): string {
   const params = new URLSearchParams({ identifier, time: String(time) });
-  if (ancillaryData && ancillaryData !== "0x") {
+  if (ancillaryDataHash) {
+    params.set("ancillaryDataHash", ancillaryDataHash);
+  } else if (ancillaryData && ancillaryData !== "0x") {
     params.set("ancillaryData", ancillaryData);
   }
   return `${baseUrl}/?${params.toString()}`;

--- a/helpers/util/deeplink.ts
+++ b/helpers/util/deeplink.ts
@@ -97,7 +97,9 @@ export function makeVoterDappDeeplink({
   const params = new URLSearchParams({ identifier, time: String(time) });
   if (ancillaryDataHash) {
     params.set("ancillaryDataHash", ancillaryDataHash);
-  } else if (ancillaryData && ancillaryData !== "0x") {
+  } else if (ancillaryData) {
+    // keep "0x" — blank ancillary data still narrows resolution to a direct
+    // uniqueKey lookup when several requests share identifier and time
     params.set("ancillaryData", ancillaryData);
   }
   return `${baseUrl}/?${params.toString()}`;

--- a/helpers/util/scrollToVote.ts
+++ b/helpers/util/scrollToVote.ts
@@ -4,7 +4,11 @@
 // it has actually rendered (it may still be mounting during a page redirect
 // or pagination jump).
 export function scrollToAndHighlightVote(uniqueKey: string) {
-  const el = document.querySelector(`[data-vote-key="${uniqueKey}"]`);
+  // uniqueKey embeds the decoded identifier — arbitrary on-chain bytes, so
+  // escape it or a quote/backslash in it makes querySelector throw
+  const el = document.querySelector(
+    `[data-vote-key="${CSS.escape(uniqueKey)}"]`
+  );
   if (!el) return;
   el.scrollIntoView({ behavior: "smooth", block: "center" });
   el.classList.remove("vote-highlight");

--- a/helpers/util/scrollToVote.ts
+++ b/helpers/util/scrollToVote.ts
@@ -1,0 +1,14 @@
+// Scrolls a vote row into view and flashes its highlight. The element must
+// already be mounted: callers don't invoke this speculatively but set
+// PanelContext's voteScrollTarget, which the row consumes in an effect once
+// it has actually rendered (it may still be mounting during a page redirect
+// or pagination jump).
+export function scrollToAndHighlightVote(uniqueKey: string) {
+  const el = document.querySelector(`[data-vote-key="${uniqueKey}"]`);
+  if (!el) return;
+  el.scrollIntoView({ behavior: "smooth", block: "center" });
+  el.classList.remove("vote-highlight");
+  void (el as HTMLElement).offsetWidth;
+  el.classList.add("vote-highlight");
+  setTimeout(() => el.classList.remove("vote-highlight"), 1500);
+}

--- a/helpers/voting/makePriceRequestsByKey.ts
+++ b/helpers/voting/makePriceRequestsByKey.ts
@@ -29,7 +29,7 @@ function formatPriceRequests(priceRequests: RawPriceRequestDataT[]) {
     .filter((priceRequest): priceRequest is PriceRequestT => !!priceRequest);
 }
 
-function formatPriceRequest(
+export function formatPriceRequest(
   priceRequest: RawPriceRequestDataT
 ): PriceRequestT & VoteParticipationT & VoteResultsT {
   const time = BigNumber.isBigNumber(priceRequest.time)

--- a/helpers/voting/makeProvisionalVote.ts
+++ b/helpers/voting/makeProvisionalVote.ts
@@ -1,0 +1,46 @@
+import { BigNumber } from "ethers";
+import { ResolvedVoteRequestT } from "helpers/util/deeplink";
+import { VoteT } from "types";
+import { getVoteMetaData } from "./getVoteMetaData";
+import { formatPriceRequest } from "./makePriceRequestsByKey";
+
+// A renderable vote built from the deeplink resolver's entity alone — what a
+// logged-out user sees. The deeplink handler opens the panel with this while
+// the app's vote lists are still loading, then swaps in the canonical vote
+// (prev/next arrows, user data, contentful) once they arrive. Same pipeline
+// helpers as the lists use, so the provisional and final renders agree.
+//
+// uniqueKey comes from the resolver (it IS the subgraph id), not from
+// re-deriving it locally: an identifier that doesn't round-trip through the
+// hex encoding would otherwise yield a key that never matches the URL's.
+export function makeProvisionalVote(
+  request: ResolvedVoteRequestT,
+  uniqueKey: string
+): VoteT {
+  const priceRequest = formatPriceRequest(request);
+  return {
+    ...priceRequest,
+    ...getVoteMetaData(
+      priceRequest.decodedIdentifier,
+      priceRequest.decodedAncillaryData,
+      undefined
+    ),
+    uniqueKey,
+    isCommitted: undefined,
+    commitHash: undefined,
+    isRevealed: undefined,
+    revealHash: undefined,
+    canReveal: undefined,
+    encryptedVote: undefined,
+    decryptedVote: undefined,
+    contentfulData: undefined,
+    decodedAdminTransactions: undefined,
+    voteHistory: {
+      uniqueKey,
+      voted: false,
+      correctness: false,
+      staking: false,
+      slashAmount: BigNumber.from(0),
+    },
+  };
+}

--- a/helpers/voting/makeUniqueKeyForVote.ts
+++ b/helpers/voting/makeUniqueKeyForVote.ts
@@ -11,5 +11,20 @@ export function makeUniqueKeyForVote(
   const dataToHash =
     ancillaryData && ancillaryData !== "0x" ? ancillaryData : "0x";
   const ancillaryDataHash = utils.keccak256(dataToHash);
-  return `${decodedIdentifier}-${time}-${ancillaryDataHash}`;
+  return makeUniqueKeyFromAncillaryHash(
+    decodedIdentifier,
+    time,
+    ancillaryDataHash
+  );
+}
+
+// For callers that hold keccak256(ancillaryData) instead of the data itself.
+// The votingV2 subgraph's PriceRequest.id shares this exact format, so every
+// construction of it must live in this module.
+export function makeUniqueKeyFromAncillaryHash(
+  decodedIdentifier: string,
+  time: number,
+  ancillaryDataHash: string
+) {
+  return `${decodedIdentifier}-${time}-${ancillaryDataHash.toLowerCase()}`;
 }

--- a/helpers/web3/decodeHexString.ts
+++ b/helpers/web3/decodeHexString.ts
@@ -1,5 +1,6 @@
+// deliberately avoids the "helpers" barrel so pure consumers (lib matching
+// code, unit tests) don't drag in the env-validated config module
 import { ethers } from "ethers";
-import { toUtf8String } from "helpers";
 import { object, string, optional } from "superstruct";
 
 export function encodeHexString(str: string): string {
@@ -8,7 +9,7 @@ export function encodeHexString(str: string): string {
 
 export function decodeHexString(hexString: string) {
   try {
-    const utf8String = toUtf8String(hexString);
+    const utf8String = ethers.utils.toUtf8String(hexString);
     // eslint-disable-next-line no-control-regex
     const paddingRemoved = utf8String.replace(/\u0000/g, "");
     return paddingRemoved;

--- a/hooks/contexts/useVoteSelectionContext.ts
+++ b/hooks/contexts/useVoteSelectionContext.ts
@@ -1,0 +1,4 @@
+import { VoteSelectionContext } from "contexts";
+import { useContext } from "react";
+
+export const useVoteSelectionContext = () => useContext(VoteSelectionContext);

--- a/hooks/helpers/useDeeplinkedVoteIndex.ts
+++ b/hooks/helpers/useDeeplinkedVoteIndex.ts
@@ -1,0 +1,39 @@
+import { voteDeeplinkQueryParam } from "helpers/util/deeplink";
+import { useRouter } from "next/router";
+import { useEffect, useMemo, useRef } from "react";
+import { VoteT } from "types";
+
+/**
+ * Index of the vote a `?vote=` deeplink points to within the given list, for
+ * driving `usePagination(votes, findIndex)` to the vote's page. Reported once
+ * per key — afterwards it returns undefined so the user can page freely while
+ * the panel (and its URL param) stays open.
+ */
+export function useDeeplinkedVoteIndex(votes: VoteT[] | undefined) {
+  const router = useRouter();
+  const appliedKeyRef = useRef<string>();
+  const value = router.query[voteDeeplinkQueryParam];
+  const targetKey = router.isReady
+    ? Array.isArray(value)
+      ? value[0]
+      : value
+    : undefined;
+
+  const index = useMemo(() => {
+    if (!targetKey || appliedKeyRef.current === targetKey || !votes?.length) {
+      return undefined;
+    }
+    const found = votes.findIndex(({ uniqueKey }) => uniqueKey === targetKey);
+    return found === -1 ? undefined : found;
+  }, [targetKey, votes]);
+
+  useEffect(() => {
+    if (!targetKey) {
+      appliedKeyRef.current = undefined;
+    } else if (index !== undefined) {
+      appliedKeyRef.current = targetKey;
+    }
+  }, [index, targetKey]);
+
+  return index;
+}

--- a/hooks/helpers/useDeeplinkedVoteIndex.ts
+++ b/hooks/helpers/useDeeplinkedVoteIndex.ts
@@ -1,36 +1,25 @@
-import { getVoteDeeplinkParam } from "helpers/util/deeplink";
-import { useRouter } from "next/router";
-import { useEffect, useMemo, useRef } from "react";
+import { usePanelContext } from "hooks/contexts/usePanelContext";
+import { useMemo } from "react";
 import { VoteT } from "types";
 
 /**
- * Index of the vote `?vote=` points to within the given list, for driving
- * `usePagination(votes, findIndex)` to the vote's page. Reported once per
- * key — afterwards it returns undefined so the user can page freely while
- * the panel (and its URL param) stays open.
+ * Index of the vote a pending scroll-and-highlight request points to within
+ * the given list, for driving `usePagination(votes, findIndex)` to the
+ * vote's page so the row can mount and consume the request. Keyed on
+ * PanelContext's voteScrollTarget — set for inbound deeplinks and panel-arrow
+ * navigation but not for plain row clicks, so in-app opens (e.g. from the
+ * history panel) never yank the user's pagination. The target is cleared
+ * when the row consumes it, after which this returns undefined and the user
+ * can page freely while the panel (and its URL param) stays open.
  */
 export function useDeeplinkedVoteIndex(votes: VoteT[] | undefined) {
-  const router = useRouter();
-  const appliedKeyRef = useRef<string>();
-  const targetKey = router.isReady
-    ? getVoteDeeplinkParam(router.query)
-    : undefined;
+  const { voteScrollTarget } = usePanelContext();
 
-  const index = useMemo(() => {
-    if (!targetKey || appliedKeyRef.current === targetKey || !votes?.length) {
-      return undefined;
-    }
-    const found = votes.findIndex(({ uniqueKey }) => uniqueKey === targetKey);
+  return useMemo(() => {
+    if (!voteScrollTarget || !votes?.length) return undefined;
+    const found = votes.findIndex(
+      ({ uniqueKey }) => uniqueKey === voteScrollTarget
+    );
     return found === -1 ? undefined : found;
-  }, [targetKey, votes]);
-
-  useEffect(() => {
-    if (!targetKey) {
-      appliedKeyRef.current = undefined;
-    } else if (index !== undefined) {
-      appliedKeyRef.current = targetKey;
-    }
-  }, [index, targetKey]);
-
-  return index;
+  }, [voteScrollTarget, votes]);
 }

--- a/hooks/helpers/useDeeplinkedVoteIndex.ts
+++ b/hooks/helpers/useDeeplinkedVoteIndex.ts
@@ -1,22 +1,19 @@
-import { voteDeeplinkQueryParam } from "helpers/util/deeplink";
+import { getVoteDeeplinkParam } from "helpers/util/deeplink";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useRef } from "react";
 import { VoteT } from "types";
 
 /**
- * Index of the vote a `?vote=` deeplink points to within the given list, for
- * driving `usePagination(votes, findIndex)` to the vote's page. Reported once
- * per key — afterwards it returns undefined so the user can page freely while
+ * Index of the vote `?vote=` points to within the given list, for driving
+ * `usePagination(votes, findIndex)` to the vote's page. Reported once per
+ * key — afterwards it returns undefined so the user can page freely while
  * the panel (and its URL param) stays open.
  */
 export function useDeeplinkedVoteIndex(votes: VoteT[] | undefined) {
   const router = useRouter();
   const appliedKeyRef = useRef<string>();
-  const value = router.query[voteDeeplinkQueryParam];
   const targetKey = router.isReady
-    ? Array.isArray(value)
-      ? value[0]
-      : value
+    ? getVoteDeeplinkParam(router.query)
     : undefined;
 
   const index = useMemo(() => {

--- a/hooks/helpers/usePersistedVotes.ts
+++ b/hooks/helpers/usePersistedVotes.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, Dispatch, SetStateAction } from "react";
+import { useState, useEffect, useRef, Dispatch, SetStateAction } from "react";
 import { SelectedVotesByKeyT } from "types";
 
 const STORAGE_KEY = "uma-voter-selected-votes";
@@ -25,21 +25,25 @@ export function usePersistedVotes(
   roundId: number
 ): [SelectedVotesByKeyT, Dispatch<SetStateAction<SelectedVotesByKeyT>>] {
   const [votes, setVotes] = useState<SelectedVotesByKeyT>({});
-  const [hasLoaded, setHasLoaded] = useState(false);
+  const loadedRoundRef = useRef<number>();
 
+  // (Re)load whenever the round changes, not just on mount: the hook lives in
+  // an app-lifetime provider, so a round can roll over while it is mounted.
+  // Reloading drops the previous round's selections (via the roundId check in
+  // loadFromStorage) instead of carrying them into — and persisting them
+  // under — the new round, where a rolled vote shares its uniqueKey. One
+  // effect, so a round change can never persist state belonging to the
+  // previous round before the reload lands.
   useEffect(() => {
-    if (roundId && !hasLoaded) {
+    if (!roundId) return;
+    if (loadedRoundRef.current !== roundId) {
+      loadedRoundRef.current = roundId;
       setVotes(loadFromStorage(roundId));
-      setHasLoaded(true);
+      return;
     }
-  }, [roundId, hasLoaded]);
-
-  useEffect(() => {
-    if (roundId && hasLoaded) {
-      const data: StoredVotesData = { roundId, votes };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-    }
-  }, [votes, roundId, hasLoaded]);
+    const data: StoredVotesData = { roundId, votes };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }, [votes, roundId]);
 
   return [votes, setVotes];
 }

--- a/hooks/helpers/useVoteDeeplink.ts
+++ b/hooks/helpers/useVoteDeeplink.ts
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { scrollToAndHighlightVote } from "contexts";
 import { emitErrorEvent } from "helpers";
 import {
   externalDeeplinkQueryParams,
@@ -11,16 +10,10 @@ import {
 import { usePanelContext } from "hooks/contexts/usePanelContext";
 import { useVotesContext } from "hooks/contexts/useVotesContext";
 import { useRouter } from "next/router";
-import { ParsedUrlQuery } from "querystring";
 import { useEffect, useRef } from "react";
-import { ActivityStatusT } from "types";
+import { ActivityStatusT, VoteT } from "types";
 
 const activityStatuses: ActivityStatusT[] = ["active", "upcoming", "past"];
-
-function getVoteParam(query: ParsedUrlQuery) {
-  const value = query[voteDeeplinkQueryParam];
-  return Array.isArray(value) ? value[0] : value;
-}
 
 function notifyVoteNotFound() {
   emitErrorEvent({
@@ -30,21 +23,33 @@ function notifyVoteNotFound() {
 }
 
 /**
- * Two-way sync between the URL and the vote details panel:
- * - inbound `?vote=` / `?identifier=&time=&ancillaryData=` params open the
- *   panel on the correct page once vote data is available
- * - an open vote panel writes `?vote=<uniqueKey>` to the address bar (shallow,
- *   so the panel survives), making the URL itself the shareable deeplink
+ * Derives the vote panel from the URL. The `?vote=` param is the single
+ * source of truth: useVoteUrl writes it (row clicks, panel arrows, panel
+ * close) and this hook is the only place that opens or closes the vote panel
+ * in response — the same path handles inbound links, back/forward, and
+ * in-app actions, so panel and URL cannot disagree.
  *
- * The URL-sync effect acts on TRANSITIONS (panel just opened/closed, param
- * just disappeared), never on plain state. Effects in one commit see sibling
- * state updates and router changes with a delay, so state-based conditions
- * here misfire and fight each other (open panel <-> strip param loops).
+ * External-form links (`?identifier=&time=&ancillaryDataHash=`) are resolved
+ * server-side first and rewritten to the canonical `?vote=` form.
+ *
+ * Inbound navigations (nothing initiated in-app via expectedVoteRef) land on
+ * the vote's own page and scroll-highlight its row; in-app opens act in
+ * place, so e.g. the history panel's rows open votes on whatever page the
+ * user is on.
  */
 export function useVoteDeeplink() {
   const router = useRouter();
-  const { panelType, panelContent, panelOpen, openVote, closePanel } =
-    usePanelContext();
+  const {
+    panelType,
+    panelContent,
+    panelOpen,
+    openPanel,
+    closePanel,
+    showVote,
+    expectedVoteRef,
+    requestVoteScroll,
+    clearVoteScroll,
+  } = usePanelContext();
   const {
     voteListsByActivityStatus,
     activeVotesIsLoading,
@@ -56,16 +61,11 @@ export function useVoteDeeplink() {
   const external = parsed?.form === "external" ? parsed : undefined;
   const targetKey = parsed?.form === "uniqueKey" ? parsed.uniqueKey : undefined;
 
-  // the key we already acted on, so the open-effect runs once per inbound link
-  const handledKeyRef = useRef<string>();
-  // previous values, so the URL-sync effect can detect transitions
-  const prevOpenKeyRef = useRef<string>();
-  const prevParamRef = useRef<string>();
-  // during a real page navigation we must not fire shallow replaces to clean
-  // up params — they would abort the navigation, and the destination route
-  // doesn't carry the param anyway
+  // While a real page navigation is in flight the router still reports the
+  // OLD query, but Nav has already closed the panel — acting on that stale
+  // combination would reopen the panel mid-navigation. Wait it out; the
+  // deriver re-runs when the route settles (query/pathname change).
   const navigatingRef = useRef(false);
-
   useEffect(() => {
     function handleStart(_url: string, { shallow }: { shallow: boolean }) {
       if (!shallow) navigatingRef.current = true;
@@ -113,6 +113,13 @@ export function useVoteDeeplink() {
     if (!external) return;
     if (resolveFailed) {
       notifyVoteNotFound();
+      // drop the params so the URL doesn't keep pointing at nothing
+      const query = { ...router.query };
+      externalDeeplinkQueryParams.forEach((param) => delete query[param]);
+      void router.replace({ pathname: router.pathname, query }, undefined, {
+        shallow: true,
+        scroll: false,
+      });
       return;
     }
     if (!resolved) return;
@@ -127,48 +134,83 @@ export function useVoteDeeplink() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [external?.identifier, external?.time, resolved, resolveFailed]);
 
-  // inbound `?vote=<uniqueKey>`: find the vote, switch pages if needed, open
+  // the deriver: make the panel state match `?vote=`
   useEffect(() => {
-    if (!targetKey || handledKeyRef.current === targetKey) return;
+    if (!router.isReady || navigatingRef.current) return;
+    const voteShowing = panelOpen && panelType === "vote";
+    const expected = expectedVoteRef.current;
 
-    if (
-      panelOpen &&
-      panelType === "vote" &&
-      panelContent?.uniqueKey === targetKey
-    ) {
-      // the panel wrote this param itself, nothing to do
-      handledKeyRef.current = targetKey;
-      return;
-    }
-
-    for (const status of activityStatuses) {
-      const votes = voteListsByActivityStatus[status];
-      if (!votes) continue;
-      const vote = votes.find(({ uniqueKey }) => uniqueKey === targetKey);
-      if (!vote) continue;
-
-      const pathname = pathForActivityStatus[status];
-      if (router.pathname !== pathname) {
-        void router.replace({ pathname, query: router.query }, undefined, {
-          scroll: false,
-        });
-        return;
+    if (!targetKey) {
+      // param gone (back button, close, page navigation): close a showing
+      // vote panel — a plain closePanel pops back to whatever panel the
+      // vote was stacked on (e.g. the history panel)
+      if (voteShowing) {
+        expectedVoteRef.current = undefined;
+        clearVoteScroll();
+        closePanel();
       }
-      handledKeyRef.current = targetKey;
-      openVote(vote, votes);
-      scrollToAndHighlightVote(targetKey);
       return;
     }
 
-    const stillLoading =
-      activeVotesIsLoading || upcomingVotesIsLoading || pastVotesIsLoading;
-    if (!stillLoading) {
-      handledKeyRef.current = targetKey;
-      notifyVoteNotFound();
+    if (voteShowing && panelContent?.uniqueKey === targetKey) return;
+
+    const selfInitiated = expected?.key === targetKey;
+
+    // a non-vote panel is on top and didn't ask for this vote (e.g. a menu
+    // covering the vote the param still describes) — leave both alone
+    if (panelOpen && panelType !== "vote" && !selfInitiated) return;
+
+    let vote: VoteT | undefined;
+    let status: ActivityStatusT | undefined;
+    for (const s of activityStatuses) {
+      vote = voteListsByActivityStatus[s]?.find(
+        (v) => v.uniqueKey === targetKey
+      );
+      if (vote) {
+        status = s;
+        break;
+      }
     }
+
+    if (!vote || !status) {
+      const stillLoading =
+        activeVotesIsLoading || upcomingVotesIsLoading || pastVotesIsLoading;
+      if (stillLoading) return; // effect re-runs when the lists arrive
+      expectedVoteRef.current = undefined;
+      notifyVoteNotFound();
+      const query = { ...router.query };
+      delete query[voteDeeplinkQueryParam];
+      void router.replace({ pathname: router.pathname, query }, undefined, {
+        shallow: true,
+        scroll: false,
+      });
+      return;
+    }
+
+    // an inbound link with nothing open lands on the vote's own page so the
+    // highlighted row is visible behind the panel; in-app opens stay put
+    const pathname = pathForActivityStatus[status];
+    if (!selfInitiated && !panelOpen && router.pathname !== pathname) {
+      void router.replace({ pathname, query: router.query }, undefined, {
+        scroll: false,
+      });
+      return; // effect re-runs once the navigation lands
+    }
+
+    const votes = voteListsByActivityStatus[status] ?? [];
+    if (voteShowing) {
+      showVote(vote, votes);
+    } else {
+      // openPanel stacks, so a vote opened from the history panel returns
+      // there on close
+      openPanel("vote", vote, { navigableVotes: votes });
+    }
+    if (!selfInitiated || expected?.scroll) requestVoteScroll(targetKey);
+    expectedVoteRef.current = undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     targetKey,
+    router.isReady,
     router.pathname,
     panelOpen,
     panelType,
@@ -178,54 +220,4 @@ export function useVoteDeeplink() {
     upcomingVotesIsLoading,
     pastVotesIsLoading,
   ]);
-
-  // keep the URL in sync with the panel, reacting only to transitions
-  useEffect(() => {
-    if (!router.isReady) return;
-    const param = getVoteParam(router.query);
-    const openKey =
-      panelOpen && panelType === "vote" ? panelContent?.uniqueKey : undefined;
-    const prevOpenKey = prevOpenKeyRef.current;
-    const prevParam = prevParamRef.current;
-    prevOpenKeyRef.current = openKey;
-    prevParamRef.current = param;
-
-    // panel just opened or switched to another vote -> write the param;
-    // push (not replace) so the browser back button closes the panel
-    if (openKey && openKey !== prevOpenKey) {
-      handledKeyRef.current = openKey;
-      if (param !== openKey) {
-        const query = { ...router.query };
-        externalDeeplinkQueryParams.forEach((key) => delete query[key]);
-        query[voteDeeplinkQueryParam] = openKey;
-        void router.push({ pathname: router.pathname, query }, undefined, {
-          shallow: true,
-          scroll: false,
-        });
-      }
-      return;
-    }
-
-    // panel just closed -> remove the param
-    if (!openKey && prevOpenKey) {
-      handledKeyRef.current = undefined;
-      if (param && !navigatingRef.current) {
-        const query = { ...router.query };
-        delete query[voteDeeplinkQueryParam];
-        void router.replace({ pathname: router.pathname, query }, undefined, {
-          shallow: true,
-          scroll: false,
-        });
-      }
-      return;
-    }
-
-    // param just disappeared while the panel is open (back button) -> close
-    if (openKey && !param && prevParam) {
-      handledKeyRef.current = undefined;
-      prevOpenKeyRef.current = undefined;
-      closePanel(true);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [panelOpen, panelType, panelContent, router.isReady, router.query]);
 }

--- a/hooks/helpers/useVoteDeeplink.ts
+++ b/hooks/helpers/useVoteDeeplink.ts
@@ -43,7 +43,7 @@ function notifyVoteNotFound() {
  */
 export function useVoteDeeplink() {
   const router = useRouter();
-  const { panelType, panelContent, panelOpen, openPanel, closePanel } =
+  const { panelType, panelContent, panelOpen, openVote, closePanel } =
     usePanelContext();
   const {
     voteListsByActivityStatus,
@@ -143,7 +143,8 @@ export function useVoteDeeplink() {
 
     for (const status of activityStatuses) {
       const votes = voteListsByActivityStatus[status];
-      const vote = votes?.find(({ uniqueKey }) => uniqueKey === targetKey);
+      if (!votes) continue;
+      const vote = votes.find(({ uniqueKey }) => uniqueKey === targetKey);
       if (!vote) continue;
 
       const pathname = pathForActivityStatus[status];
@@ -154,7 +155,7 @@ export function useVoteDeeplink() {
         return;
       }
       handledKeyRef.current = targetKey;
-      openPanel("vote", vote, { navigableVotes: votes });
+      openVote(vote, votes);
       scrollToAndHighlightVote(targetKey);
       return;
     }

--- a/hooks/helpers/useVoteDeeplink.ts
+++ b/hooks/helpers/useVoteDeeplink.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { emitErrorEvent } from "helpers";
 import {
   externalDeeplinkQueryParams,
@@ -7,10 +7,11 @@ import {
   ResolvedVoteDeeplink,
   voteDeeplinkQueryParam,
 } from "helpers/util/deeplink";
+import { makeProvisionalVote } from "helpers/voting/makeProvisionalVote";
 import { usePanelContext } from "hooks/contexts/usePanelContext";
 import { useVotesContext } from "hooks/contexts/useVotesContext";
 import { useRouter } from "next/router";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { ActivityStatusT, VoteT } from "types";
 
 const activityStatuses: ActivityStatusT[] = ["active", "upcoming", "past"];
@@ -36,6 +37,12 @@ function notifyVoteNotFound() {
  * the vote's own page and scroll-highlight its row; in-app opens act in
  * place, so e.g. the history panel's rows open votes on whatever page the
  * user is on.
+ *
+ * The resolver returns the price request itself, so while the app's vote
+ * lists are still loading the panel opens with a PROVISIONAL vote built from
+ * that entity (the logged-out view, no prev/next). Once the lists arrive the
+ * canonical vote is swapped in through the same showVote path that handles
+ * every other vote-to-vote transition.
  */
 export function useVoteDeeplink() {
   const router = useRouter();
@@ -57,9 +64,46 @@ export function useVoteDeeplink() {
     pastVotesIsInitialLoading,
   } = useVotesContext();
 
+  const queryClient = useQueryClient();
+
   const parsed = router.isReady ? parseVoteDeeplink(router.query) : undefined;
   const external = parsed?.form === "external" ? parsed : undefined;
   const targetKey = parsed?.form === "uniqueKey" ? parsed.uniqueKey : undefined;
+
+  // isInitialLoading, not isLoading: a disabled list query (wrong chain,
+  // graph off) reports isLoading forever, which would leave the deeplink
+  // stuck waiting instead of surfacing the not-found notification
+  const votesStillLoading =
+    activeVotesIsInitialLoading ||
+    upcomingVotesIsInitialLoading ||
+    pastVotesIsInitialLoading;
+  const targetInLists = useMemo(
+    () =>
+      !!targetKey &&
+      activityStatuses.some((status) =>
+        voteListsByActivityStatus[status]?.some(
+          (vote) => vote.uniqueKey === targetKey
+        )
+      ),
+    [targetKey, voteListsByActivityStatus]
+  );
+
+  // canonical links: fetch the entity so the panel can render before the
+  // lists load; external links seed this cache from their own resolution
+  const { data: targetEntity } = useQuery({
+    queryKey: ["voteDeeplinkEntity", targetKey],
+    queryFn: async (): Promise<ResolvedVoteDeeplink> => {
+      const params = new URLSearchParams({ vote: targetKey ?? "" });
+      const response = await fetch(
+        `/api/resolve-deeplink?${params.toString()}`
+      );
+      if (!response.ok) throw new Error("Deeplink entity fetch failed");
+      return (await response.json()) as ResolvedVoteDeeplink;
+    },
+    enabled: !!targetKey && !targetInLists && votesStillLoading,
+    staleTime: Infinity,
+    retry: 1,
+  });
 
   // While a real page navigation is in flight the router still reports the
   // OLD query, but Nav has already closed the panel — acting on that stale
@@ -123,6 +167,12 @@ export function useVoteDeeplink() {
       return;
     }
     if (!resolved) return;
+    // the external resolution already carries the entity — seed the canonical
+    // key's cache so the provisional panel opens without a second fetch
+    queryClient.setQueryData(
+      ["voteDeeplinkEntity", resolved.uniqueKey],
+      resolved
+    );
     const pathname = pathForActivityStatus[resolved.activityStatus];
     const query = { ...router.query };
     externalDeeplinkQueryParams.forEach((param) => delete query[param]);
@@ -133,6 +183,10 @@ export function useVoteDeeplink() {
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [external?.identifier, external?.time, resolved, resolveFailed]);
+
+  // the vote panel is showing a provisional build of this key, awaiting the
+  // canonical vote from the lists
+  const provisionalKeyRef = useRef<string>();
 
   // the deriver: make the panel state match `?vote=`
   useEffect(() => {
@@ -145,6 +199,7 @@ export function useVoteDeeplink() {
       // for a vote whose param is gone must never fire — clear it even when
       // something else (e.g. Nav on navigation) already closed the panel
       clearVoteScroll();
+      provisionalKeyRef.current = undefined;
       // close a showing vote panel — a plain closePanel pops back to
       // whatever panel the vote was stacked on (e.g. the history panel)
       if (voteShowing) {
@@ -154,7 +209,16 @@ export function useVoteDeeplink() {
       return;
     }
 
-    if (voteShowing && panelContent?.uniqueKey === targetKey) return;
+    // a provisional panel with the right key still needs its canonical
+    // upgrade, so it does not count as "in sync"
+    const upgradingProvisional = provisionalKeyRef.current === targetKey;
+    if (
+      voteShowing &&
+      panelContent?.uniqueKey === targetKey &&
+      !upgradingProvisional
+    ) {
+      return;
+    }
 
     const selfInitiated = expected?.key === targetKey;
 
@@ -175,14 +239,35 @@ export function useVoteDeeplink() {
     }
 
     if (!vote || !status) {
-      // isInitialLoading, not isLoading: a disabled list query (wrong chain,
-      // graph off) reports isLoading forever, which would leave the deeplink
-      // silently unresolved instead of surfacing the not-found notification
-      const stillLoading =
-        activeVotesIsInitialLoading ||
-        upcomingVotesIsInitialLoading ||
-        pastVotesIsInitialLoading;
-      if (stillLoading) return; // effect re-runs when the lists arrive
+      const entity =
+        targetEntity?.uniqueKey === targetKey ? targetEntity : undefined;
+      if (votesStillLoading) {
+        // show what the resolver already knows instead of waiting for the
+        // full vote lists; entity errors just fall back to the waiting path
+        if (!entity?.request) return;
+        const pathname = pathForActivityStatus[entity.activityStatus];
+        if (!selfInitiated && !panelOpen && router.pathname !== pathname) {
+          void router.replace({ pathname, query: router.query }, undefined, {
+            scroll: false,
+          });
+          return;
+        }
+        if (voteShowing && panelContent?.uniqueKey === targetKey) return;
+        const provisional = makeProvisionalVote(entity.request, entity.uniqueKey);
+        if (voteShowing) {
+          showVote(provisional, []);
+        } else {
+          openPanel("vote", provisional, { navigableVotes: [] });
+        }
+        provisionalKeyRef.current = targetKey;
+        // consumed once the lists render the row
+        if (!selfInitiated || expected?.scroll) requestVoteScroll(targetKey);
+        expectedVoteRef.current = undefined;
+        return;
+      }
+      // the lists are loaded and lack the vote, but a provisional panel is
+      // showing it: the resolver's entity is authoritative, lists can lag
+      if (upgradingProvisional && voteShowing) return;
       expectedVoteRef.current = undefined;
       notifyVoteNotFound();
       const query = { ...router.query };
@@ -212,19 +297,22 @@ export function useVoteDeeplink() {
       // there on close
       openPanel("vote", vote, { navigableVotes: votes });
     }
-    if (!selfInitiated || expected?.scroll) requestVoteScroll(targetKey);
+    // a provisional upgrade already requested its scroll when it opened
+    if ((!selfInitiated || expected?.scroll) && !upgradingProvisional) {
+      requestVoteScroll(targetKey);
+    }
+    provisionalKeyRef.current = undefined;
     expectedVoteRef.current = undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     targetKey,
+    targetEntity,
     router.isReady,
     router.pathname,
     panelOpen,
     panelType,
     panelContent,
     voteListsByActivityStatus,
-    activeVotesIsInitialLoading,
-    upcomingVotesIsInitialLoading,
-    pastVotesIsInitialLoading,
+    votesStillLoading,
   ]);
 }

--- a/hooks/helpers/useVoteDeeplink.ts
+++ b/hooks/helpers/useVoteDeeplink.ts
@@ -52,9 +52,9 @@ export function useVoteDeeplink() {
   } = usePanelContext();
   const {
     voteListsByActivityStatus,
-    activeVotesIsLoading,
-    upcomingVotesIsLoading,
-    pastVotesIsLoading,
+    activeVotesIsInitialLoading,
+    upcomingVotesIsInitialLoading,
+    pastVotesIsInitialLoading,
   } = useVotesContext();
 
   const parsed = router.isReady ? parseVoteDeeplink(router.query) : undefined;
@@ -141,12 +141,14 @@ export function useVoteDeeplink() {
     const expected = expectedVoteRef.current;
 
     if (!targetKey) {
-      // param gone (back button, close, page navigation): close a showing
-      // vote panel — a plain closePanel pops back to whatever panel the
-      // vote was stacked on (e.g. the history panel)
+      // param gone (back button, close, page navigation): a pending scroll
+      // for a vote whose param is gone must never fire — clear it even when
+      // something else (e.g. Nav on navigation) already closed the panel
+      clearVoteScroll();
+      // close a showing vote panel — a plain closePanel pops back to
+      // whatever panel the vote was stacked on (e.g. the history panel)
       if (voteShowing) {
         expectedVoteRef.current = undefined;
-        clearVoteScroll();
         closePanel();
       }
       return;
@@ -173,8 +175,13 @@ export function useVoteDeeplink() {
     }
 
     if (!vote || !status) {
+      // isInitialLoading, not isLoading: a disabled list query (wrong chain,
+      // graph off) reports isLoading forever, which would leave the deeplink
+      // silently unresolved instead of surfacing the not-found notification
       const stillLoading =
-        activeVotesIsLoading || upcomingVotesIsLoading || pastVotesIsLoading;
+        activeVotesIsInitialLoading ||
+        upcomingVotesIsInitialLoading ||
+        pastVotesIsInitialLoading;
       if (stillLoading) return; // effect re-runs when the lists arrive
       expectedVoteRef.current = undefined;
       notifyVoteNotFound();
@@ -216,8 +223,8 @@ export function useVoteDeeplink() {
     panelType,
     panelContent,
     voteListsByActivityStatus,
-    activeVotesIsLoading,
-    upcomingVotesIsLoading,
-    pastVotesIsLoading,
+    activeVotesIsInitialLoading,
+    upcomingVotesIsInitialLoading,
+    pastVotesIsInitialLoading,
   ]);
 }

--- a/hooks/helpers/useVoteDeeplink.ts
+++ b/hooks/helpers/useVoteDeeplink.ts
@@ -92,7 +92,9 @@ export function useVoteDeeplink() {
         identifier: external.identifier,
         time: String(external.time),
       });
-      if (external.ancillaryData) {
+      if (external.ancillaryDataHash) {
+        params.set("ancillaryDataHash", external.ancillaryDataHash);
+      } else if (external.ancillaryData) {
         params.set("ancillaryData", external.ancillaryData);
       }
       const response = await fetch(

--- a/hooks/helpers/useVoteDeeplink.ts
+++ b/hooks/helpers/useVoteDeeplink.ts
@@ -1,0 +1,228 @@
+import { useQuery } from "@tanstack/react-query";
+import { scrollToAndHighlightVote } from "contexts";
+import { emitErrorEvent } from "helpers";
+import {
+  externalDeeplinkQueryParams,
+  parseVoteDeeplink,
+  pathForActivityStatus,
+  ResolvedVoteDeeplink,
+  voteDeeplinkQueryParam,
+} from "helpers/util/deeplink";
+import { usePanelContext } from "hooks/contexts/usePanelContext";
+import { useVotesContext } from "hooks/contexts/useVotesContext";
+import { useRouter } from "next/router";
+import { ParsedUrlQuery } from "querystring";
+import { useEffect, useRef } from "react";
+import { ActivityStatusT } from "types";
+
+const activityStatuses: ActivityStatusT[] = ["active", "upcoming", "past"];
+
+function getVoteParam(query: ParsedUrlQuery) {
+  const value = query[voteDeeplinkQueryParam];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function notifyVoteNotFound() {
+  emitErrorEvent({
+    message: "Unable to find the vote this link points to.",
+    pendingId: "vote-deeplink-error",
+  });
+}
+
+/**
+ * Two-way sync between the URL and the vote details panel:
+ * - inbound `?vote=` / `?identifier=&time=&ancillaryData=` params open the
+ *   panel on the correct page once vote data is available
+ * - an open vote panel writes `?vote=<uniqueKey>` to the address bar (shallow,
+ *   so the panel survives), making the URL itself the shareable deeplink
+ *
+ * The URL-sync effect acts on TRANSITIONS (panel just opened/closed, param
+ * just disappeared), never on plain state. Effects in one commit see sibling
+ * state updates and router changes with a delay, so state-based conditions
+ * here misfire and fight each other (open panel <-> strip param loops).
+ */
+export function useVoteDeeplink() {
+  const router = useRouter();
+  const { panelType, panelContent, panelOpen, openPanel, closePanel } =
+    usePanelContext();
+  const {
+    voteListsByActivityStatus,
+    activeVotesIsLoading,
+    upcomingVotesIsLoading,
+    pastVotesIsLoading,
+  } = useVotesContext();
+
+  const parsed = router.isReady ? parseVoteDeeplink(router.query) : undefined;
+  const external = parsed?.form === "external" ? parsed : undefined;
+  const targetKey = parsed?.form === "uniqueKey" ? parsed.uniqueKey : undefined;
+
+  // the key we already acted on, so the open-effect runs once per inbound link
+  const handledKeyRef = useRef<string>();
+  // previous values, so the URL-sync effect can detect transitions
+  const prevOpenKeyRef = useRef<string>();
+  const prevParamRef = useRef<string>();
+  // during a real page navigation we must not fire shallow replaces to clean
+  // up params — they would abort the navigation, and the destination route
+  // doesn't carry the param anyway
+  const navigatingRef = useRef(false);
+
+  useEffect(() => {
+    function handleStart(_url: string, { shallow }: { shallow: boolean }) {
+      if (!shallow) navigatingRef.current = true;
+    }
+    function handleSettled() {
+      navigatingRef.current = false;
+    }
+    router.events.on("routeChangeStart", handleStart);
+    router.events.on("routeChangeComplete", handleSettled);
+    router.events.on("routeChangeError", handleSettled);
+    return () => {
+      router.events.off("routeChangeStart", handleStart);
+      router.events.off("routeChangeComplete", handleSettled);
+      router.events.off("routeChangeError", handleSettled);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const { data: resolved, isError: resolveFailed } = useQuery({
+    queryKey: ["resolveDeeplink", external],
+    queryFn: async (): Promise<ResolvedVoteDeeplink> => {
+      if (!external) throw new Error("no deeplink params");
+      const params = new URLSearchParams({
+        identifier: external.identifier,
+        time: String(external.time),
+      });
+      if (external.ancillaryData) {
+        params.set("ancillaryData", external.ancillaryData);
+      }
+      const response = await fetch(
+        `/api/resolve-deeplink?${params.toString()}`
+      );
+      if (!response.ok) throw new Error("Deeplink resolution failed");
+      return (await response.json()) as ResolvedVoteDeeplink;
+    },
+    enabled: !!external,
+    staleTime: Infinity,
+    retry: 1,
+  });
+
+  // rewrite external params to the canonical `?vote=` form on the right page
+  useEffect(() => {
+    if (!external) return;
+    if (resolveFailed) {
+      notifyVoteNotFound();
+      return;
+    }
+    if (!resolved) return;
+    const pathname = pathForActivityStatus[resolved.activityStatus];
+    const query = { ...router.query };
+    externalDeeplinkQueryParams.forEach((param) => delete query[param]);
+    query[voteDeeplinkQueryParam] = resolved.uniqueKey;
+    void router.replace({ pathname, query }, undefined, {
+      shallow: pathname === router.pathname,
+      scroll: false,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [external?.identifier, external?.time, resolved, resolveFailed]);
+
+  // inbound `?vote=<uniqueKey>`: find the vote, switch pages if needed, open
+  useEffect(() => {
+    if (!targetKey || handledKeyRef.current === targetKey) return;
+
+    if (
+      panelOpen &&
+      panelType === "vote" &&
+      panelContent?.uniqueKey === targetKey
+    ) {
+      // the panel wrote this param itself, nothing to do
+      handledKeyRef.current = targetKey;
+      return;
+    }
+
+    for (const status of activityStatuses) {
+      const votes = voteListsByActivityStatus[status];
+      const vote = votes?.find(({ uniqueKey }) => uniqueKey === targetKey);
+      if (!vote) continue;
+
+      const pathname = pathForActivityStatus[status];
+      if (router.pathname !== pathname) {
+        void router.replace({ pathname, query: router.query }, undefined, {
+          scroll: false,
+        });
+        return;
+      }
+      handledKeyRef.current = targetKey;
+      openPanel("vote", vote, { navigableVotes: votes });
+      scrollToAndHighlightVote(targetKey);
+      return;
+    }
+
+    const stillLoading =
+      activeVotesIsLoading || upcomingVotesIsLoading || pastVotesIsLoading;
+    if (!stillLoading) {
+      handledKeyRef.current = targetKey;
+      notifyVoteNotFound();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    targetKey,
+    router.pathname,
+    panelOpen,
+    panelType,
+    panelContent,
+    voteListsByActivityStatus,
+    activeVotesIsLoading,
+    upcomingVotesIsLoading,
+    pastVotesIsLoading,
+  ]);
+
+  // keep the URL in sync with the panel, reacting only to transitions
+  useEffect(() => {
+    if (!router.isReady) return;
+    const param = getVoteParam(router.query);
+    const openKey =
+      panelOpen && panelType === "vote" ? panelContent?.uniqueKey : undefined;
+    const prevOpenKey = prevOpenKeyRef.current;
+    const prevParam = prevParamRef.current;
+    prevOpenKeyRef.current = openKey;
+    prevParamRef.current = param;
+
+    // panel just opened or switched to another vote -> write the param;
+    // push (not replace) so the browser back button closes the panel
+    if (openKey && openKey !== prevOpenKey) {
+      handledKeyRef.current = openKey;
+      if (param !== openKey) {
+        const query = { ...router.query };
+        externalDeeplinkQueryParams.forEach((key) => delete query[key]);
+        query[voteDeeplinkQueryParam] = openKey;
+        void router.push({ pathname: router.pathname, query }, undefined, {
+          shallow: true,
+          scroll: false,
+        });
+      }
+      return;
+    }
+
+    // panel just closed -> remove the param
+    if (!openKey && prevOpenKey) {
+      handledKeyRef.current = undefined;
+      if (param && !navigatingRef.current) {
+        const query = { ...router.query };
+        delete query[voteDeeplinkQueryParam];
+        void router.replace({ pathname: router.pathname, query }, undefined, {
+          shallow: true,
+          scroll: false,
+        });
+      }
+      return;
+    }
+
+    // param just disappeared while the panel is open (back button) -> close
+    if (openKey && !param && prevParam) {
+      handledKeyRef.current = undefined;
+      prevOpenKeyRef.current = undefined;
+      closePanel(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [panelOpen, panelType, panelContent, router.isReady, router.query]);
+}

--- a/hooks/helpers/useVoteUrl.ts
+++ b/hooks/helpers/useVoteUrl.ts
@@ -1,0 +1,70 @@
+import {
+  externalDeeplinkQueryParams,
+  getVoteDeeplinkParam,
+  voteDeeplinkQueryParam,
+} from "helpers/util/deeplink";
+import { usePanelContext } from "hooks/contexts/usePanelContext";
+import { useRouter } from "next/router";
+import { useCallback } from "react";
+
+/**
+ * The URL is the single source of truth for which vote panel is open: every
+ * in-app way of opening, switching, or closing a vote writes only the
+ * `?vote=` param (shallow, so no data refetch), and useVoteDeeplink derives
+ * the panel state from the router. That makes the address bar the shareable
+ * link for free and leaves exactly one code path — URL → panel — however a
+ * vote is opened: row click, panel arrows, inbound link, back/forward.
+ */
+export function useVoteUrl() {
+  const router = useRouter();
+  const { expectedVoteRef, closePanel } = usePanelContext();
+
+  // row clicks: push so the browser back button closes the panel
+  const openVote = useCallback(
+    (uniqueKey: string) => {
+      expectedVoteRef.current = { key: uniqueKey, scroll: false };
+      const query = { ...router.query };
+      externalDeeplinkQueryParams.forEach((param) => delete query[param]);
+      query[voteDeeplinkQueryParam] = uniqueKey;
+      void router.push({ pathname: router.pathname, query }, undefined, {
+        shallow: true,
+        scroll: false,
+      });
+    },
+    [router, expectedVoteRef]
+  );
+
+  // panel arrows: replace, so paging through votes doesn't spam history;
+  // the row navigated to scrolls into view like it always has
+  const switchVote = useCallback(
+    (uniqueKey: string) => {
+      expectedVoteRef.current = { key: uniqueKey, scroll: true };
+      const query = { ...router.query };
+      externalDeeplinkQueryParams.forEach((param) => delete query[param]);
+      query[voteDeeplinkQueryParam] = uniqueKey;
+      void router.replace({ pathname: router.pathname, query }, undefined, {
+        shallow: true,
+        scroll: false,
+      });
+    },
+    [router, expectedVoteRef]
+  );
+
+  const closeVote = useCallback(() => {
+    expectedVoteRef.current = undefined;
+    if (getVoteDeeplinkParam(router.query) === undefined) {
+      // no param to clean up (the panel outlived its param, e.g. after a
+      // back-navigation while another panel covered it) — close directly
+      closePanel();
+      return;
+    }
+    const query = { ...router.query };
+    delete query[voteDeeplinkQueryParam];
+    void router.replace({ pathname: router.pathname, query }, undefined, {
+      shallow: true,
+      scroll: false,
+    });
+  }, [router, expectedVoteRef, closePanel]);
+
+  return { openVote, switchVote, closeVote };
+}

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -6,6 +6,7 @@ export { usePanelContext } from "./contexts/usePanelContext";
 export { useVoteTimingContext } from "./contexts/useVoteTimingContext";
 export { useVotesContext } from "./contexts/useVotesContext";
 export { useWalletContext } from "./contexts/useWalletContext";
+export { useDeeplinkedVoteIndex } from "./helpers/useDeeplinkedVoteIndex";
 export { useHandleDecimalInput } from "./helpers/useHandleDecimalInput";
 export { useHandleError } from "./helpers/useHandleError";
 export { useInitializeVoteTiming } from "./helpers/useInitializeVoteTiming";

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -3,6 +3,7 @@ export { useDelegationContext } from "./contexts/useDelegationContext";
 export { useErrorContext } from "./contexts/useErrorContext";
 export { useNotificationsContext } from "./contexts/useNotificationsContext";
 export { usePanelContext } from "./contexts/usePanelContext";
+export { useVoteSelectionContext } from "./contexts/useVoteSelectionContext";
 export { useVoteTimingContext } from "./contexts/useVoteTimingContext";
 export { useVotesContext } from "./contexts/useVotesContext";
 export { useWalletContext } from "./contexts/useWalletContext";

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -15,6 +15,7 @@ export { useMounted } from "./helpers/useMounted";
 export { usePanelWidth } from "./helpers/usePanelWidth";
 export { usePersistedVotes } from "./helpers/usePersistedVotes";
 export { useSign } from "./helpers/useSign";
+export { useVoteDeeplink } from "./helpers/useVoteDeeplink";
 export { useVotePanelKeyboard } from "./helpers/useVotePanelKeyboard";
 export { useWindowSize } from "./helpers/useWindowSize";
 export { useAcceptReceivedRequestToBeDelegate } from "./mutations/delegation/useAcceptReceivedRequestToBeDelegate";

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -19,6 +19,7 @@ export { usePersistedVotes } from "./helpers/usePersistedVotes";
 export { useSign } from "./helpers/useSign";
 export { useVoteDeeplink } from "./helpers/useVoteDeeplink";
 export { useVotePanelKeyboard } from "./helpers/useVotePanelKeyboard";
+export { useVoteUrl } from "./helpers/useVoteUrl";
 export { useWindowSize } from "./helpers/useWindowSize";
 export { useAcceptReceivedRequestToBeDelegate } from "./mutations/delegation/useAcceptReceivedRequestToBeDelegate";
 export { useCancelSentRequestToBeDelegate } from "./mutations/delegation/useCancelSentRequestToBeDelegate";

--- a/lib/deeplink-matching.ts
+++ b/lib/deeplink-matching.ts
@@ -1,0 +1,175 @@
+import { keccak256 } from "ethers/lib/utils";
+import { decodeHexString, encodeHexString } from "helpers/web3/decodeHexString";
+
+// Pure matching logic behind /api/resolve-deeplink: given a set of subgraph
+// price-request candidates and the ancillary data (or its hash) an external
+// caller holds, decide which candidate — if any — the caller means. Callers
+// hold *different versions* of the same request's ancillary data (raw request
+// bytes, oracle-stamped, DVM-side, bridged/compressed), so every matcher here
+// is deliberately forgiving about which version it is handed.
+//
+// Everything in this module is pure so it can be unit tested with fixtures;
+// the API route owns all IO (subgraph queries, child-chain event fetches).
+
+// Minimal candidate shape the matchers need; the route's subgraph entity
+// satisfies it structurally.
+export type DeeplinkCandidate = {
+  id: string;
+  ancillaryData: string | null;
+};
+
+export const OO_REQUESTER_STAMP = encodeHexString(",ooRequester:").slice(2);
+
+// The stamp is appended as the final key-value pair, so stripping from its
+// last occurrence recovers the pre-stamp bytes.
+export function stripOoRequesterStamp(dataHex: string) {
+  const index = dataHex.toLowerCase().lastIndexOf(OO_REQUESTER_STAMP);
+  return index === -1 ? undefined : dataHex.slice(0, index);
+}
+
+export function hashesOfHex(dataHex: string | undefined) {
+  if (!dataHex || dataHex === "0x") return [];
+  const hashes = [keccak256(dataHex)];
+  // a stripped value of "0x" is still meaningful: an OO request with blank
+  // caller ancillary data is stamped to just `,ooRequester:<addr>`, and links
+  // built from the raw request bytes hash the empty data
+  const stripped = stripOoRequesterStamp(dataHex);
+  if (stripped) hashes.push(keccak256(stripped));
+  return hashes;
+}
+
+export function decodeAncillaryDataSafe(ancillaryData: string | null) {
+  if (!ancillaryData) return undefined;
+  try {
+    return decodeHexString(ancillaryData);
+  } catch {
+    return undefined;
+  }
+}
+
+export function pickByFullAncillaryData<T extends DeeplinkCandidate>(
+  candidates: T[],
+  ancillaryData: string
+): T | undefined {
+  const normalized = ancillaryData.toLowerCase();
+  const exact = candidates.find(
+    (candidate) => candidate.ancillaryData?.toLowerCase() === normalized
+  );
+  if (exact) return exact;
+
+  // Requests reaching the DVM from an oracle contract have the original
+  // ancillary data "stamped", so the requesting side's data is a byte-prefix
+  // of what the DVM stores. Requiring the remainder to be the stamp prevents
+  // an unrelated same-batch request that merely begins with the same bytes
+  // from stealing the match.
+  const stamped = candidates.filter((candidate) => {
+    const data = candidate.ancillaryData?.toLowerCase();
+    return (
+      data?.startsWith(normalized) &&
+      data.slice(normalized.length).startsWith(OO_REQUESTER_STAMP)
+    );
+  });
+  if (stamped.length === 1) return stamped[0];
+
+  // Requests bridged via AncillaryDataCompression replace the data with
+  // `ancillaryDataHash:<keccak256(childData)>,childBlockNumber:...`, so match
+  // the hash of the provided data against the compressed form.
+  const providedDataHash = keccak256(normalized).slice(2);
+  const compressed = candidates.filter((candidate) =>
+    decodeAncillaryDataSafe(candidate.ancillaryData)?.startsWith(
+      `ancillaryDataHash:${providedDataHash},`
+    )
+  );
+  if (compressed.length === 1) return compressed[0];
+
+  return undefined;
+}
+
+// Parses the decoded form of AncillaryDataCompression's replacement data:
+// `ancillaryDataHash:...,childBlockNumber:...,childOracle:...,
+// childRequester:...,childChainId:...`. Lives here (not in l2-ancillary-data)
+// so it stays importable without the env-validated provider config.
+export function extractMaybeAncillaryDataFields(decodedAncillaryData: string) {
+  const pattern = new RegExp(
+    "^" +
+      "ancillaryDataHash:(\\w+),\\s*" +
+      "childBlockNumber:(\\d+),\\s*" +
+      "childOracle:(\\w+),\\s*" +
+      "childRequester:(\\w+),\\s*" +
+      "childChainId:(\\d+)" +
+      "$"
+  );
+
+  const match = decodedAncillaryData.match(pattern);
+  if (!match) return {};
+
+  return {
+    ancillaryDataHash: match[1],
+    childBlockNumber: match[2],
+    childOracle: match[3],
+    childRequester: match[4],
+    childChainId: match[5],
+  };
+}
+
+export type BridgedAncillaryDataFields = {
+  ancillaryDataHash: string;
+  childOracle: string;
+  childChainId: number;
+  childBlockNumber: number;
+};
+
+// Bridged (compressed) requests carry a reference to the child-chain data
+// instead of the data itself. Returns undefined unless every field needed to
+// locate the child data is present.
+export function getBridgedFields(
+  ancillaryData: string | null
+): BridgedAncillaryDataFields | undefined {
+  const decoded = decodeAncillaryDataSafe(ancillaryData);
+  if (!decoded) return undefined;
+  const { ancillaryDataHash, childOracle, childChainId, childBlockNumber } =
+    extractMaybeAncillaryDataFields(decoded);
+  if (!ancillaryDataHash || !childOracle || !childChainId || !childBlockNumber)
+    return undefined;
+  return {
+    ancillaryDataHash,
+    childOracle: `0x${childOracle}`,
+    childChainId: Number(childChainId),
+    childBlockNumber: Number(childBlockNumber),
+  };
+}
+
+// True when the caller's hash is keccak256 of the given data or of its
+// pre-stamp form.
+export function matchesHexHashVariants(
+  dataHex: string | undefined,
+  hash: string
+): boolean {
+  const normalizedHash = hash.toLowerCase();
+  return hashesOfHex(dataHex).some((h) => h.toLowerCase() === normalizedHash);
+}
+
+// Hash variants checkable without any IO: the DVM-side data, its pre-stamp
+// form, and — for bridged requests — the child-data hash embedded in the
+// compressed form.
+export function matchesCheapHashVariants(
+  mainnetData: string | null,
+  hash: string
+): boolean {
+  const normalizedHash = hash.toLowerCase();
+  if (matchesHexHashVariants(mainnetData ?? "0x", normalizedHash)) return true;
+  const bridged = getBridgedFields(mainnetData);
+  return (
+    !!bridged &&
+    `0x${bridged.ancillaryDataHash.toLowerCase()}` === normalizedHash
+  );
+}
+
+// The subgraph identifier id is the decoded string ("YES_OR_NO_QUERY"), but
+// callers may pass the on-chain bytes32 form instead.
+export function normalizeIdentifier(identifier: string) {
+  if (/^0x[0-9a-fA-F]{64}$/.test(identifier)) {
+    return decodeHexString(identifier);
+  }
+  return identifier;
+}

--- a/lib/deeplink-matching.ts
+++ b/lib/deeplink-matching.ts
@@ -1,4 +1,8 @@
-import { keccak256 } from "ethers/lib/utils";
+import {
+  formatBytes32String,
+  getAddress,
+  keccak256,
+} from "ethers/lib/utils";
 import { decodeHexString, encodeHexString } from "helpers/web3/decodeHexString";
 
 // Pure matching logic behind /api/resolve-deeplink: given a set of subgraph
@@ -179,4 +183,81 @@ export function normalizeIdentifier(identifier: string) {
     return decodeHexString(identifier);
   }
   return identifier;
+}
+
+// The subgraph PriceRequest shape /api/resolve-deeplink fetches: the fields
+// the matchers need plus everything required to hand the client a renderable
+// raw price request (mirrors what getPastVotesV2 pulls).
+export type DeeplinkPriceRequestEntity = {
+  id: string;
+  isResolved: boolean;
+  isDeleted: boolean;
+  time: string;
+  ancillaryData: string | null;
+  identifier: { id: string };
+  price: string | null;
+  resolvedPriceRequestIndex: string | null;
+  isGovernance: boolean | null;
+  rollCount: number | null;
+  latestRound: {
+    roundId: string;
+    totalVotesRevealed: string | null;
+    totalTokensCommitted: string | null;
+    minAgreementRequirement: string | null;
+    minParticipationRequirement: string | null;
+    groups: { price: string; totalVoteAmount: string }[];
+    committedVotes: { id: string }[];
+    revealedVotes: { voter: { address: string }; price: string }[];
+  } | null;
+};
+
+// Maps a resolved entity to the JSON-safe raw price request the client's
+// existing pipeline helpers (formatPriceRequest, getVoteMetaData) can turn
+// into a renderable vote — same math as getPastVotesV2's transform, so the
+// provisional panel shows what the lists will. ancillaryDataL2 is appended
+// by the route after L2 resolution.
+export function makeRawRequestFromEntity(entity: DeeplinkPriceRequestEntity) {
+  const round = entity.latestRound;
+  const participation = {
+    uniqueCommitAddresses: round?.committedVotes.length ?? 0,
+    uniqueRevealAddresses: round?.revealedVotes.length ?? 0,
+    totalTokensVotedWith: Number(round?.totalVotesRevealed ?? 0),
+    totalTokensCommitted: round?.totalTokensCommitted
+      ? Number(round.totalTokensCommitted)
+      : undefined,
+    minAgreementRequirement: Number(round?.minAgreementRequirement ?? 0),
+    minParticipationRequirement: Number(
+      round?.minParticipationRequirement ?? 0
+    ),
+  };
+  const results = (round?.groups ?? []).map(({ price, totalVoteAmount }) => ({
+    vote: price,
+    tokensVotedWith: Number(totalVoteAmount),
+  }));
+  const revealedVoteByAddress: Record<string, string> = {};
+  (round?.revealedVotes ?? []).forEach((vote) => {
+    revealedVoteByAddress[getAddress(vote.voter.address)] = vote.price;
+  });
+  // formatBytes32String (the lists' encoding) throws for identifiers of 32
+  // bytes; plain utf8 encoding round-trips those — decodeHexString strips the
+  // bytes32 padding either way
+  let identifier: string;
+  try {
+    identifier = formatBytes32String(entity.identifier.id);
+  } catch {
+    identifier = encodeHexString(entity.identifier.id);
+  }
+  return {
+    identifier,
+    time: Number(entity.time),
+    ancillaryData: entity.ancillaryData ?? "0x",
+    correctVote: entity.price ?? undefined,
+    resolvedPriceRequestIndex: entity.resolvedPriceRequestIndex ?? undefined,
+    isGovernance: entity.isGovernance ?? undefined,
+    rollCount: entity.rollCount ?? 0,
+    isV1: false,
+    participation,
+    results,
+    revealedVoteByAddress,
+  };
 }

--- a/lib/deeplink-matching.ts
+++ b/lib/deeplink-matching.ts
@@ -21,9 +21,16 @@ export type DeeplinkCandidate = {
 export const OO_REQUESTER_STAMP = encodeHexString(",ooRequester:").slice(2);
 
 // The stamp is appended as the final key-value pair, so stripping from its
-// last occurrence recovers the pre-stamp bytes.
+// last occurrence recovers the pre-stamp bytes. Hex-string offsets are
+// nibbles: an odd offset is not a byte boundary, so a match there is a
+// coincidental nibble alignment inside binary data, not the stamp — and
+// slicing at it would produce odd-length hex that keccak256 rejects.
 export function stripOoRequesterStamp(dataHex: string) {
-  const index = dataHex.toLowerCase().lastIndexOf(OO_REQUESTER_STAMP);
+  const lower = dataHex.toLowerCase();
+  let index = lower.lastIndexOf(OO_REQUESTER_STAMP);
+  while (index > 0 && index % 2 !== 0) {
+    index = lower.lastIndexOf(OO_REQUESTER_STAMP, index - 1);
+  }
   return index === -1 ? undefined : dataHex.slice(0, index);
 }
 

--- a/lib/l2-ancillary-data.ts
+++ b/lib/l2-ancillary-data.ts
@@ -66,7 +66,7 @@ export interface ResolveAncillaryDataResult {
   resolvedAncillaryData: string;
 }
 
-function extractMaybeAncillaryDataFields(decodedAncillaryData: string) {
+export function extractMaybeAncillaryDataFields(decodedAncillaryData: string) {
   const pattern = new RegExp(
     "^" +
       "ancillaryDataHash:(\\w+),\\s*" +
@@ -99,7 +99,7 @@ function mergeAncillaryData(
   return encodeHexString(merged);
 }
 
-async function fetchAncillaryDataFromSpoke(args: {
+export async function fetchAncillaryDataFromSpoke(args: {
   parentRequestId: BytesLike;
   childOracle: string;
   childChainId: number;

--- a/lib/l2-ancillary-data.ts
+++ b/lib/l2-ancillary-data.ts
@@ -3,6 +3,7 @@ import { Contract } from "ethers";
 import {
   BytesLike,
   defaultAbiCoder,
+  hexlify,
   Interface,
   keccak256,
 } from "ethers/lib/utils";
@@ -80,12 +81,15 @@ function mergeAncillaryData(
   return encodeHexString(merged);
 }
 
-export async function fetchAncillaryDataFromSpoke(args: {
-  parentRequestId: BytesLike;
+// All PriceRequestBridged events an oracle spoke emitted at a given block.
+// Unfiltered on purpose: requests bridged in the same batch share (chain,
+// oracle, block), so one fetch serves every one of them — callers matching
+// several candidates memoize on exactly these arguments.
+export async function fetchBridgedEventsAt(args: {
   childOracle: string;
   childChainId: number;
   childBlockNumber: number;
-}): Promise<string> {
+}) {
   const provider = getProvider(args.childChainId);
   const OracleSpoke = new Contract(
     args.childOracle,
@@ -93,30 +97,34 @@ export async function fetchAncillaryDataFromSpoke(args: {
     provider
   );
 
-  const filter = OracleSpoke.filters.PriceRequestBridged(
-    null,
-    null,
-    null,
-    null,
-    null,
-    args.parentRequestId
-  );
-
-  const events = await OracleSpoke.queryFilter(
-    filter,
+  return OracleSpoke.queryFilter(
+    OracleSpoke.filters.PriceRequestBridged(),
     args.childBlockNumber - 1,
     args.childBlockNumber
   );
+}
 
-  if (!events.length) {
+export async function fetchAncillaryDataFromSpoke(args: {
+  parentRequestId: BytesLike;
+  childOracle: string;
+  childChainId: number;
+  childBlockNumber: number;
+}): Promise<string> {
+  const parentRequestId = hexlify(args.parentRequestId).toLowerCase();
+  const events = await fetchBridgedEventsAt(args);
+  const event = events.find(
+    (e) =>
+      (e.args?.parentRequestId as string | undefined)?.toLowerCase() ===
+      parentRequestId
+  );
+
+  if (!event) {
     throw new Error(
-      `Unable to find event with request Id: ${String(
-        args.parentRequestId
-      )} on chain ${args.childChainId}`
+      `Unable to find event with request Id: ${parentRequestId} on chain ${args.childChainId}`
     );
   }
 
-  return events[0]?.args?.ancillaryData as string;
+  return event.args?.ancillaryData as string;
 }
 
 export function createRequestHash(

--- a/lib/l2-ancillary-data.ts
+++ b/lib/l2-ancillary-data.ts
@@ -8,6 +8,10 @@ import {
 } from "ethers/lib/utils";
 import { getProvider } from "helpers/config";
 import { decodeHexString, encodeHexString } from "helpers/web3/decodeHexString";
+// moved to lib/deeplink-matching so pure consumers can import it without the
+// provider config this module needs; re-exported for existing callers
+import { extractMaybeAncillaryDataFields } from "lib/deeplink-matching";
+export { extractMaybeAncillaryDataFields };
 
 // ABI for OracleSpoke contract events
 export const PRICE_REQUEST_BRIDGED_ABI = [
@@ -64,29 +68,6 @@ export interface ResolveAncillaryDataRequest {
 
 export interface ResolveAncillaryDataResult {
   resolvedAncillaryData: string;
-}
-
-export function extractMaybeAncillaryDataFields(decodedAncillaryData: string) {
-  const pattern = new RegExp(
-    "^" +
-      "ancillaryDataHash:(\\w+),\\s*" +
-      "childBlockNumber:(\\d+),\\s*" +
-      "childOracle:(\\w+),\\s*" +
-      "childRequester:(\\w+),\\s*" +
-      "childChainId:(\\d+)" +
-      "$"
-  );
-
-  const match = decodedAncillaryData.match(pattern);
-  if (!match) return {};
-
-  return {
-    ancillaryDataHash: match[1],
-    childBlockNumber: match[2],
-    childOracle: match[3],
-    childRequester: match[4],
-    childChainId: match[5],
-  };
 }
 
 function mergeAncillaryData(

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,6 +12,7 @@ import {
   ErrorProvider,
   NotificationsProvider,
   PanelProvider,
+  VoteSelectionProvider,
   VoteTimingProvider,
   VotesProvider,
   WalletProvider,
@@ -34,14 +35,18 @@ function MyApp({ Component, pageProps }: AppProps) {
               <ContractsProvider>
                 <DelegationProvider>
                   <VotesProvider>
-                    <PanelProvider>
-                      <GlobalStyle />
-                      <Component {...pageProps} />
-                      <Panel />
-                      <VoteDeeplinkHandler />
-                      <Notifications />
-                      {config.gaTag && <GoogleAnalytics gaId={config.gaTag} />}
-                    </PanelProvider>
+                    <VoteSelectionProvider>
+                      <PanelProvider>
+                        <GlobalStyle />
+                        <Component {...pageProps} />
+                        <Panel />
+                        <VoteDeeplinkHandler />
+                        <Notifications />
+                        {config.gaTag && (
+                          <GoogleAnalytics gaId={config.gaTag} />
+                        )}
+                      </PanelProvider>
+                    </VoteSelectionProvider>
                   </VotesProvider>
                 </DelegationProvider>
               </ContractsProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { GlobalStyle, Notifications, Panel } from "components";
+import {
+  GlobalStyle,
+  Notifications,
+  Panel,
+  VoteDeeplinkHandler,
+} from "components";
 import {
   ContractsProvider,
   DelegationProvider,
@@ -33,6 +38,7 @@ function MyApp({ Component, pageProps }: AppProps) {
                       <GlobalStyle />
                       <Component {...pageProps} />
                       <Panel />
+                      <VoteDeeplinkHandler />
                       <Notifications />
                       {config.gaTag && <GoogleAnalytics gaId={config.gaTag} />}
                     </PanelProvider>

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -24,7 +24,10 @@ const RequestParams = ss.union([
   ss.object({
     identifier: ss.string(),
     time: ss.coerce(ss.integer(), ss.string(), (value) => Number(value)),
-    ancillaryData: ss.optional(ss.pattern(ss.string(), /^0x[0-9a-fA-F]*$/)),
+    ancillaryData: ss.optional(
+      // even-length so keccak256 cannot throw on odd-length hex
+      ss.pattern(ss.string(), /^0x([0-9a-fA-F]{2})*$/)
+    ),
     ancillaryDataHash: ss.optional(Bytes32Hash),
   }),
 ]);
@@ -248,17 +251,25 @@ async function resolveEntity(
   }
 
   const candidates = await findCandidatesByDetails(decodedIdentifier, time);
-  if (ancillaryDataHash) {
-    const byHash = await pickByAncillaryDataHash(
-      candidates,
-      decodedIdentifier,
-      ancillaryDataHash
-    );
-    if (byHash) return byHash;
-  }
   if (ancillaryData && ancillaryData !== "0x") {
     const byData = pickByFullAncillaryData(candidates, ancillaryData);
     if (byData) return byData;
+  }
+  // full ancillary data degrades to its hash so both forms resolve the same
+  // requests — the hash matcher covers bridged variants that need the child
+  // chain's event data
+  const hash =
+    ancillaryDataHash ??
+    (ancillaryData && ancillaryData !== "0x"
+      ? keccak256(ancillaryData.toLowerCase())
+      : undefined);
+  if (hash) {
+    const byHash = await pickByAncillaryDataHash(
+      candidates,
+      decodedIdentifier,
+      hash
+    );
+    if (byHash) return byHash;
   }
   return candidates.length === 1 ? candidates[0] : undefined;
 }

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -1,10 +1,13 @@
 import { gql, request as gqlRequest } from "graphql-request";
-import { decodeHexString, encodeHexString } from "helpers/web3/decodeHexString";
 import { makeUniqueKeyForVote } from "helpers/voting/makeUniqueKeyForVote";
+import { fetchAncillaryDataFromSpoke } from "lib/l2-ancillary-data";
 import {
-  extractMaybeAncillaryDataFields,
-  fetchAncillaryDataFromSpoke,
-} from "lib/l2-ancillary-data";
+  getBridgedFields,
+  matchesCheapHashVariants,
+  matchesHexHashVariants,
+  normalizeIdentifier,
+  pickByFullAncillaryData,
+} from "lib/deeplink-matching";
 import { defaultAbiCoder, keccak256 } from "ethers/lib/utils";
 import { formatBytes32String } from "helpers/web3/ethers";
 import { NextApiRequest, NextApiResponse } from "next";
@@ -113,73 +116,6 @@ async function findCandidatesByDetails(
   return allCandidates;
 }
 
-function pickByFullAncillaryData(
-  candidates: PriceRequestEntity[],
-  ancillaryData: string
-) {
-  const normalized = ancillaryData.toLowerCase();
-  const exact = candidates.find(
-    (candidate) => candidate.ancillaryData?.toLowerCase() === normalized
-  );
-  if (exact) return exact;
-
-  // Requests reaching the DVM from an oracle contract have the original
-  // ancillary data "stamped", so the requesting side's data is a byte-prefix
-  // of what the DVM stores. Requiring the remainder to be the stamp prevents
-  // an unrelated same-batch request that merely begins with the same bytes
-  // from stealing the match.
-  const stamped = candidates.filter((candidate) => {
-    const data = candidate.ancillaryData?.toLowerCase();
-    return (
-      data?.startsWith(normalized) &&
-      data.slice(normalized.length).startsWith(OO_REQUESTER_STAMP)
-    );
-  });
-  if (stamped.length === 1) return stamped[0];
-
-  // Requests bridged via AncillaryDataCompression replace the data with
-  // `ancillaryDataHash:<keccak256(childData)>,childBlockNumber:...`, so match
-  // the hash of the provided data against the compressed form.
-  const providedDataHash = keccak256(normalized).slice(2);
-  const compressed = candidates.filter((candidate) =>
-    decodeAncillaryDataSafe(candidate.ancillaryData)?.startsWith(
-      `ancillaryDataHash:${providedDataHash},`
-    )
-  );
-  if (compressed.length === 1) return compressed[0];
-
-  return undefined;
-}
-
-const OO_REQUESTER_STAMP = encodeHexString(",ooRequester:").slice(2);
-
-// The stamp is appended as the final key-value pair, so stripping from its
-// last occurrence recovers the pre-stamp bytes.
-function stripOoRequesterStamp(dataHex: string) {
-  const index = dataHex.toLowerCase().lastIndexOf(OO_REQUESTER_STAMP);
-  return index === -1 ? undefined : dataHex.slice(0, index);
-}
-
-function hashesOfHex(dataHex: string | undefined) {
-  if (!dataHex || dataHex === "0x") return [];
-  const hashes = [keccak256(dataHex)];
-  // a stripped value of "0x" is still meaningful: an OO request with blank
-  // caller ancillary data is stamped to just `,ooRequester:<addr>`, and links
-  // built from the raw request bytes hash the empty data
-  const stripped = stripOoRequesterStamp(dataHex);
-  if (stripped) hashes.push(keccak256(stripped));
-  return hashes;
-}
-
-function decodeAncillaryDataSafe(ancillaryData: string | null) {
-  if (!ancillaryData) return undefined;
-  try {
-    return decodeHexString(ancillaryData);
-  } catch {
-    return undefined;
-  }
-}
-
 // Callers hash whichever ancillary data version they hold, so compare against
 // every variant reconstructable for this candidate: the DVM-side data, the
 // pre-stamp form of it, the compressed hash reference, and (via the bridge
@@ -189,40 +125,28 @@ async function candidateMatchesHash(
   decodedIdentifier: string,
   hash: string
 ): Promise<boolean> {
-  const mainnetData = candidate.ancillaryData ?? "0x";
-  const normalizedHash = hash.toLowerCase();
+  if (matchesCheapHashVariants(candidate.ancillaryData, hash)) return true;
 
-  if (
-    hashesOfHex(mainnetData).some((h) => h.toLowerCase() === normalizedHash)
-  ) {
-    return true;
-  }
-
-  const decoded = decodeAncillaryDataSafe(mainnetData);
-  if (!decoded) return false;
-  const { ancillaryDataHash, childOracle, childChainId, childBlockNumber } =
-    extractMaybeAncillaryDataFields(decoded);
-  if (!ancillaryDataHash || !childOracle || !childChainId || !childBlockNumber)
-    return false;
-
-  // hash of the stamped child data is embedded in the compressed form
-  if (`0x${ancillaryDataHash.toLowerCase()}` === normalizedHash) return true;
+  const bridged = getBridgedFields(candidate.ancillaryData);
+  if (!bridged) return false;
 
   try {
     const childData = await fetchAncillaryDataFromSpoke({
       parentRequestId: keccak256(
         defaultAbiCoder.encode(
           ["bytes32", "uint256", "bytes"],
-          [formatBytes32String(decodedIdentifier), candidate.time, mainnetData]
+          [
+            formatBytes32String(decodedIdentifier),
+            candidate.time,
+            candidate.ancillaryData ?? "0x",
+          ]
         )
       ),
-      childOracle: `0x${childOracle}`,
-      childChainId: Number(childChainId),
-      childBlockNumber: Number(childBlockNumber),
+      childOracle: bridged.childOracle,
+      childChainId: bridged.childChainId,
+      childBlockNumber: bridged.childBlockNumber,
     });
-    return hashesOfHex(childData).some(
-      (h) => h.toLowerCase() === normalizedHash
-    );
+    return matchesHexHashVariants(childData, hash);
   } catch (error) {
     console.warn("Unable to fetch child ancillary data for hash match", {
       candidate: candidate.id,
@@ -246,15 +170,6 @@ async function pickByAncillaryDataHash(
     )
   ).filter(({ matched }) => matched);
   return matches.length === 1 ? matches[0].candidate : undefined;
-}
-
-// The subgraph identifier id is the decoded string ("YES_OR_NO_QUERY"), but
-// callers may pass the on-chain bytes32 form instead.
-function normalizeIdentifier(identifier: string) {
-  if (/^0x[0-9a-fA-F]{64}$/.test(identifier)) {
-    return decodeHexString(identifier);
-  }
-  return identifier;
 }
 
 function getActivityStatus(entity: PriceRequestEntity): ActivityStatusT {

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -1,7 +1,12 @@
-import { utils } from "ethers";
 import { gql, request as gqlRequest } from "graphql-request";
-import { decodeHexString } from "helpers/web3/decodeHexString";
+import { decodeHexString, encodeHexString } from "helpers/web3/decodeHexString";
 import { makeUniqueKeyForVote } from "helpers/voting/makeUniqueKeyForVote";
+import {
+  extractMaybeAncillaryDataFields,
+  fetchAncillaryDataFromSpoke,
+} from "lib/l2-ancillary-data";
+import { defaultAbiCoder, keccak256 } from "ethers/lib/utils";
+import { formatBytes32String } from "helpers/web3/ethers";
 import { NextApiRequest, NextApiResponse } from "next";
 import * as ss from "superstruct";
 import { ActivityStatusT } from "types";
@@ -12,12 +17,15 @@ import { validateQueryParams } from "./_utils/validation";
 const phaseLength = Number(process.env.NEXT_PUBLIC_PHASE_LENGTH || 86400);
 const roundLength = phaseLength * 2;
 
+const Bytes32Hash = ss.pattern(ss.string(), /^0x[0-9a-fA-F]{64}$/);
+
 const RequestParams = ss.union([
   ss.object({ vote: ss.string() }),
   ss.object({
     identifier: ss.string(),
     time: ss.coerce(ss.integer(), ss.string(), (value) => Number(value)),
     ancillaryData: ss.optional(ss.pattern(ss.string(), /^0x[0-9a-fA-F]*$/)),
+    ancillaryDataHash: ss.optional(Bytes32Hash),
   }),
 ]);
 
@@ -60,10 +68,9 @@ async function findByUniqueKey(uniqueKey: string) {
   return result.priceRequest;
 }
 
-async function findByDetails(
+async function findCandidatesByDetails(
   decodedIdentifier: string,
-  time: number,
-  ancillaryData: string | undefined
+  time: number
 ) {
   const query = gql`
     ${priceRequestFields}
@@ -73,14 +80,16 @@ async function findByDetails(
       }
     }
   `;
-  const { priceRequests: candidates } = await gqlRequest<{
+  const { priceRequests } = await gqlRequest<{
     priceRequests: PriceRequestEntity[];
   }>(VoteSubgraphURL, query, { identifier: decodedIdentifier, time });
+  return priceRequests;
+}
 
-  if (!ancillaryData || ancillaryData === "0x") {
-    return candidates.length === 1 ? candidates[0] : undefined;
-  }
-
+function pickByFullAncillaryData(
+  candidates: PriceRequestEntity[],
+  ancillaryData: string
+) {
   const normalized = ancillaryData.toLowerCase();
   const exact = candidates.find(
     (candidate) => candidate.ancillaryData?.toLowerCase() === normalized
@@ -98,7 +107,7 @@ async function findByDetails(
   // Requests bridged via AncillaryDataCompression replace the data with
   // `ancillaryDataHash:<keccak256(childData)>,childBlockNumber:...`, so match
   // the hash of the provided data against the compressed form.
-  const providedDataHash = utils.keccak256(normalized).slice(2);
+  const providedDataHash = keccak256(normalized).slice(2);
   const compressed = candidates.filter((candidate) =>
     decodeAncillaryDataSafe(candidate.ancillaryData)?.startsWith(
       `ancillaryDataHash:${providedDataHash},`
@@ -106,7 +115,24 @@ async function findByDetails(
   );
   if (compressed.length === 1) return compressed[0];
 
-  return candidates.length === 1 ? candidates[0] : undefined;
+  return undefined;
+}
+
+const OO_REQUESTER_STAMP = encodeHexString(",ooRequester:").slice(2);
+
+// The stamp is appended as the final key-value pair, so stripping from its
+// last occurrence recovers the pre-stamp bytes.
+function stripOoRequesterStamp(dataHex: string) {
+  const index = dataHex.toLowerCase().lastIndexOf(OO_REQUESTER_STAMP);
+  return index === -1 ? undefined : dataHex.slice(0, index);
+}
+
+function hashesOfHex(dataHex: string | undefined) {
+  if (!dataHex || dataHex === "0x") return [];
+  const hashes = [keccak256(dataHex)];
+  const stripped = stripOoRequesterStamp(dataHex);
+  if (stripped && stripped !== "0x") hashes.push(keccak256(stripped));
+  return hashes;
 }
 
 function decodeAncillaryDataSafe(ancillaryData: string | null) {
@@ -116,6 +142,74 @@ function decodeAncillaryDataSafe(ancillaryData: string | null) {
   } catch {
     return undefined;
   }
+}
+
+// Callers hash whichever ancillary data version they hold, so compare against
+// every variant reconstructable for this candidate: the DVM-side data, the
+// pre-stamp form of it, the compressed hash reference, and (via the bridge
+// event) the child-side data and its pre-stamp form.
+async function candidateMatchesHash(
+  candidate: PriceRequestEntity,
+  decodedIdentifier: string,
+  hash: string
+): Promise<boolean> {
+  const mainnetData = candidate.ancillaryData ?? "0x";
+  const normalizedHash = hash.toLowerCase();
+
+  if (
+    hashesOfHex(mainnetData).some((h) => h.toLowerCase() === normalizedHash)
+  ) {
+    return true;
+  }
+
+  const decoded = decodeAncillaryDataSafe(mainnetData);
+  if (!decoded) return false;
+  const { ancillaryDataHash, childOracle, childChainId, childBlockNumber } =
+    extractMaybeAncillaryDataFields(decoded);
+  if (!ancillaryDataHash || !childOracle || !childChainId || !childBlockNumber)
+    return false;
+
+  // hash of the stamped child data is embedded in the compressed form
+  if (`0x${ancillaryDataHash.toLowerCase()}` === normalizedHash) return true;
+
+  try {
+    const childData = await fetchAncillaryDataFromSpoke({
+      parentRequestId: keccak256(
+        defaultAbiCoder.encode(
+          ["bytes32", "uint256", "bytes"],
+          [formatBytes32String(decodedIdentifier), candidate.time, mainnetData]
+        )
+      ),
+      childOracle: `0x${childOracle}`,
+      childChainId: Number(childChainId),
+      childBlockNumber: Number(childBlockNumber),
+    });
+    return hashesOfHex(childData).some(
+      (h) => h.toLowerCase() === normalizedHash
+    );
+  } catch (error) {
+    console.warn("Unable to fetch child ancillary data for hash match", {
+      candidate: candidate.id,
+      cause: error,
+    });
+    return false;
+  }
+}
+
+async function pickByAncillaryDataHash(
+  candidates: PriceRequestEntity[],
+  decodedIdentifier: string,
+  hash: string
+) {
+  const matches = (
+    await Promise.all(
+      candidates.map(async (candidate) => ({
+        candidate,
+        matched: await candidateMatchesHash(candidate, decodedIdentifier, hash),
+      }))
+    )
+  ).filter(({ matched }) => matched);
+  return matches.length === 1 ? matches[0].candidate : undefined;
 }
 
 // The subgraph identifier id is the decoded string ("YES_OR_NO_QUERY"), but
@@ -134,6 +228,41 @@ function getActivityStatus(entity: PriceRequestEntity): ActivityStatusT {
   return latestRoundId > currentRoundId ? "upcoming" : "active";
 }
 
+async function resolveEntity(
+  params: ss.Infer<typeof RequestParams>
+): Promise<PriceRequestEntity | null | undefined> {
+  if ("vote" in params) return findByUniqueKey(params.vote);
+
+  const decodedIdentifier = normalizeIdentifier(params.identifier);
+  const { time, ancillaryData, ancillaryDataHash } = params;
+
+  // when the caller's data or hash corresponds to the DVM-side data, the
+  // uniqueKey is directly constructible — single cheap lookup
+  const directHash = ancillaryDataHash ?? undefined;
+  if (ancillaryData || directHash) {
+    const uniqueKey = ancillaryData
+      ? makeUniqueKeyForVote(decodedIdentifier, time, ancillaryData)
+      : `${decodedIdentifier}-${time}-${directHash?.toLowerCase() ?? ""}`;
+    const direct = await findByUniqueKey(uniqueKey);
+    if (direct) return direct;
+  }
+
+  const candidates = await findCandidatesByDetails(decodedIdentifier, time);
+  if (ancillaryDataHash) {
+    const byHash = await pickByAncillaryDataHash(
+      candidates,
+      decodedIdentifier,
+      ancillaryDataHash
+    );
+    if (byHash) return byHash;
+  }
+  if (ancillaryData && ancillaryData !== "0x") {
+    const byData = pickByFullAncillaryData(candidates, ancillaryData);
+    if (byData) return byData;
+  }
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
 export default async function handler(
   request: NextApiRequest,
   response: NextApiResponse
@@ -143,27 +272,7 @@ export default async function handler(
       throw new HttpError({ statusCode: 405 });
     }
     const params = validateQueryParams(request.query, RequestParams);
-
-    let entity: PriceRequestEntity | null | undefined;
-    if ("vote" in params) {
-      entity = await findByUniqueKey(params.vote);
-    } else {
-      const decodedIdentifier = normalizeIdentifier(params.identifier);
-      if (params.ancillaryData) {
-        entity = await findByUniqueKey(
-          makeUniqueKeyForVote(
-            decodedIdentifier,
-            params.time,
-            params.ancillaryData
-          )
-        );
-      }
-      entity ??= await findByDetails(
-        decodedIdentifier,
-        params.time,
-        params.ancillaryData
-      );
-    }
+    const entity = await resolveEntity(params);
 
     if (!entity || entity.isDeleted) {
       throw new HttpError({ statusCode: 404, msg: "Vote not found" });

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -1,6 +1,7 @@
 import { gql, request as gqlRequest } from "graphql-request";
+import { computeRoundId } from "helpers/voting/voteTiming";
 import { makeUniqueKeyForVote } from "helpers/voting/makeUniqueKeyForVote";
-import { fetchAncillaryDataFromSpoke } from "lib/l2-ancillary-data";
+import { fetchBridgedEventsAt } from "lib/l2-ancillary-data";
 import {
   getBridgedFields,
   matchesCheapHashVariants,
@@ -17,14 +18,22 @@ import { VoteSubgraphURL } from "./_common";
 import { handleApiError, HttpError } from "./_utils/errors";
 import { validateQueryParams } from "./_utils/validation";
 
-const phaseLength = Number(process.env.NEXT_PUBLIC_PHASE_LENGTH || 86400);
-const roundLength = phaseLength * 2;
+// Resolves a deeplink to `{ uniqueKey, activityStatus }`. Two forms:
+// - `?vote=<uniqueKey>`: a direct id lookup. The dapp itself never calls this
+//   form (it searches its already-loaded lists); it exists for external
+//   consumers (explorer, oracle dapp) that hold a uniqueKey and want to know
+//   whether/where the vote exists before linking to it.
+// - `?identifier=&time=&ancillaryDataHash=` (or full `ancillaryData`): the
+//   external form built by makeVoterDappDeeplink; see lib/deeplink-matching
+//   for the matching semantics.
+// Unknown query params are ignored (ss.type), so shared links that pick up
+// trackers (utm_*) still resolve.
 
 const Bytes32Hash = ss.pattern(ss.string(), /^0x[0-9a-fA-F]{64}$/);
 
 const RequestParams = ss.union([
-  ss.object({ vote: ss.string() }),
-  ss.object({
+  ss.type({ vote: ss.string() }),
+  ss.type({
     identifier: ss.string(),
     time: ss.coerce(ss.integer(), ss.string(), (value) => Number(value)),
     ancillaryData: ss.optional(
@@ -75,7 +84,10 @@ async function findByUniqueKey(uniqueKey: string) {
 }
 
 // paginated like fetchAllDocuments so large same-timestamp batches cannot
-// truncate the candidate set before matching
+// truncate the candidate set before matching; capped because the endpoint is
+// unauthenticated and this loop is its most expensive amplification path
+const maxCandidatePages = 5;
+
 async function findCandidatesByDetails(
   decodedIdentifier: string,
   time: number
@@ -100,52 +112,78 @@ async function findCandidatesByDetails(
   const pageSize = 1000;
   let allCandidates: PriceRequestEntity[] = [];
   let page: PriceRequestEntity[];
-  let skip = 0;
+  let pages = 0;
   do {
     ({ priceRequests: page } = await gqlRequest<{
       priceRequests: PriceRequestEntity[];
     }>(VoteSubgraphURL, query, {
       identifier: decodedIdentifier,
       time,
-      skip,
+      skip: pages * pageSize,
       limit: pageSize,
     }));
     allCandidates = allCandidates.concat(page);
-    skip += pageSize;
-  } while (page.length === pageSize);
+    pages += 1;
+  } while (page.length === pageSize && pages < maxCandidatePages);
+  if (page.length === pageSize) {
+    console.warn("Deeplink candidate set truncated", {
+      identifier: decodedIdentifier,
+      time,
+      fetched: allCandidates.length,
+    });
+  }
   return allCandidates;
 }
 
-// Callers hash whichever ancillary data version they hold, so compare against
-// every variant reconstructable for this candidate: the DVM-side data, the
-// pre-stamp form of it, the compressed hash reference, and (via the bridge
-// event) the child-side data and its pre-stamp form.
-async function candidateMatchesHash(
+// Requests bridged in the same batch share (chain, oracle, block), so cache
+// the event fetch on exactly that key: matching N same-batch candidates costs
+// one RPC call, not N.
+function makeMemoizedBridgedEvents() {
+  const cache = new Map<string, ReturnType<typeof fetchBridgedEventsAt>>();
+  return (args: Parameters<typeof fetchBridgedEventsAt>[0]) => {
+    const key = `${args.childChainId}:${args.childOracle.toLowerCase()}:${
+      args.childBlockNumber
+    }`;
+    const cached = cache.get(key);
+    if (cached) return cached;
+    const pending = fetchBridgedEventsAt(args);
+    cache.set(key, pending);
+    return pending;
+  };
+}
+
+// The expensive variant: fetch the candidate's child-chain data via the
+// bridge event and compare the caller's hash against it and its pre-stamp
+// form. The cheap variants must have been ruled out first.
+async function candidateMatchesChildHash(
   candidate: PriceRequestEntity,
   decodedIdentifier: string,
-  hash: string
+  hash: string,
+  fetchEvents: ReturnType<typeof makeMemoizedBridgedEvents>
 ): Promise<boolean> {
-  if (matchesCheapHashVariants(candidate.ancillaryData, hash)) return true;
-
   const bridged = getBridgedFields(candidate.ancillaryData);
   if (!bridged) return false;
 
+  const parentRequestId = keccak256(
+    defaultAbiCoder.encode(
+      ["bytes32", "uint256", "bytes"],
+      [
+        formatBytes32String(decodedIdentifier),
+        candidate.time,
+        candidate.ancillaryData ?? "0x",
+      ]
+    )
+  ).toLowerCase();
+
   try {
-    const childData = await fetchAncillaryDataFromSpoke({
-      parentRequestId: keccak256(
-        defaultAbiCoder.encode(
-          ["bytes32", "uint256", "bytes"],
-          [
-            formatBytes32String(decodedIdentifier),
-            candidate.time,
-            candidate.ancillaryData ?? "0x",
-          ]
-        )
-      ),
-      childOracle: bridged.childOracle,
-      childChainId: bridged.childChainId,
-      childBlockNumber: bridged.childBlockNumber,
-    });
+    const events = await fetchEvents(bridged);
+    const event = events.find(
+      (e) =>
+        (e.args?.parentRequestId as string | undefined)?.toLowerCase() ===
+        parentRequestId
+    );
+    if (!event) return false;
+    const childData = event.args?.ancillaryData as string;
     return matchesHexHashVariants(childData, hash);
   } catch (error) {
     console.warn("Unable to fetch child ancillary data for hash match", {
@@ -156,27 +194,49 @@ async function candidateMatchesHash(
   }
 }
 
+// Callers hash whichever ancillary data version they hold, so compare against
+// every variant reconstructable per candidate: the DVM-side data, the
+// pre-stamp form of it, the compressed hash reference, and (via the bridge
+// event) the child-side data and its pre-stamp form. Exactly one candidate
+// must match.
 async function pickByAncillaryDataHash(
   candidates: PriceRequestEntity[],
   decodedIdentifier: string,
   hash: string
 ) {
-  const matches = (
-    await Promise.all(
-      candidates.map(async (candidate) => ({
-        candidate,
-        matched: await candidateMatchesHash(candidate, decodedIdentifier, hash),
-      }))
-    )
-  ).filter(({ matched }) => matched);
-  return matches.length === 1 ? matches[0].candidate : undefined;
+  // IO-free variants first. A single cheap match is decisive without checking
+  // the others' child data: another candidate could only share the hash by
+  // holding byte-identical data, which requestId uniqueness precludes for the
+  // same identifier and time.
+  const cheap = candidates.filter((candidate) =>
+    matchesCheapHashVariants(candidate.ancillaryData, hash)
+  );
+  if (cheap.length === 1) return cheap[0];
+  if (cheap.length > 1) return undefined;
+
+  // Sequential on purpose: bounded RPC concurrency for this unauthenticated
+  // endpoint, and ambiguity aborts before burning further calls. Same-batch
+  // candidates still cost one RPC total via the memoized event fetch.
+  const fetchEvents = makeMemoizedBridgedEvents();
+  const matches: PriceRequestEntity[] = [];
+  for (const candidate of candidates) {
+    const matched = await candidateMatchesChildHash(
+      candidate,
+      decodedIdentifier,
+      hash,
+      fetchEvents
+    );
+    if (!matched) continue;
+    matches.push(candidate);
+    if (matches.length > 1) return undefined;
+  }
+  return matches.length === 1 ? matches[0] : undefined;
 }
 
 function getActivityStatus(entity: PriceRequestEntity): ActivityStatusT {
   if (entity.isResolved) return "past";
-  const currentRoundId = Math.floor(Date.now() / 1000 / roundLength);
   const latestRoundId = Number(entity.latestRound?.roundId ?? 0);
-  return latestRoundId > currentRoundId ? "upcoming" : "active";
+  return latestRoundId > computeRoundId() ? "upcoming" : "active";
 }
 
 async function resolveEntity(
@@ -244,6 +304,14 @@ export default async function handler(
     );
     response.status(200).json({ uniqueKey: entity.id, activityStatus });
   } catch (error) {
+    if (error instanceof HttpError && error.statusCode === 404) {
+      // cache misses briefly too — a repeatedly shared dead link shouldn't
+      // re-run the whole resolution against the subgraph on every hit
+      response.setHeader(
+        "Cache-Control",
+        "public, s-maxage=60, stale-while-revalidate=300"
+      );
+    }
     handleApiError(error, response);
   }
 }

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -1,6 +1,9 @@
 import { gql, request as gqlRequest } from "graphql-request";
 import { computeRoundId } from "helpers/voting/voteTiming";
-import { makeUniqueKeyForVote } from "helpers/voting/makeUniqueKeyForVote";
+import {
+  makeUniqueKeyForVote,
+  makeUniqueKeyFromAncillaryHash,
+} from "helpers/voting/makeUniqueKeyForVote";
 import { fetchBridgedEventsAt } from "lib/l2-ancillary-data";
 import {
   getBridgedFields,
@@ -164,18 +167,20 @@ async function candidateMatchesChildHash(
   const bridged = getBridgedFields(candidate.ancillaryData);
   if (!bridged) return false;
 
-  const parentRequestId = keccak256(
-    defaultAbiCoder.encode(
-      ["bytes32", "uint256", "bytes"],
-      [
-        formatBytes32String(decodedIdentifier),
-        candidate.time,
-        candidate.ancillaryData ?? "0x",
-      ]
-    )
-  ).toLowerCase();
-
   try {
+    // inside the try: formatBytes32String throws for identifiers of 32+
+    // bytes, which cannot be re-encoded and so cannot match a bridged parent
+    const parentRequestId = keccak256(
+      defaultAbiCoder.encode(
+        ["bytes32", "uint256", "bytes"],
+        [
+          formatBytes32String(decodedIdentifier),
+          candidate.time,
+          candidate.ancillaryData ?? "0x",
+        ]
+      )
+    ).toLowerCase();
+
     const events = await fetchEvents(bridged);
     const event = events.find(
       (e) =>
@@ -235,8 +240,12 @@ async function pickByAncillaryDataHash(
 
 function getActivityStatus(entity: PriceRequestEntity): ActivityStatusT {
   if (entity.isResolved) return "past";
-  const latestRoundId = Number(entity.latestRound?.roundId ?? 0);
-  return latestRoundId > computeRoundId() ? "upcoming" : "active";
+  // not tied to a round on the subgraph yet — a brand-new request cannot be
+  // in the current (active) round
+  if (!entity.latestRound) return "upcoming";
+  return Number(entity.latestRound.roundId) > computeRoundId()
+    ? "upcoming"
+    : "active";
 }
 
 async function resolveEntity(
@@ -244,17 +253,29 @@ async function resolveEntity(
 ): Promise<PriceRequestEntity | null | undefined> {
   if ("vote" in params) return findByUniqueKey(params.vote);
 
-  const decodedIdentifier = normalizeIdentifier(params.identifier);
+  let decodedIdentifier: string;
+  try {
+    decodedIdentifier = normalizeIdentifier(params.identifier);
+  } catch {
+    // a bytes32 identifier whose bytes aren't valid UTF-8 can never equal the
+    // subgraph's decoded identifier strings — caller input, not a server error
+    throw new HttpError({
+      statusCode: 400,
+      msg: "identifier is not decodable as UTF-8",
+    });
+  }
   const { time, ancillaryData, ancillaryDataHash } = params;
 
   // when the caller's data or hash corresponds to the DVM-side data, the
   // uniqueKey is directly constructible — single cheap lookup
   const directHash = ancillaryDataHash ?? undefined;
-  if (ancillaryData || directHash) {
-    const uniqueKey = ancillaryData
-      ? makeUniqueKeyForVote(decodedIdentifier, time, ancillaryData)
-      : `${decodedIdentifier}-${time}-${directHash?.toLowerCase() ?? ""}`;
-    const direct = await findByUniqueKey(uniqueKey);
+  const directKey = ancillaryData
+    ? makeUniqueKeyForVote(decodedIdentifier, time, ancillaryData)
+    : directHash
+    ? makeUniqueKeyFromAncillaryHash(decodedIdentifier, time, directHash)
+    : undefined;
+  if (directKey) {
+    const direct = await findByUniqueKey(directKey);
     if (direct) return direct;
   }
 
@@ -275,8 +296,14 @@ async function resolveEntity(
       decodedIdentifier,
       hash
     );
-    if (byHash) return byHash;
+    // The caller said exactly which data they mean and it matched nothing —
+    // possibly a request the subgraph hasn't indexed yet. A lone candidate
+    // sharing identifier+time is NOT safely "the one": resolving it would
+    // return (and CDN-cache) the wrong vote. 404s are cached briefly, so a
+    // not-yet-indexed request heals on retry.
+    return byHash;
   }
+  // identifier+time alone: a single candidate is unambiguous
   return candidates.length === 1 ? candidates[0] : undefined;
 }
 

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -124,11 +124,17 @@ function pickByFullAncillaryData(
   if (exact) return exact;
 
   // Requests reaching the DVM from an oracle contract have the original
-  // ancillary data "stamped" (suffixed with ooRequester/childChainId), so the
-  // requesting side's data is a byte-prefix of what the DVM stores.
-  const stamped = candidates.filter((candidate) =>
-    candidate.ancillaryData?.toLowerCase().startsWith(normalized)
-  );
+  // ancillary data "stamped", so the requesting side's data is a byte-prefix
+  // of what the DVM stores. Requiring the remainder to be the stamp prevents
+  // an unrelated same-batch request that merely begins with the same bytes
+  // from stealing the match.
+  const stamped = candidates.filter((candidate) => {
+    const data = candidate.ancillaryData?.toLowerCase();
+    return (
+      data?.startsWith(normalized) &&
+      data.slice(normalized.length).startsWith(OO_REQUESTER_STAMP)
+    );
+  });
   if (stamped.length === 1) return stamped[0];
 
   // Requests bridged via AncillaryDataCompression replace the data with

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -71,22 +71,46 @@ async function findByUniqueKey(uniqueKey: string) {
   return result.priceRequest;
 }
 
+// paginated like fetchAllDocuments so large same-timestamp batches cannot
+// truncate the candidate set before matching
 async function findCandidatesByDetails(
   decodedIdentifier: string,
   time: number
 ) {
   const query = gql`
     ${priceRequestFields}
-    query resolveDeeplinkSearch($identifier: String!, $time: BigInt!) {
-      priceRequests(where: { identifier: $identifier, time: $time }) {
+    query resolveDeeplinkSearch(
+      $identifier: String!
+      $time: BigInt!
+      $skip: Int!
+      $limit: Int!
+    ) {
+      priceRequests(
+        where: { identifier: $identifier, time: $time }
+        first: $limit
+        skip: $skip
+      ) {
         ...DeeplinkFields
       }
     }
   `;
-  const { priceRequests } = await gqlRequest<{
-    priceRequests: PriceRequestEntity[];
-  }>(VoteSubgraphURL, query, { identifier: decodedIdentifier, time });
-  return priceRequests;
+  const pageSize = 1000;
+  let allCandidates: PriceRequestEntity[] = [];
+  let page: PriceRequestEntity[];
+  let skip = 0;
+  do {
+    ({ priceRequests: page } = await gqlRequest<{
+      priceRequests: PriceRequestEntity[];
+    }>(VoteSubgraphURL, query, {
+      identifier: decodedIdentifier,
+      time,
+      skip,
+      limit: pageSize,
+    }));
+    allCandidates = allCandidates.concat(page);
+    skip += pageSize;
+  } while (page.length === pageSize);
+  return allCandidates;
 }
 
 function pickByFullAncillaryData(

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -163,8 +163,11 @@ function stripOoRequesterStamp(dataHex: string) {
 function hashesOfHex(dataHex: string | undefined) {
   if (!dataHex || dataHex === "0x") return [];
   const hashes = [keccak256(dataHex)];
+  // a stripped value of "0x" is still meaningful: an OO request with blank
+  // caller ancillary data is stamped to just `,ooRequester:<addr>`, and links
+  // built from the raw request bytes hash the empty data
   const stripped = stripOoRequesterStamp(dataHex);
-  if (stripped && stripped !== "0x") hashes.push(keccak256(stripped));
+  if (stripped) hashes.push(keccak256(stripped));
   return hashes;
 }
 
@@ -287,12 +290,10 @@ async function resolveEntity(
   }
   // full ancillary data degrades to its hash so both forms resolve the same
   // requests — the hash matcher covers bridged variants that need the child
-  // chain's event data
+  // chain's event data, and blank data ("0x") matches stamped-blank requests
   const hash =
     ancillaryDataHash ??
-    (ancillaryData && ancillaryData !== "0x"
-      ? keccak256(ancillaryData.toLowerCase())
-      : undefined);
+    (ancillaryData ? keccak256(ancillaryData.toLowerCase()) : undefined);
   if (hash) {
     const byHash = await pickByAncillaryDataHash(
       candidates,

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -1,12 +1,18 @@
+import { BigNumber } from "ethers";
 import { gql, request as gqlRequest } from "graphql-request";
 import { computeRoundId } from "helpers/voting/voteTiming";
 import {
   makeUniqueKeyForVote,
   makeUniqueKeyFromAncillaryHash,
 } from "helpers/voting/makeUniqueKeyForVote";
-import { fetchBridgedEventsAt } from "lib/l2-ancillary-data";
 import {
+  fetchBridgedEventsAt,
+  resolveAncillaryData,
+} from "lib/l2-ancillary-data";
+import {
+  DeeplinkPriceRequestEntity,
   getBridgedFields,
+  makeRawRequestFromEntity,
   matchesCheapHashVariants,
   matchesHexHashVariants,
   normalizeIdentifier,
@@ -21,11 +27,13 @@ import { VoteSubgraphURL } from "./_common";
 import { handleApiError, HttpError } from "./_utils/errors";
 import { validateQueryParams } from "./_utils/validation";
 
-// Resolves a deeplink to `{ uniqueKey, activityStatus }`. Two forms:
-// - `?vote=<uniqueKey>`: a direct id lookup. The dapp itself never calls this
-//   form (it searches its already-loaded lists); it exists for external
-//   consumers (explorer, oracle dapp) that hold a uniqueKey and want to know
-//   whether/where the vote exists before linking to it.
+// Resolves a deeplink to `{ uniqueKey, activityStatus, request }`, where
+// `request` is the price request itself in the app's raw shape (with the
+// child-chain ancillary data already resolved) so the panel can render the
+// vote before the app's own vote lists finish loading. Two forms:
+// - `?vote=<uniqueKey>`: a direct id lookup — used by the dapp for canonical
+//   links while its lists load, and by external consumers (explorer, oracle
+//   dapp) that hold a uniqueKey.
 // - `?identifier=&time=&ancillaryDataHash=` (or full `ancillaryData`): the
 //   external form built by makeVoterDappDeeplink; see lib/deeplink-matching
 //   for the matching semantics.
@@ -47,15 +55,10 @@ const RequestParams = ss.union([
   }),
 ]);
 
-type PriceRequestEntity = {
-  id: string;
-  isResolved: boolean;
-  isDeleted: boolean;
-  time: string;
-  ancillaryData: string | null;
-  latestRound: { roundId: string } | null;
-};
+type PriceRequestEntity = DeeplinkPriceRequestEntity;
 
+// the latestRound sub-selections mirror getPastVotesV2's query so the
+// provisional panel shows the same participation/results the lists will
 const priceRequestFields = gql`
   fragment DeeplinkFields on PriceRequest {
     id
@@ -63,8 +66,33 @@ const priceRequestFields = gql`
     isDeleted
     time
     ancillaryData
+    identifier {
+      id
+    }
+    price
+    resolvedPriceRequestIndex
+    isGovernance
+    rollCount
     latestRound {
       roundId
+      totalVotesRevealed
+      totalTokensCommitted
+      minAgreementRequirement
+      minParticipationRequirement
+      groups(first: 100) {
+        price
+        totalVoteAmount
+      }
+      committedVotes(first: 100) {
+        id
+      }
+      revealedVotes(first: 100) {
+        id
+        voter {
+          address
+        }
+        price
+      }
     }
   }
 `;
@@ -323,13 +351,26 @@ export default async function handler(
     }
 
     const activityStatus = getActivityStatus(entity);
+    const raw = makeRawRequestFromEntity(entity);
+    // resolve the child-chain data server-side so the client renders the
+    // provisional vote without an extra round trip; falls back to the
+    // original data internally if the child fetch fails
+    const { resolvedAncillaryData } = await resolveAncillaryData({
+      identifier: raw.identifier,
+      time: BigNumber.from(raw.time),
+      ancillaryData: raw.ancillaryData,
+    });
     response.setHeader(
       "Cache-Control",
       activityStatus === "past"
         ? "public, s-maxage=31536000, stale-while-revalidate=86400"
         : "public, s-maxage=60, stale-while-revalidate=300"
     );
-    response.status(200).json({ uniqueKey: entity.id, activityStatus });
+    response.status(200).json({
+      uniqueKey: entity.id,
+      activityStatus,
+      request: { ...raw, ancillaryDataL2: resolvedAncillaryData },
+    });
   } catch (error) {
     if (error instanceof HttpError && error.statusCode === 404) {
       // cache misses briefly too — a repeatedly shared dead link shouldn't

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -1,0 +1,183 @@
+import { utils } from "ethers";
+import { gql, request as gqlRequest } from "graphql-request";
+import { decodeHexString } from "helpers/web3/decodeHexString";
+import { makeUniqueKeyForVote } from "helpers/voting/makeUniqueKeyForVote";
+import { NextApiRequest, NextApiResponse } from "next";
+import * as ss from "superstruct";
+import { ActivityStatusT } from "types";
+import { VoteSubgraphURL } from "./_common";
+import { handleApiError, HttpError } from "./_utils/errors";
+import { validateQueryParams } from "./_utils/validation";
+
+const phaseLength = Number(process.env.NEXT_PUBLIC_PHASE_LENGTH || 86400);
+const roundLength = phaseLength * 2;
+
+const RequestParams = ss.union([
+  ss.object({ vote: ss.string() }),
+  ss.object({
+    identifier: ss.string(),
+    time: ss.coerce(ss.integer(), ss.string(), (value) => Number(value)),
+    ancillaryData: ss.optional(ss.pattern(ss.string(), /^0x[0-9a-fA-F]*$/)),
+  }),
+]);
+
+type PriceRequestEntity = {
+  id: string;
+  isResolved: boolean;
+  isDeleted: boolean;
+  time: string;
+  ancillaryData: string | null;
+  latestRound: { roundId: string } | null;
+};
+
+const priceRequestFields = gql`
+  fragment DeeplinkFields on PriceRequest {
+    id
+    isResolved
+    isDeleted
+    time
+    ancillaryData
+    latestRound {
+      roundId
+    }
+  }
+`;
+
+async function findByUniqueKey(uniqueKey: string) {
+  const query = gql`
+    ${priceRequestFields}
+    query resolveDeeplink($id: ID!) {
+      priceRequest(id: $id) {
+        ...DeeplinkFields
+      }
+    }
+  `;
+  const result = await gqlRequest<{ priceRequest: PriceRequestEntity | null }>(
+    VoteSubgraphURL,
+    query,
+    { id: uniqueKey }
+  );
+  return result.priceRequest;
+}
+
+async function findByDetails(
+  decodedIdentifier: string,
+  time: number,
+  ancillaryData: string | undefined
+) {
+  const query = gql`
+    ${priceRequestFields}
+    query resolveDeeplinkSearch($identifier: String!, $time: BigInt!) {
+      priceRequests(where: { identifier: $identifier, time: $time }) {
+        ...DeeplinkFields
+      }
+    }
+  `;
+  const { priceRequests: candidates } = await gqlRequest<{
+    priceRequests: PriceRequestEntity[];
+  }>(VoteSubgraphURL, query, { identifier: decodedIdentifier, time });
+
+  if (!ancillaryData || ancillaryData === "0x") {
+    return candidates.length === 1 ? candidates[0] : undefined;
+  }
+
+  const normalized = ancillaryData.toLowerCase();
+  const exact = candidates.find(
+    (candidate) => candidate.ancillaryData?.toLowerCase() === normalized
+  );
+  if (exact) return exact;
+
+  // Requests reaching the DVM from an oracle contract have the original
+  // ancillary data "stamped" (suffixed with ooRequester/childChainId), so the
+  // requesting side's data is a byte-prefix of what the DVM stores.
+  const stamped = candidates.filter((candidate) =>
+    candidate.ancillaryData?.toLowerCase().startsWith(normalized)
+  );
+  if (stamped.length === 1) return stamped[0];
+
+  // Requests bridged via AncillaryDataCompression replace the data with
+  // `ancillaryDataHash:<keccak256(childData)>,childBlockNumber:...`, so match
+  // the hash of the provided data against the compressed form.
+  const providedDataHash = utils.keccak256(normalized).slice(2);
+  const compressed = candidates.filter((candidate) =>
+    decodeAncillaryDataSafe(candidate.ancillaryData)?.startsWith(
+      `ancillaryDataHash:${providedDataHash},`
+    )
+  );
+  if (compressed.length === 1) return compressed[0];
+
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
+function decodeAncillaryDataSafe(ancillaryData: string | null) {
+  if (!ancillaryData) return undefined;
+  try {
+    return decodeHexString(ancillaryData);
+  } catch {
+    return undefined;
+  }
+}
+
+// The subgraph identifier id is the decoded string ("YES_OR_NO_QUERY"), but
+// callers may pass the on-chain bytes32 form instead.
+function normalizeIdentifier(identifier: string) {
+  if (/^0x[0-9a-fA-F]{64}$/.test(identifier)) {
+    return decodeHexString(identifier);
+  }
+  return identifier;
+}
+
+function getActivityStatus(entity: PriceRequestEntity): ActivityStatusT {
+  if (entity.isResolved) return "past";
+  const currentRoundId = Math.floor(Date.now() / 1000 / roundLength);
+  const latestRoundId = Number(entity.latestRound?.roundId ?? 0);
+  return latestRoundId > currentRoundId ? "upcoming" : "active";
+}
+
+export default async function handler(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  try {
+    if (request.method !== "GET") {
+      throw new HttpError({ statusCode: 405 });
+    }
+    const params = validateQueryParams(request.query, RequestParams);
+
+    let entity: PriceRequestEntity | null | undefined;
+    if ("vote" in params) {
+      entity = await findByUniqueKey(params.vote);
+    } else {
+      const decodedIdentifier = normalizeIdentifier(params.identifier);
+      if (params.ancillaryData) {
+        entity = await findByUniqueKey(
+          makeUniqueKeyForVote(
+            decodedIdentifier,
+            params.time,
+            params.ancillaryData
+          )
+        );
+      }
+      entity ??= await findByDetails(
+        decodedIdentifier,
+        params.time,
+        params.ancillaryData
+      );
+    }
+
+    if (!entity || entity.isDeleted) {
+      throw new HttpError({ statusCode: 404, msg: "Vote not found" });
+    }
+
+    const activityStatus = getActivityStatus(entity);
+    response.setHeader(
+      "Cache-Control",
+      activityStatus === "past"
+        ? "public, s-maxage=31536000, stale-while-revalidate=86400"
+        : "public, s-maxage=60, stale-while-revalidate=300"
+    );
+    response.status(200).json({ uniqueKey: entity.id, activityStatus });
+  } catch (error) {
+    handleApiError(error, response);
+  }
+}

--- a/tests/helpers/deeplink.test.ts
+++ b/tests/helpers/deeplink.test.ts
@@ -66,7 +66,9 @@ describe("makeVoterDappDeeplink", () => {
     );
   });
 
-  it("omits empty ancillary data and respects baseUrl", () => {
+  // blank ancillary data ("0x") must survive: it enables a direct uniqueKey
+  // lookup when several requests share identifier and time
+  it("keeps blank ancillary data and respects baseUrl", () => {
     expect(
       makeVoterDappDeeplink({
         identifier:
@@ -76,7 +78,7 @@ describe("makeVoterDappDeeplink", () => {
         baseUrl: "https://testnet.vote.uma.xyz",
       })
     ).toBe(
-      "https://testnet.vote.uma.xyz/?identifier=0x5945535f4f525f4e4f5f51554552590000000000000000000000000000000000&time=1751900000"
+      "https://testnet.vote.uma.xyz/?identifier=0x5945535f4f525f4e4f5f51554552590000000000000000000000000000000000&time=1751900000&ancillaryData=0x"
     );
   });
 });

--- a/tests/helpers/deeplink.test.ts
+++ b/tests/helpers/deeplink.test.ts
@@ -1,0 +1,77 @@
+import {
+  makeVoterDappDeeplink,
+  parseVoteDeeplink,
+} from "helpers/util/deeplink";
+import { describe, expect, it } from "vitest";
+
+const uniqueKey =
+  "YES_OR_NO_QUERY-1751900000-0x40e832d2323085fa42bd2f76a41ef993ffdbe4f6a06e938ce1a9a2a2c45ae7fa";
+
+describe("parseVoteDeeplink", () => {
+  it("prefers the canonical uniqueKey form", () => {
+    expect(
+      parseVoteDeeplink({ vote: uniqueKey, identifier: "ignored" })
+    ).toEqual({ form: "uniqueKey", uniqueKey });
+  });
+
+  it("parses the external form", () => {
+    expect(
+      parseVoteDeeplink({
+        identifier: "YES_OR_NO_QUERY",
+        time: "1751900000",
+        ancillaryData: "0xabcd",
+      })
+    ).toEqual({
+      form: "external",
+      identifier: "YES_OR_NO_QUERY",
+      time: 1751900000,
+      ancillaryData: "0xabcd",
+    });
+  });
+
+  // next/router repeats a param as an array when it appears twice
+  it("takes the first value of repeated params", () => {
+    expect(parseVoteDeeplink({ vote: [uniqueKey, "other"] })).toEqual({
+      form: "uniqueKey",
+      uniqueKey,
+    });
+  });
+
+  it("returns undefined for unrelated or malformed queries", () => {
+    expect(parseVoteDeeplink({})).toBeUndefined();
+    expect(
+      parseVoteDeeplink({ identifier: "YES_OR_NO_QUERY" })
+    ).toBeUndefined();
+    expect(
+      parseVoteDeeplink({ identifier: "YES_OR_NO_QUERY", time: "not-a-number" })
+    ).toBeUndefined();
+  });
+});
+
+describe("makeVoterDappDeeplink", () => {
+  it("builds a production link with encoded params", () => {
+    expect(
+      makeVoterDappDeeplink({
+        identifier: "YES_OR_NO_QUERY",
+        time: 1751900000,
+        ancillaryData: "0xabcd",
+      })
+    ).toBe(
+      "https://vote.uma.xyz/?identifier=YES_OR_NO_QUERY&time=1751900000&ancillaryData=0xabcd"
+    );
+  });
+
+  it("omits empty ancillary data and respects baseUrl", () => {
+    expect(
+      makeVoterDappDeeplink({
+        identifier:
+          "0x5945535f4f525f4e4f5f51554552590000000000000000000000000000000000",
+        time: "1751900000",
+        ancillaryData: "0x",
+        baseUrl: "https://testnet.vote.uma.xyz",
+      })
+    ).toBe(
+      "https://testnet.vote.uma.xyz/?identifier=0x5945535f4f525f4e4f5f51554552590000000000000000000000000000000000&time=1751900000"
+    );
+  });
+});

--- a/tests/helpers/deeplink.test.ts
+++ b/tests/helpers/deeplink.test.ts
@@ -19,13 +19,16 @@ describe("parseVoteDeeplink", () => {
       parseVoteDeeplink({
         identifier: "YES_OR_NO_QUERY",
         time: "1751900000",
-        ancillaryData: "0xabcd",
+        ancillaryDataHash:
+          "0x40e832d2323085fa42bd2f76a41ef993ffdbe4f6a06e938ce1a9a2a2c45ae7fa",
       })
     ).toEqual({
       form: "external",
       identifier: "YES_OR_NO_QUERY",
       time: 1751900000,
-      ancillaryData: "0xabcd",
+      ancillaryData: undefined,
+      ancillaryDataHash:
+        "0x40e832d2323085fa42bd2f76a41ef993ffdbe4f6a06e938ce1a9a2a2c45ae7fa",
     });
   });
 
@@ -49,15 +52,17 @@ describe("parseVoteDeeplink", () => {
 });
 
 describe("makeVoterDappDeeplink", () => {
-  it("builds a production link with encoded params", () => {
+  it("builds a production link, preferring the hash over full data", () => {
     expect(
       makeVoterDappDeeplink({
         identifier: "YES_OR_NO_QUERY",
         time: 1751900000,
+        ancillaryDataHash:
+          "0x40e832d2323085fa42bd2f76a41ef993ffdbe4f6a06e938ce1a9a2a2c45ae7fa",
         ancillaryData: "0xabcd",
       })
     ).toBe(
-      "https://vote.uma.xyz/?identifier=YES_OR_NO_QUERY&time=1751900000&ancillaryData=0xabcd"
+      "https://vote.uma.xyz/?identifier=YES_OR_NO_QUERY&time=1751900000&ancillaryDataHash=0x40e832d2323085fa42bd2f76a41ef993ffdbe4f6a06e938ce1a9a2a2c45ae7fa"
     );
   });
 

--- a/tests/lib/deeplink-matching.test.ts
+++ b/tests/lib/deeplink-matching.test.ts
@@ -1,8 +1,10 @@
-import { keccak256 } from "ethers/lib/utils";
+import { formatBytes32String, getAddress, keccak256 } from "ethers/lib/utils";
 import { encodeHexString } from "helpers/web3/decodeHexString";
 import {
+  DeeplinkPriceRequestEntity,
   getBridgedFields,
   hashesOfHex,
+  makeRawRequestFromEntity,
   matchesCheapHashVariants,
   matchesHexHashVariants,
   normalizeIdentifier,
@@ -218,6 +220,92 @@ describe("matchesCheapHashVariants", () => {
     expect(matchesCheapHashVariants(callerData, keccak256(childData))).toBe(
       false
     );
+  });
+});
+
+describe("makeRawRequestFromEntity", () => {
+  const voterA = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8";
+  const entity: DeeplinkPriceRequestEntity = {
+    id: "YES_OR_NO_QUERY-1751900000-0xabc",
+    isResolved: true,
+    isDeleted: false,
+    time: "1751900000",
+    ancillaryData: callerData,
+    identifier: { id: "YES_OR_NO_QUERY" },
+    price: "1000000000000000000",
+    resolvedPriceRequestIndex: "123",
+    isGovernance: false,
+    rollCount: 1,
+    latestRound: {
+      roundId: "10000",
+      totalVotesRevealed: "5000000",
+      totalTokensCommitted: "6000000",
+      minAgreementRequirement: "1000000",
+      minParticipationRequirement: "2000000",
+      groups: [
+        { price: "1000000000000000000", totalVoteAmount: "4000000" },
+        { price: "0", totalVoteAmount: "1000000" },
+      ],
+      committedVotes: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      revealedVotes: [{ voter: { address: voterA }, price: "0" }],
+    },
+  };
+
+  it("mirrors the getPastVotesV2 transform", () => {
+    expect(makeRawRequestFromEntity(entity)).toEqual({
+      identifier: formatBytes32String("YES_OR_NO_QUERY"),
+      time: 1751900000,
+      ancillaryData: callerData,
+      correctVote: "1000000000000000000",
+      resolvedPriceRequestIndex: "123",
+      isGovernance: false,
+      rollCount: 1,
+      isV1: false,
+      participation: {
+        uniqueCommitAddresses: 3,
+        uniqueRevealAddresses: 1,
+        totalTokensVotedWith: 5000000,
+        totalTokensCommitted: 6000000,
+        minAgreementRequirement: 1000000,
+        minParticipationRequirement: 2000000,
+      },
+      results: [
+        { vote: "1000000000000000000", tokensVotedWith: 4000000 },
+        { vote: "0", tokensVotedWith: 1000000 },
+      ],
+      revealedVoteByAddress: { [getAddress(voterA)]: "0" },
+    });
+  });
+
+  // formatBytes32String rejects identifiers of exactly 32 bytes; plain utf8
+  // encoding round-trips them and decodeHexString strips padding either way
+  it("encodes a 32-byte identifier without throwing", () => {
+    const longId = "A".repeat(32);
+    const raw = makeRawRequestFromEntity({
+      ...entity,
+      identifier: { id: longId },
+    });
+    expect(raw.identifier).toBe(encodeHexString(longId));
+  });
+
+  it("handles an unresolved request with sparse round data", () => {
+    const unresolved = makeRawRequestFromEntity({
+      ...entity,
+      isResolved: false,
+      price: null,
+      resolvedPriceRequestIndex: null,
+      rollCount: null,
+      ancillaryData: null,
+      latestRound: null,
+    });
+    expect(unresolved.correctVote).toBeUndefined();
+    expect(unresolved.resolvedPriceRequestIndex).toBeUndefined();
+    expect(unresolved.rollCount).toBe(0);
+    expect(unresolved.ancillaryData).toBe("0x");
+    expect(unresolved.results).toEqual([]);
+    expect(unresolved.revealedVoteByAddress).toEqual({});
+    expect(unresolved.participation.totalTokensCommitted).toBeUndefined();
+    expect(unresolved.participation.uniqueCommitAddresses).toBe(0);
   });
 });
 

--- a/tests/lib/deeplink-matching.test.ts
+++ b/tests/lib/deeplink-matching.test.ts
@@ -1,0 +1,216 @@
+import { keccak256 } from "ethers/lib/utils";
+import { encodeHexString } from "helpers/web3/decodeHexString";
+import {
+  getBridgedFields,
+  hashesOfHex,
+  matchesCheapHashVariants,
+  matchesHexHashVariants,
+  normalizeIdentifier,
+  pickByFullAncillaryData,
+  stripOoRequesterStamp,
+} from "lib/deeplink-matching";
+import { describe, expect, it } from "vitest";
+
+// Fixtures mirror the shapes seen in production: a plain DVM request, an
+// OO-stamped request (`<caller data>,ooRequester:<addr>`), a stamped request
+// with blank caller data, and a bridged/compressed request that replaces the
+// data with `ancillaryDataHash:<keccak256(childData)>,...`.
+
+const requester = "f39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+const childRequester = "70997970c51812dc3a010c7d01b50e0d17dc79c8";
+
+const callerData = encodeHexString('q:"Will it settle?",p1:0,p2:1');
+const stampedData = encodeHexString(
+  `q:"Will it settle?",p1:0,p2:1,ooRequester:${requester}`
+);
+// shares callerData's byte-prefix but the remainder is not the stamp
+const prefixCollisionData = encodeHexString(
+  'q:"Will it settle?",p1:0,p2:1,extra:1'
+);
+const blankStampedData = encodeHexString(`,ooRequester:${requester}`);
+
+const childData = stampedData;
+const compressedData = encodeHexString(
+  `ancillaryDataHash:${keccak256(childData).slice(2)},` +
+    `childBlockNumber:12345,` +
+    `childOracle:${requester},` +
+    `childRequester:${childRequester},` +
+    `childChainId:137`
+);
+
+const emptyDataHash = keccak256("0x");
+
+function candidate(id: string, ancillaryData: string | null) {
+  return { id, ancillaryData };
+}
+
+describe("stripOoRequesterStamp", () => {
+  it("strips the stamp back to the caller's bytes", () => {
+    expect(stripOoRequesterStamp(stampedData)).toBe(callerData);
+  });
+
+  it("returns undefined when no stamp is present", () => {
+    expect(stripOoRequesterStamp(callerData)).toBeUndefined();
+  });
+
+  it("strips a blank-data stamp to empty bytes", () => {
+    expect(stripOoRequesterStamp(blankStampedData)).toBe("0x");
+  });
+});
+
+describe("hashesOfHex", () => {
+  it("hashes unstamped data once", () => {
+    expect(hashesOfHex(callerData)).toEqual([keccak256(callerData)]);
+  });
+
+  it("hashes stamped data and its pre-stamp form", () => {
+    expect(hashesOfHex(stampedData)).toEqual([
+      keccak256(stampedData),
+      keccak256(callerData),
+    ]);
+  });
+
+  it("includes the empty-data hash for a blank-data stamp", () => {
+    expect(hashesOfHex(blankStampedData)).toEqual([
+      keccak256(blankStampedData),
+      emptyDataHash,
+    ]);
+  });
+
+  it("returns nothing for empty input", () => {
+    expect(hashesOfHex(undefined)).toEqual([]);
+    expect(hashesOfHex("0x")).toEqual([]);
+  });
+});
+
+describe("pickByFullAncillaryData", () => {
+  const candidates = [
+    candidate("exact", callerData),
+    candidate("stamped", stampedData),
+    candidate("collision", prefixCollisionData),
+    candidate("compressed", compressedData),
+  ];
+
+  it("prefers an exact match", () => {
+    expect(pickByFullAncillaryData(candidates, callerData)?.id).toBe("exact");
+  });
+
+  it("matches stamped data when the caller holds the pre-stamp bytes", () => {
+    const withoutExact = candidates.filter((c) => c.id !== "exact");
+    expect(pickByFullAncillaryData(withoutExact, callerData)?.id).toBe(
+      "stamped"
+    );
+  });
+
+  it("does not let a byte-prefix collision steal a stamped match", () => {
+    const onlyCollision = [candidate("collision", prefixCollisionData)];
+    expect(pickByFullAncillaryData(onlyCollision, callerData)).toBeUndefined();
+  });
+
+  it("refuses ambiguous stamped matches", () => {
+    const twoStamped = [
+      candidate("a", stampedData),
+      candidate(
+        "b",
+        encodeHexString(
+          `q:"Will it settle?",p1:0,p2:1,ooRequester:${childRequester}`
+        )
+      ),
+    ];
+    expect(pickByFullAncillaryData(twoStamped, callerData)).toBeUndefined();
+  });
+
+  it("matches a compressed request by the embedded child-data hash", () => {
+    expect(
+      pickByFullAncillaryData([candidate("compressed", compressedData)], childData)
+        ?.id
+    ).toBe("compressed");
+  });
+
+  it("is case-insensitive on the provided data", () => {
+    expect(
+      pickByFullAncillaryData(candidates, callerData.toUpperCase().replace("0X", "0x"))
+        ?.id
+    ).toBe("exact");
+  });
+});
+
+describe("getBridgedFields", () => {
+  it("extracts the child-chain reference from a compressed request", () => {
+    expect(getBridgedFields(compressedData)).toEqual({
+      ancillaryDataHash: keccak256(childData).slice(2),
+      childOracle: `0x${requester}`,
+      childChainId: 137,
+      childBlockNumber: 12345,
+    });
+  });
+
+  it("returns undefined for non-bridged data", () => {
+    expect(getBridgedFields(callerData)).toBeUndefined();
+    expect(getBridgedFields(null)).toBeUndefined();
+    expect(getBridgedFields("0xzz")).toBeUndefined();
+  });
+});
+
+describe("matchesHexHashVariants", () => {
+  it("matches the hash of the data itself", () => {
+    expect(matchesHexHashVariants(stampedData, keccak256(stampedData))).toBe(
+      true
+    );
+  });
+
+  it("matches the hash of the pre-stamp form", () => {
+    expect(matchesHexHashVariants(stampedData, keccak256(callerData))).toBe(
+      true
+    );
+  });
+
+  it("rejects an unrelated hash", () => {
+    expect(
+      matchesHexHashVariants(stampedData, keccak256(prefixCollisionData))
+    ).toBe(false);
+  });
+});
+
+describe("matchesCheapHashVariants", () => {
+  it("matches DVM-side and pre-stamp hashes", () => {
+    expect(matchesCheapHashVariants(stampedData, keccak256(stampedData))).toBe(
+      true
+    );
+    expect(matchesCheapHashVariants(stampedData, keccak256(callerData))).toBe(
+      true
+    );
+  });
+
+  it("matches the hash embedded in a compressed request", () => {
+    expect(matchesCheapHashVariants(compressedData, keccak256(childData))).toBe(
+      true
+    );
+  });
+
+  it("matches the empty-data hash for a blank-data stamp", () => {
+    expect(matchesCheapHashVariants(blankStampedData, emptyDataHash)).toBe(
+      true
+    );
+  });
+
+  it("does not match the child data hash without the embedded reference", () => {
+    expect(matchesCheapHashVariants(callerData, keccak256(childData))).toBe(
+      false
+    );
+  });
+});
+
+describe("normalizeIdentifier", () => {
+  it("decodes the on-chain bytes32 form", () => {
+    expect(
+      normalizeIdentifier(
+        "0x5945535f4f525f4e4f5f51554552590000000000000000000000000000000000"
+      )
+    ).toBe("YES_OR_NO_QUERY");
+  });
+
+  it("passes decoded identifiers through", () => {
+    expect(normalizeIdentifier("YES_OR_NO_QUERY")).toBe("YES_OR_NO_QUERY");
+  });
+});

--- a/tests/lib/deeplink-matching.test.ts
+++ b/tests/lib/deeplink-matching.test.ts
@@ -6,6 +6,7 @@ import {
   matchesCheapHashVariants,
   matchesHexHashVariants,
   normalizeIdentifier,
+  OO_REQUESTER_STAMP,
   pickByFullAncillaryData,
   stripOoRequesterStamp,
 } from "lib/deeplink-matching";
@@ -55,6 +56,21 @@ describe("stripOoRequesterStamp", () => {
 
   it("strips a blank-data stamp to empty bytes", () => {
     expect(stripOoRequesterStamp(blankStampedData)).toBe("0x");
+  });
+
+  // binary ancillary data can contain the stamp's nibble sequence shifted off
+  // a byte boundary; slicing there would produce odd-length hex and make
+  // keccak256 throw (a 500 for every deeplink sharing that identifier+time)
+  it("ignores a nibble-shifted stamp coincidence in binary data", () => {
+    const unaligned = `0xa${OO_REQUESTER_STAMP}b`;
+    expect(stripOoRequesterStamp(unaligned)).toBeUndefined();
+    expect(() => hashesOfHex(unaligned)).not.toThrow();
+  });
+
+  it("walks back to a byte-aligned stamp past a later unaligned coincidence", () => {
+    const tricky = `0x${OO_REQUESTER_STAMP}00a${OO_REQUESTER_STAMP}b`;
+    expect(stripOoRequesterStamp(tricky)).toBe("0x");
+    expect(() => hashesOfHex(tricky)).not.toThrow();
   });
 });
 
@@ -122,15 +138,19 @@ describe("pickByFullAncillaryData", () => {
 
   it("matches a compressed request by the embedded child-data hash", () => {
     expect(
-      pickByFullAncillaryData([candidate("compressed", compressedData)], childData)
-        ?.id
+      pickByFullAncillaryData(
+        [candidate("compressed", compressedData)],
+        childData
+      )?.id
     ).toBe("compressed");
   });
 
   it("is case-insensitive on the provided data", () => {
     expect(
-      pickByFullAncillaryData(candidates, callerData.toUpperCase().replace("0X", "0x"))
-        ?.id
+      pickByFullAncillaryData(
+        candidates,
+        callerData.toUpperCase().replace("0X", "0x")
+      )?.id
     ).toBe("exact");
   });
 });


### PR DESCRIPTION
> Supersedes #473 — same commits, recreated with Droplet as author (requested by @gsteenkamp89 in Slack).

## What

Adds deeplinking to specific votes, mirroring the oracle dapp's pattern where the address bar is the shareable link.

Two URL forms work on any page:

- **Canonical**: `?vote=<uniqueKey>` — the URL is the single source of truth for the vote panel: opening a vote (row click, panel arrows, inbound link) writes this param, and the panel state is derived from it, so opened/next/prev/closed and the back button stay in sync by construction.
- **External**: `?identifier=<string|bytes32>&time=<unixSeconds>&ancillaryDataHash=<keccak256>` — for the oracle dapp and the new explorer dapp. Ancillary data is often kilobytes (too long for a URL), so callers pass its keccak256 hash instead; full `ancillaryData` is still accepted when short.

Inbound links redirect to the correct page (`/`, `/upcoming-votes`, `/past-votes`), open the details panel **immediately from the resolver's own data** — before the app's vote lists finish loading, like the oracle dapp — then upgrade in place with prev/next navigation, user data, and a scroll-highlighted row once the lists arrive. Unresolvable links surface a notification and the dead params are dropped from the URL.

### Link builder for external dapps

`makeVoterDappDeeplink({ identifier, time, ancillaryDataHash })` in `helpers/util/deeplink.ts` is the canonical dependency-free builder — copy it as-is. The hash is `keccak256(request.ancillaryData)`, of **whichever version the caller holds**: raw request data, oracle-stamped, or DVM-side all resolve. The API tolerates unknown query params (e.g. `utm_*`), so links stay forward-compatible.

## How

- **`lib/deeplink-matching.ts`**: all resolution semantics — stamp-remainder verification, compressed-hash matching, hash-variant generation, bridged-field extraction, and the entity→raw-request mapping — live in a pure module with unit tests (`tests/lib/deeplink-matching.test.ts`) covering stamped, prefix-collision, nibble-shifted-stamp, compressed, blank-data, and sparse-round fixtures.
- **`pages/api/resolve-deeplink.ts`**: resolves either form to `{ uniqueKey, activityStatus, request }`, where `request` is the price request in the app's raw shape with the child-chain ancillary data already resolved server-side (the same latestRound sub-selections `getPastVotesV2` pulls, so the provisional panel shows what the lists will). The votingV2 subgraph's `PriceRequest.id` is constructed identically to the frontend `uniqueKey`, so DVM-side hashes are a direct id lookup. Otherwise candidates are fetched by identifier+time (paginated, capped at 5 pages) and matched: IO-free hash variants first; child-chain bridge-event fetches only when nothing matched cheaply, memoized on (chain, oracle, block) so a same-batch candidate set costs one RPC call, sequential with an early abort once a second match makes the result ambiguous. Verified this disambiguates 8 Polymarket requests sharing one timestamp in ~2s. Settled votes get `s-maxage=31536000`, unresolved 60s, and 404s a short s-maxage so dead links don't re-run resolution.
- **`hooks/helpers/useVoteUrl.ts` + `hooks/helpers/useVoteDeeplink.ts`** (mounted via `VoteDeeplinkHandler` in `_app`): one-directional URL↔panel flow. Every in-app action writes only the URL (`useVoteUrl`: row clicks push so back closes the panel; arrows and close replace so paging doesn't spam history), and `useVoteDeeplink` is the only place that opens/closes the vote panel in response. While the vote lists are still loading, the deriver opens a **provisional vote** built from the resolver's entity via `makeProvisionalVote` (the same `formatPriceRequest`/`getVoteMetaData` pipeline the lists use — logged-out view, no arrows yet, uniqueKey taken from the resolver so it always matches the URL) and swaps in the canonical vote through the normal `showVote` path when they arrive. Canonical links fetch the entity through the API's `vote` branch; external links seed the same react-query cache from their own resolution, so nothing is fetched twice. Inbound links (not marked self-initiated) land on the vote's page — now decided from the resolver's `activityStatus`, before the lists exist — and scroll-highlight its row; in-app opens act in place, so history-panel rows open votes on whatever page the user is on. Vote-to-vote transitions swap the panel-stack top, so a vote opened over the history panel returns there on close.
- **`contexts/VoteSelectionContext.tsx`**: quick-vote selections (persisted per round) shared by the active-votes list and the vote panel, so the panel's quick-vote controls work identically however it was opened — no callbacks threaded through `openPanel`, no mirrored state.
- **Scroll-and-highlight**: the deriver sets a scroll-target in `PanelContext`; the row consumes it in an effect once it is actually mounted — deterministic across page redirects, list hydration after a provisional open, and pagination jumps.
- **`Nav.tsx`**: skip the close-panel-on-route-change handler for shallow (query-only) updates.
- **`lib/l2-ancillary-data.ts`**: adds `fetchBridgedEventsAt` (all `PriceRequestBridged` events at a block, unfiltered so batch-mates share one fetch); `fetchAncillaryDataFromSpoke` now matches `parentRequestId` locally on top of it.

## Review notes

- Verified end-to-end against a production build (`next build && next start`) on the original architecture: hash-form resolution (mainnet / stamped / raw hashes, real Polygon bridge events) → page redirect → canonical rewrite → panel open; row-click/next-arrow/close/back-button URL sync; active vs upcoming vs past classification against live round data. The follow-up revisions (URL-driven panel, provisional render) are covered by unit tests, tsc, lint, and a clean production build; the interactive flows deserve a fresh pass on the Vercel preview.
- If the caller's explicit hash matches nothing, the resolver returns 404 rather than falling back to a lone identifier+time candidate (which could be the wrong vote when a sibling isn't indexed yet — and would get CDN-cached). Identifier+time *without* a hash keeps the single-candidate lenience. 404s are cached briefly, so a not-yet-indexed request heals on retry.
- If the lists finish loading without the deeplinked vote while a provisional panel is showing it, the panel stays — the resolver's entity is authoritative and the lists can lag it.
- Heads-up for manual testing: `next dev` on this app never flips `router.isReady` when *any* query param is present (pre-existing, reproducible on master with `?foo=bar`; production and vote.uma.xyz are fine). Test deeplinks against a production build.
- The `handleApiError` missing-return bug this route would otherwise trip is fixed separately in #474.

### Behavior convergences (deliberate)

- Past/upcoming row clicks now get the same prev/next arrows deeplink-opened panels already had.
- History-panel rows open the vote panel in place (previously the only `openPanel("vote")` caller without navigation).
- Quick-vote selection persists across page navigation within a round (it was already persisted to localStorage per round; the context now reads one store instead of two copies). The panel's quick-vote controls appear once the active list confirms membership — on a provisional panel that means a beat after open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
