### PR TITLE
fix: resolve L2 ancillary data on demand instead of for all past votes

### DIFF
--- a/components/Panel/VotePanel/VotePanelWithLazyLoad.tsx
+++ b/components/Panel/VotePanel/VotePanelWithLazyLoad.tsx
@@ -1,6 +1,7 @@
 import { LoadingSpinner } from "components";
 import {
   usePastVoteDetails,
+  useResolvedVoteList,
   useUserVotingAndStakingDetails,
   useAccountDetails,
   useDelegationContext,
@@ -14,7 +15,12 @@ interface Props {
   content: VoteT;
 }
 
-export function VotePanelWithLazyLoad({ content }: Props) {
+export function VotePanelWithLazyLoad({ content: rawContent }: Props) {
+  // votes from the past votes list carry unresolved (bridged) ancillary data
+  const {
+    resolvedVotes: [content],
+    isResolving,
+  } = useResolvedVoteList(useMemo(() => [rawContent], [rawContent]));
   const { address: userAddress } = useAccountDetails();
   const { isDelegate, delegatorAddress } = useDelegationContext();
   const userOrDelegatorAddress = isDelegate ? delegatorAddress : userAddress;
@@ -59,7 +65,7 @@ export function VotePanelWithLazyLoad({ content }: Props) {
     return content;
   }, [content, detailedVote, needsDetailedData]);
 
-  if (needsDetailedData && isLoading) {
+  if ((needsDetailedData && isLoading) || isResolving) {
     return (
       <LoadingWrapper>
         <LoadingSpinner size={40} variant="black" />

--- a/components/Votes/PastVotes.tsx
+++ b/components/Votes/PastVotes.tsx
@@ -1,5 +1,6 @@
 import { Button, VoteList } from "components";
 import {
+  useResolvedVoteList,
   useVoteTimingContext,
   useVotesContext,
   useVoteUrl,
@@ -28,13 +29,14 @@ export function PastVotes() {
 
   // Get the first 5 votes
   const recentVotes = pastVoteList.slice(0, 5);
+  const { resolvedVotes } = useResolvedVoteList(recentVotes);
 
   // Fetch user vote details for these votes
   const { data: userVoteDetails, isLoading: userVotesLoading } =
     useUserPastVotes(recentVotes);
 
   const data = useMemo(() => {
-    return recentVotes.map((vote) => {
+    return resolvedVotes.map((vote) => {
       // Merge the revealed vote data if available
       const revealedVoteByAddress =
         userVoteDetails?.[vote.uniqueKey] || vote.revealedVoteByAddress || {};
@@ -77,7 +79,7 @@ export function PastVotes() {
       };
     });
   }, [
-    recentVotes,
+    resolvedVotes,
     userVoteDetails,
     phase,
     openVote,

--- a/components/pages/PastVotes.tsx
+++ b/components/pages/PastVotes.tsx
@@ -10,6 +10,7 @@ import {
 } from "components";
 import {
   useDeeplinkedVoteIndex,
+  useResolvedVoteList,
   useVoteTimingContext,
   useVotesContext,
   useVoteUrl,
@@ -34,6 +35,7 @@ export function PastVotes() {
     pastVoteList ?? [],
     deeplinkedVoteIndex
   );
+  const { resolvedVotes } = useResolvedVoteList(entriesToShow);
 
   // Check if wallet is connected
   const isWalletConnected = !!(address || delegatorAddress);
@@ -43,7 +45,7 @@ export function PastVotes() {
     useUserPastVotes(entriesToShow);
 
   const data = useMemo(() => {
-    return entriesToShow.map((vote) => {
+    return resolvedVotes.map((vote) => {
       // Merge the revealed vote data if available
       const revealedVoteByAddress =
         userVoteDetails?.[vote.uniqueKey] || vote.revealedVoteByAddress || {};
@@ -86,7 +88,7 @@ export function PastVotes() {
       };
     });
   }, [
-    entriesToShow,
+    resolvedVotes,
     userVoteDetails,
     phase,
     openVote,

--- a/constant/query/queryKeys.ts
+++ b/constant/query/queryKeys.ts
@@ -7,6 +7,7 @@ export const augmentedVoteDataKey = "augmentedVoteDataKey";
 export const voteDiscussionKey = "voteDiscussionKey";
 export const assertionClaimsKey = "assertionClaimsKey";
 export const discussionSummaryKey = "discussionSummary";
+export const resolvedAncillaryDataKey = "resolvedAncillaryDataKey";
 // voting - user dependent
 export const encryptedVotesKey = "encryptedVotesKey";
 export const decryptedVotesKey = "decryptedVotesKey";

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -93,7 +93,7 @@ export async function getPastVotesV2Lightweight() {
     200 // Larger page size since query is lighter
   );
 
-  const results = result?.map(
+  return result?.map(
     ({
       identifier: { id },
       time,
@@ -107,6 +107,10 @@ export async function getPastVotesV2Lightweight() {
         time: Number(time),
         correctVote: price,
         ancillaryData,
+        // Resolving bridged (L2) ancillary data costs one API call per vote,
+        // far too many for the full history. Lists render from the raw data;
+        // useResolvedVoteList resolves the votes actually on screen.
+        ancillaryDataL2: ancillaryData,
         resolvedPriceRequestIndex: String(resolvedPriceRequestIndex),
         isV1: false,
         // Placeholder data - will be fetched on demand
@@ -122,15 +126,6 @@ export async function getPastVotesV2Lightweight() {
         revealedVoteByAddress: {},
       };
     }
-  );
-
-  return resolveAncillaryDataForRequests(
-    results.map((request) => {
-      return {
-        ...request,
-        time: BigNumber.from(request.time),
-      };
-    })
   );
 }
 

--- a/helpers/voting/getVoteMetaData.ts
+++ b/helpers/voting/getVoteMetaData.ts
@@ -17,6 +17,7 @@ import {
   VoteOriginT,
 } from "types";
 import { checkIfIsInfiniteGames } from "./projects/infiniteGames";
+import { extractMaybeAncillaryDataFields } from "lib/deeplink-matching";
 import * as s from "superstruct";
 import { maxInt256, minInt256 } from "constant/web3/numbers";
 import { stripInvalidCharacters } from "lib/utils";
@@ -34,6 +35,29 @@ export function getVoteMetaData(
   decodedAncillaryData: string,
   umipDataFromContentful: ContentfulDataT | undefined
 ): VoteMetaDataT {
+  // Bridged (L2) requests carry only a reference to their ancillary data
+  // until resolved (see useResolvedVoteList) — nothing in the reference is
+  // parseable, so return identifier-derived metadata instead.
+  const bridgedFields = extractMaybeAncillaryDataFields(decodedAncillaryData);
+  if (
+    bridgedFields.ancillaryDataHash &&
+    bridgedFields.childOracle &&
+    bridgedFields.childChainId &&
+    bridgedFields.childBlockNumber
+  ) {
+    return {
+      title: stripInvalidCharacters(decodedIdentifier),
+      description: "No description found for this request.",
+      umipOrUppLink: undefined,
+      umipOrUppNumber: undefined,
+      options: getDefaultOptionsForIdentifier(decodedIdentifier),
+      origin: "UMA",
+      isGovernance: false,
+      discordLink,
+      isAssertion: false,
+    };
+  }
+
   const isAssertion = ["assertionId:", "ooAsserter:"].every((lookup) =>
     decodedAncillaryData.includes(lookup)
   );

--- a/helpers/voting/resolveAncillaryData.ts
+++ b/helpers/voting/resolveAncillaryData.ts
@@ -1,5 +1,6 @@
 import { RequestAddedEvent } from "@uma/contracts-frontend/dist/typechain/core/ethers/VotingV2";
 import { resolveAncillaryData as resolveAncillaryDataShared } from "lib/l2-ancillary-data";
+import { getBridgedFields } from "lib/deeplink-matching";
 import { buildSearchParams } from "helpers/util/buildSearchParams";
 import { promiseAllWithConcurrency } from "helpers/util/promiseConcurrency";
 import { getBaseUrl } from "helpers/util/http";
@@ -16,7 +17,34 @@ export async function resolveAncillaryDataForRequests<
   }));
 }
 
-export async function resolveAncillaryData(
+// Resolution is immutable (the bridged event never changes), so each unique
+// request resolves at most once per session no matter how many queries ask.
+const resolutionCache = new Map<string, Promise<string>>();
+
+export function resolveAncillaryData(
+  args: Pick<RequestAddedEvent["args"], "ancillaryData" | "time" | "identifier">
+): Promise<string> {
+  // Only bridged (compressed) requests need resolution; everything else
+  // already carries its full ancillary data.
+  if (!getBridgedFields(args.ancillaryData)) {
+    return Promise.resolve(args.ancillaryData);
+  }
+
+  const cacheKey = `${args.identifier}-${args.time.toString()}-${
+    args.ancillaryData
+  }`;
+  const cached = resolutionCache.get(cacheKey);
+  if (cached) return cached;
+
+  const pending = resolveAncillaryDataUncached(args).catch((error) => {
+    resolutionCache.delete(cacheKey);
+    throw error;
+  });
+  resolutionCache.set(cacheKey, pending);
+  return pending;
+}
+
+async function resolveAncillaryDataUncached(
   args: Pick<RequestAddedEvent["args"], "ancillaryData" | "time" | "identifier">
 ): Promise<string> {
   try {

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -70,6 +70,7 @@ export { useEncryptedVotes } from "./queries/votes/useEncryptedVotes";
 export { useNewVotesAdded } from "./queries/votes/useNewVotesAdded";
 export { usePastVotes } from "./queries/votes/usePastVotes";
 export { usePastVoteDetails } from "./queries/votes/usePastVoteDetails";
+export { useResolvedVoteList } from "./queries/votes/useResolvedVoteList";
 export { useRevealedVotes } from "./queries/votes/useRevealedVotes";
 export { useUpcomingVotes } from "./queries/votes/useUpcomingVotes";
 export { useVoteDiscussion } from "./queries/votes/useVoteDiscussion";

--- a/hooks/queries/votes/index.ts
+++ b/hooks/queries/votes/index.ts
@@ -4,6 +4,7 @@ export { useContentfulData } from "./useContentfulData";
 export { useDecryptedVotes } from "./useDecryptedVotes";
 export { useEncryptedVotes } from "./useEncryptedVotes";
 export { usePastVotes } from "./usePastVotes";
+export { useResolvedVoteList } from "./useResolvedVoteList";
 export { useRevealedVotes } from "./useRevealedVotes";
 export { useUpcomingVotes } from "./useUpcomingVotes";
 export { useActiveVoteResults } from "./useActiveVoteResults";

--- a/hooks/queries/votes/useResolvedVoteList.ts
+++ b/hooks/queries/votes/useResolvedVoteList.ts
@@ -1,0 +1,63 @@
+import { useQueries } from "@tanstack/react-query";
+import { resolvedAncillaryDataKey } from "constant";
+import { BigNumber } from "ethers";
+import { decodeHexString, getVoteMetaData } from "helpers";
+import { resolveAncillaryData } from "helpers/voting/resolveAncillaryData";
+import { getBridgedFields } from "lib/deeplink-matching";
+import { VoteT } from "types";
+
+// Bridged (L2) votes carry a reference to their real ancillary data instead
+// of the data itself. Lists ship them unresolved — resolving the full vote
+// history costs one API call per vote. This hook resolves only the votes
+// passed in (i.e. the ones on screen) and re-derives the metadata that
+// depends on the resolved data. Resolution is immutable, so each vote is
+// fetched at most once.
+export function useResolvedVoteList(votes: VoteT[]) {
+  const results = useQueries({
+    queries: votes.map((vote) => ({
+      queryKey: [resolvedAncillaryDataKey, vote.uniqueKey],
+      queryFn: () =>
+        resolveAncillaryData({
+          identifier: vote.identifier,
+          time: BigNumber.from(vote.time),
+          ancillaryData: vote.ancillaryData,
+        }),
+      staleTime: Infinity,
+      cacheTime: Infinity,
+      enabled: needsResolution(vote),
+    })),
+  });
+
+  const resolvedVotes = votes.map((vote, i) => {
+    const resolved = results[i]?.data;
+    if (!resolved || resolved === vote.ancillaryDataL2) return vote;
+    try {
+      const decodedAncillaryData = decodeHexString(resolved);
+      return {
+        ...vote,
+        ancillaryDataL2: resolved,
+        decodedAncillaryData,
+        ...getVoteMetaData(
+          vote.decodedIdentifier,
+          decodedAncillaryData,
+          vote.contentfulData
+        ),
+      };
+    } catch {
+      return vote;
+    }
+  });
+
+  const isResolving = results.some(
+    (result, i) => needsResolution(votes[i]) && result.isLoading
+  );
+
+  return { resolvedVotes, isResolving };
+}
+
+function needsResolution(vote: VoteT) {
+  return (
+    vote.ancillaryDataL2 === vote.ancillaryData &&
+    !!getBridgedFields(vote.ancillaryData)
+  );
+}


### PR DESCRIPTION
## Problem

Opening the voter dapp spammed `/api/resolve-l2-ancillary-data` in what looked like an endless loop. Measured on prod: **~3,900 requests on load** (one per past vote in UMA's history), repeated **every 60 seconds** via `usePastVotes`' `refetchInterval`, and again on every window focus. Most repeats were absorbed by the browser cache, but every cold visitor slams the endpoint with the full sweep, and the dapp burns main-thread time issuing thousands of fetches per minute.

Root cause: `getPastVotesV2Lightweight` called `resolveAncillaryDataForRequests` over the entire resolved-request history, and the client helper called the API unconditionally — even for the ~1,000 requests that aren't bridged and need no resolution at all.

## Fix

Resolution is now on demand, scoped to what's actually rendered:

- **`getPastVotesV2Lightweight`** no longer resolves anything; the list ships raw ancillary data (`ancillaryDataL2` defaults to the raw value).
- **New `useResolvedVoteList` hook** resolves bridged ancillary data for only the votes passed to it, via one react-query entry per vote with `staleTime: Infinity` (resolution is immutable). Applied at the three render sites: the paginated past-votes page, the homepage recent-5, and the vote panel (which shows its existing loading state while resolving, so deeplinks and history clicks still get fully resolved data).
- **`resolveAncillaryData` (client helper)** short-circuits without any HTTP call when the ancillary data has no bridged (L2) fields, and memoizes in-flight/settled resolutions per session. This also shrinks the remaining query-level resolution done for active/upcoming votes.
- **`getVoteMetaData`** returns identifier-derived metadata for unresolved bridged references instead of trying to parse them (previously this logged `JSON.parse` errors for every unresolved `MULTIPLE_VALUES` vote on every render).

`uniqueKey` is derived from the *raw* ancillary data, so deeplinks, vote lookups, and contentful/admin matching are unaffected.

## Result

Verified against a local dev server: page loads now make **~50 resolution calls** (active votes + visible rows) instead of ~3,900, titles and option labels for bridged Polymarket votes render correctly, and the per-minute refetch cycle no longer re-hits the endpoint at all (each vote resolves at most once per session).

## Notes for review

- `HistoryPanel` rows don't render titles, so they intentionally don't resolve; clicking through to a vote resolves it in the panel.
- Active/upcoming vote queries still resolve at query level — those sets are small (~40) and now benefit from the non-bridged skip + memoization.
- Typecheck, lint, and the vitest suite (102 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)