### PR TITLE
fix: abort hung subgraph requests so retries and RPC fallbacks can fire

### DIFF
--- a/constant/graph/requestTimeouts.ts
+++ b/constant/graph/requestTimeouts.ts
@@ -1,0 +1,11 @@
+// Subgraph outages can hang connections open instead of erroring. Nothing
+// above the fetch layer copes with a promise that never settles — react-query
+// only retries on rejection and RPC fallbacks live in catch blocks — so
+// subgraph requests are aborted after these windows. Values are deliberately
+// generous (~5-10x the slowest healthy response) so a slow success is never
+// cut off; the goal is only to turn "hangs forever" into a rejection.
+export const SUBGRAPH_REQUEST_TIMEOUT_MS = 20_000;
+
+// tighter on API routes so a hung subgraph returns a controlled error
+// instead of burning the function's whole execution window
+export const SERVER_SUBGRAPH_REQUEST_TIMEOUT_MS = 10_000;

--- a/constant/index.ts
+++ b/constant/index.ts
@@ -1,3 +1,4 @@
+export * from "./graph/requestTimeouts";
 export * from "./misc/defaultResultsPerPage";
 export * from "./misc/errorMessages";
 export * from "./misc/maximumApprovalAmountString";

--- a/graph/queries/getActiveVoteResults.ts
+++ b/graph/queries/getActiveVoteResults.ts
@@ -1,6 +1,7 @@
 import { config } from "helpers/config";
-import request, { gql } from "graphql-request";
+import { gql } from "graphql-request";
 import { formatBytes32String, makePriceRequestsByKey } from "helpers";
+import { subgraphRequest } from "helpers/util/subgraphRequest";
 import {
   PastVotesQuery,
   RevealedVotesByAddress,
@@ -59,7 +60,10 @@ export async function getActiveVoteResults(): Promise<
     }
   `;
 
-  const result = await request<PastVotesQuery>(endpoint, pastVotesQuery);
+  const result = await subgraphRequest<PastVotesQuery>(
+    endpoint,
+    pastVotesQuery
+  );
   const requests = result?.priceRequests?.map(
     ({
       identifier: { id },

--- a/graph/queries/getGlobals.ts
+++ b/graph/queries/getGlobals.ts
@@ -1,5 +1,6 @@
-import request, { gql } from "graphql-request";
+import { gql } from "graphql-request";
 import { config } from "helpers/config";
+import { subgraphRequest } from "helpers/util/subgraphRequest";
 import { SubgraphGlobals } from "types";
 const { graphEndpoint, overrideApr } = config;
 
@@ -15,6 +16,9 @@ export async function getGlobals() {
     }
   `;
 
-  const { global } = await request<SubgraphGlobals>(graphEndpoint, query);
+  const { global } = await subgraphRequest<SubgraphGlobals>(
+    graphEndpoint,
+    query
+  );
   return global;
 }

--- a/graph/queries/getPastVotes.ts
+++ b/graph/queries/getPastVotes.ts
@@ -1,8 +1,9 @@
 import { BigNumber, utils } from "ethers";
-import { gql, request } from "graphql-request";
+import { gql } from "graphql-request";
 import { formatBytes32String, makePriceRequestsByKey } from "helpers";
 import { config } from "helpers/config";
 import { fetchAllDocuments } from "helpers/util/fetchAllDocuments";
+import { subgraphRequest } from "helpers/util/subgraphRequest";
 import { warnOnce } from "helpers/util/log";
 import { resolveAncillaryData } from "helpers/voting/resolveAncillaryData";
 import { PastVotesQuery, RevealedVotesByAddress } from "types";
@@ -173,11 +174,15 @@ export async function getPastVoteDetails(resolvedPriceRequestIndex: number) {
     }
   `;
 
-  const response = await request<PastVotesQuery>(endpoint, voteDetailsQuery, {
-    // BigInt is serialized as a string
-    index: String(resolvedPriceRequestIndex),
-    latestRoundLimit: VOTE_DETAILS_LATEST_ROUND_LIMIT,
-  });
+  const response = await subgraphRequest<PastVotesQuery>(
+    endpoint,
+    voteDetailsQuery,
+    {
+      // BigInt is serialized as a string
+      index: String(resolvedPriceRequestIndex),
+      latestRoundLimit: VOTE_DETAILS_LATEST_ROUND_LIMIT,
+    }
+  );
 
   if (!response?.priceRequests?.[0]) return null;
 
@@ -278,7 +283,7 @@ export async function getUserVotesForRequests(
   `;
 
   try {
-    const response = await request<{
+    const response = await subgraphRequest<{
       priceRequests: Array<{
         resolvedPriceRequestIndex: string;
         latestRound: {

--- a/graph/queries/getUpcomingVotes.ts
+++ b/graph/queries/getUpcomingVotes.ts
@@ -1,7 +1,8 @@
 import { BigNumber } from "ethers";
-import { gql, request } from "graphql-request";
+import { gql } from "graphql-request";
 import { formatBytes32String } from "helpers";
 import { config } from "helpers/config";
+import { subgraphRequest } from "helpers/util/subgraphRequest";
 
 type UpcomingRequestEntity = {
   identifier: { id: string };
@@ -35,15 +36,20 @@ export async function getUpcomingVotesFromSubgraph(currentRoundId: number) {
     }
   `;
 
-  const result = await request<{ priceRequests: UpcomingRequestEntity[] }>(
-    endpoint,
-    query
-  );
+  const result = await subgraphRequest<{
+    priceRequests: UpcomingRequestEntity[];
+  }>(endpoint, query);
 
   return result.priceRequests
     .filter(({ latestRound }) => Number(latestRound.roundId) > currentRoundId)
     .map(
-      ({ identifier: { id }, time, ancillaryData, isGovernance, rollCount }) => ({
+      ({
+        identifier: { id },
+        time,
+        ancillaryData,
+        isGovernance,
+        rollCount,
+      }) => ({
         identifier: formatBytes32String(id),
         time: BigNumber.from(time),
         ancillaryData,

--- a/graph/queries/getUserVotingAndStakingDetails.ts
+++ b/graph/queries/getUserVotingAndStakingDetails.ts
@@ -1,7 +1,8 @@
 import { BigNumber } from "ethers";
-import request, { gql } from "graphql-request";
+import { gql } from "graphql-request";
 import { bigNumberFromFloatString } from "helpers";
 import { config } from "helpers/config";
+import { subgraphRequest } from "helpers/util/subgraphRequest";
 import {
   UserDataQuery,
   UserDataT,
@@ -88,7 +89,7 @@ export async function getUserVotingAndStakingDetails(
   while (true) {
     const variables = { address, first: pageSize, skip };
 
-    const result = await request<{ users: FullUserNode[] }>(
+    const result = await subgraphRequest<{ users: FullUserNode[] }>(
       graphEndpoint,
       USER_WITH_VOTES_QUERY,
       variables

--- a/helpers/util/fetchAllDocuments.ts
+++ b/helpers/util/fetchAllDocuments.ts
@@ -1,4 +1,4 @@
-import request from "graphql-request";
+import { subgraphRequest } from "helpers/util/subgraphRequest";
 
 /**
  * Thegraph can only return a maximum of 1000 documents at a time and does not support pagination features whereby the client can determine the total amount of documents in the store.
@@ -25,7 +25,7 @@ export async function fetchAllDocuments<
 
   do {
     const variables = { skip, limit: pageSize };
-    response = await request<RequestType>(endpoint, query, variables);
+    response = await subgraphRequest<RequestType>(endpoint, query, variables);
     allData = allData.concat(response[dataKey]);
     skip += pageSize;
     // if we get less than 1000 we know we got them all

--- a/helpers/util/subgraphRequest.ts
+++ b/helpers/util/subgraphRequest.ts
@@ -1,0 +1,48 @@
+import request, {
+  RequestDocument,
+  RequestExtendedOptions,
+  Variables,
+} from "graphql-request";
+// deep import: the constant barrel transitively validates env, which must
+// not run just because this fetch wrapper is imported (e.g. in tests)
+import { SUBGRAPH_REQUEST_TIMEOUT_MS } from "constant/graph/requestTimeouts";
+
+// graphql-request vendors its own DOM types, so the runtime AbortSignal needs
+// a cast to satisfy its structurally-identical copy
+type GraphqlRequestSignal = RequestExtendedOptions["signal"];
+
+/**
+ * graphql-request with an abort timeout. Every subgraph call must go through
+ * this instead of calling `request` directly, so that a hung endpoint
+ * rejects and the caller's retry/fallback path actually runs.
+ */
+export async function subgraphRequest<T, V extends Variables = Variables>(
+  url: string,
+  document: RequestDocument,
+  variables?: V,
+  timeoutMs: number = SUBGRAPH_REQUEST_TIMEOUT_MS
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    // the options form is the only request() signature accepting a signal;
+    // its `variables` field is a conditional type that cannot be checked
+    // against an unresolved generic, hence the assertion
+    const options = {
+      url,
+      document,
+      variables,
+      signal: controller.signal as GraphqlRequestSignal,
+    } as unknown as RequestExtendedOptions<V, T>;
+    return await request<T, V>(options);
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(
+        `Subgraph request timed out after ${timeoutMs}ms: ${url}`
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/hooks/queries/votes/useOptimisticGovernorData.ts
+++ b/hooks/queries/votes/useOptimisticGovernorData.ts
@@ -2,7 +2,8 @@ import { useQuery } from "@tanstack/react-query";
 import { MainnetOrL1Testnet } from "types";
 
 import { useSetChain } from "@web3-onboard/react";
-import request, { gql } from "graphql-request";
+import { gql } from "graphql-request";
+import { subgraphRequest } from "helpers/util/subgraphRequest";
 import { appConfig } from "helpers";
 import { useWalletContext } from "hooks/contexts/useWalletContext";
 import { useHandleError } from "hooks/helpers/useHandleError";
@@ -85,7 +86,10 @@ export async function getProposalData(
     }
   `;
 
-  return request<OptimisticGovernorProposalData>(endpoint, proposalQuery);
+  return subgraphRequest<OptimisticGovernorProposalData>(
+    endpoint,
+    proposalQuery
+  );
 }
 
 export function useOptimisticGovernorData(decodedAncillaryData: string) {

--- a/pages/api/augment-request-gql.ts
+++ b/pages/api/augment-request-gql.ts
@@ -1,5 +1,7 @@
-import request, { gql } from "graphql-request";
+import { gql, Variables } from "graphql-request";
 import assert from "assert";
+import { SERVER_SUBGRAPH_REQUEST_TIMEOUT_MS } from "constant";
+import { subgraphRequest } from "helpers/util/subgraphRequest";
 import { NextApiRequest, NextApiResponse } from "next";
 import * as ss from "superstruct";
 import { makeUniqueKeyForVote, decodeHexString } from "helpers";
@@ -13,6 +15,19 @@ import { handleApiError } from "./_utils/errors";
 import { validateBodyParams } from "./_utils/validation";
 
 const debug = Boolean(process.env.DEBUG === "true");
+
+function requestSubgraph<T>(
+  url: string,
+  document: string,
+  variables?: Variables
+) {
+  return subgraphRequest<T>(
+    url,
+    document,
+    variables,
+    SERVER_SUBGRAPH_REQUEST_TIMEOUT_MS
+  );
+}
 
 const RequestBody = ss.object({
   ancillaryData: ss.string(),
@@ -88,7 +103,11 @@ async function voteQuery({
     priceRequest: GqlRequest | undefined | null;
   };
   try {
-    const data: GqlResponse = await request(VoteSubgraphURL, query, { id });
+    const data: GqlResponse = await requestSubgraph<GqlResponse>(
+      VoteSubgraphURL,
+      query,
+      { id }
+    );
     assert(data.priceRequest, "vote query request not found");
     return data.priceRequest;
   } catch (error) {
@@ -126,9 +145,13 @@ async function ooSkinnyQuery({
   };
 
   try {
-    const data: GqlResponse = await request(subgraph.url, query, {
-      id,
-    });
+    const data: GqlResponse = await requestSubgraph<GqlResponse>(
+      subgraph.url,
+      query,
+      {
+        id,
+      }
+    );
     const { optimisticPriceRequest } = data;
     assert(optimisticPriceRequest, "skinny request not found");
     const requestHash = optimisticPriceRequest?.requestHash;
@@ -196,9 +219,13 @@ async function oov3Query({
   };
 
   try {
-    const data: GqlResponse = await request(subgraph.url, query, {
-      id: assertionId,
-    });
+    const data: GqlResponse = await requestSubgraph<GqlResponse>(
+      subgraph.url,
+      query,
+      {
+        id: assertionId,
+      }
+    );
     assert(data.assertion, "oov3 query request not found");
     const { assertion } = data;
     const assertionHash = assertion?.assertionHash;
@@ -283,10 +310,14 @@ async function oov2Query({
   };
 
   try {
-    const data: GqlResponse = await request(subgraph.url, query, {
-      ancillaryData: cleanAncillaryData,
-      identifier,
-    });
+    const data: GqlResponse = await requestSubgraph<GqlResponse>(
+      subgraph.url,
+      query,
+      {
+        ancillaryData: cleanAncillaryData,
+        identifier,
+      }
+    );
     assert(data.optimisticPriceRequests.length > 0, "oov2 request not found");
     let optimisticPriceRequest: GqlRequest | undefined;
     if (data.optimisticPriceRequests.length > 1) {
@@ -368,10 +399,14 @@ async function ooManagedQuery({
   };
 
   try {
-    const data: GqlResponse = await request(subgraph.url, query, {
-      ancillaryData: cleanAncillaryData,
-      identifier,
-    });
+    const data: GqlResponse = await requestSubgraph<GqlResponse>(
+      subgraph.url,
+      query,
+      {
+        ancillaryData: cleanAncillaryData,
+        identifier,
+      }
+    );
     assert(
       data.optimisticPriceRequests.length > 0,
       "Managed oov2 request not found"
@@ -447,9 +482,13 @@ async function oov1Query({
       optimisticPriceRequest: GqlRequest;
     };
 
-    const data: GqlResponse = await request(subgraph.url, query, {
-      id,
-    });
+    const data: GqlResponse = await requestSubgraph<GqlResponse>(
+      subgraph.url,
+      query,
+      {
+        id,
+      }
+    );
     const { optimisticPriceRequest } = data;
     assert(optimisticPriceRequest, "oov1 request not found");
     const requestHash = optimisticPriceRequest?.requestHash;

--- a/pages/api/resolve-deeplink.ts
+++ b/pages/api/resolve-deeplink.ts
@@ -1,5 +1,7 @@
 import { BigNumber } from "ethers";
-import { gql, request as gqlRequest } from "graphql-request";
+import { gql, Variables } from "graphql-request";
+import { SERVER_SUBGRAPH_REQUEST_TIMEOUT_MS } from "constant";
+import { subgraphRequest } from "helpers/util/subgraphRequest";
 import { computeRoundId } from "helpers/voting/voteTiming";
 import {
   makeUniqueKeyForVote,
@@ -24,6 +26,15 @@ import { NextApiRequest, NextApiResponse } from "next";
 import * as ss from "superstruct";
 import { ActivityStatusT } from "types";
 import { VoteSubgraphURL } from "./_common";
+
+function gqlRequest<T>(url: string, document: string, variables?: Variables) {
+  return subgraphRequest<T>(
+    url,
+    document,
+    variables,
+    SERVER_SUBGRAPH_REQUEST_TIMEOUT_MS
+  );
+}
 import { handleApiError, HttpError } from "./_utils/errors";
 import { validateQueryParams } from "./_utils/validation";
 

--- a/tests/helpers/subgraphRequest.test.ts
+++ b/tests/helpers/subgraphRequest.test.ts
@@ -1,0 +1,34 @@
+import { subgraphRequest } from "helpers/util/subgraphRequest";
+import { describe, expect, it, vi } from "vitest";
+
+const requestMock = vi.hoisted(() => vi.fn());
+vi.mock("graphql-request", () => ({ default: requestMock }));
+
+describe("subgraphRequest", () => {
+  it("resolves with the underlying request's result", async () => {
+    requestMock.mockResolvedValueOnce({ priceRequests: [] });
+    await expect(
+      subgraphRequest("https://example.com/subgraph", "query {}")
+    ).resolves.toEqual({ priceRequests: [] });
+  });
+
+  it("rejects when the request hangs past the timeout", async () => {
+    // a hung subgraph never settles; the abort signal is the only way out
+    requestMock.mockImplementationOnce(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("aborted")));
+        })
+    );
+    await expect(
+      subgraphRequest("https://example.com/subgraph", "query {}", undefined, 20)
+    ).rejects.toThrow(/timed out after 20ms/);
+  });
+
+  it("passes real errors through instead of reporting a timeout", async () => {
+    requestMock.mockRejectedValueOnce(new Error("bad query"));
+    await expect(
+      subgraphRequest("https://example.com/subgraph", "query {}")
+    ).rejects.toThrow("bad query");
+  });
+});


### PR DESCRIPTION
## Motivation

During the 2026-07-24 Goldsky outage, subgraph requests **hung** instead of erroring. Nothing above the fetch layer copes with a promise that never settles:

- react-query only retries on **rejection** — a pending promise keeps queries in `isLoading` forever, with no error state and no console warning
- the upcoming-votes RPC fallback lives in a `catch` block, so the one fallback protecting a live-vote path was structurally unreachable during exactly the outage type it was built for
- API routes (`resolve-deeplink`, `augment-request-gql`) hung until Vercel killed the function (504, full execution window billed)

## Changes

- **`helpers/util/subgraphRequest.ts`** (new): wraps `graphql-request` with an `AbortController` timeout. On timeout the fetch aborts and the promise **rejects** with a descriptive error, which re-arms everything that already exists: react-query retries with backoff, the upcoming-votes catch falls back to the RPC scan, `warnOnce` logs, error states render. Real errors pass through unchanged.
- **`constant/graph/requestTimeouts.ts`** (new): 20s for client fetches, 10s for API routes. Deliberately generous (~5–10× the slowest healthy response, the 1000-row past-votes pages) — the goal is only to convert "hangs forever" into a rejection, never to cut off a slow success.
- Every subgraph call site now goes through the wrapper: `fetchAllDocuments` (per page), past votes list/details/user votes, upcoming votes, active vote results, globals (APR), user voting & staking details, OptimisticGovernor proposal data, and the `resolve-deeplink` + `augment-request-gql` routes (server timeout).

Deliberately untouched: RPC/ethers calls and wallet interactions — different providers and failure modes, and the critical commit/reveal path is already subgraph-independent.

## Testing

- New unit test covers the three wrapper behaviors: passthrough success, rejection on hang, real errors not masked as timeouts.
- `tsc --noEmit` clean; full vitest suite 105/105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)