### PR TITLE
Show proposed answer in vote panel Details tab

### DIFF
--- a/components/Panel/VotePanel/Details.tsx
+++ b/components/Panel/VotePanel/Details.tsx
@@ -4,6 +4,7 @@ import {
   checkIfIsPolymarket,
   decodeHexString,
   formatNumberForDisplay,
+  formatProposedAnswer,
   getQuestionId,
   makeBlockExplorerLink,
   makeTransactionHashLink,
@@ -123,6 +124,12 @@ export function Details(query: VoteT) {
     };
   }
 
+  const proposedAnswer = formatProposedAnswer(
+    augmentedData?.proposedPrice,
+    decodedIdentifier,
+    options
+  );
+
   const optionLabels = options?.map(({ label }) => label);
   const links = [
     makeAsserterLink(),
@@ -184,6 +191,12 @@ export function Details(query: VoteT) {
             <span>{decodedIdentifier}</span>
           </IdentifierPill>
         </RequestInfoIcons>
+
+        {proposedAnswer && (
+          <Text>
+            <Strong>Proposed as:</Strong> {proposedAnswer}
+          </Text>
+        )}
 
         <PanelSectionTitle>
           <IconWrapper>

--- a/helpers/voting/formatVotes.ts
+++ b/helpers/voting/formatVotes.ts
@@ -143,6 +143,49 @@ export function formatVoteStringWithPrecision(
   return formatted.endsWith(".0") ? formatted.slice(0, -2) : formatted;
 }
 
+// Formats a proposed price for display, e.g. "P2 (Yes)" for votes with
+// Polymarket-style options, the bare option label otherwise, or the plain
+// numeric value when no option matches.
+export function formatProposedAnswer(
+  proposedPrice: string | undefined,
+  decodedIdentifier: string,
+  options: DropdownItemT[] | undefined
+): string | undefined {
+  if (!proposedPrice) return undefined;
+
+  const isTooEarly = proposedPrice === minInt256.toString();
+  const isUnresolvable = proposedPrice === maxInt256.toString();
+
+  if (decodedIdentifier === "MULTIPLE_VALUES") {
+    if (isTooEarly) return "Early request";
+    if (isUnresolvable) return "Unresolvable";
+    if (!options?.length) return undefined;
+    try {
+      const values = decodeMultipleQuery(proposedPrice, options.length);
+      if (typeof values === "string") return undefined;
+      return options
+        .map((option, index) => `${option.label}: ${values[index]}`)
+        .join(", ");
+    } catch {
+      return undefined;
+    }
+  }
+
+  const formatted = formatVoteStringWithPrecision(
+    proposedPrice,
+    decodedIdentifier
+  );
+  const match = options?.find((option) => String(option.value) === formatted);
+  if (match) {
+    return match.secondaryLabel && /^p\d+$/i.test(match.secondaryLabel)
+      ? `${match.secondaryLabel.toUpperCase()} (${match.label})`
+      : match.label;
+  }
+  if (isTooEarly) return "Early request";
+  if (isUnresolvable) return "Unresolvable";
+  return formatted;
+}
+
 export function formatMultipleValuesVote(
   result: ResultsT[number],
   options: DropdownItemT[] | undefined,

--- a/tests/helpers/voting/formatVotes.test.ts
+++ b/tests/helpers/voting/formatVotes.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from "vitest";
+import { ethers } from "ethers";
+
+vi.mock("helpers/config", () => ({
+  config: {},
+  appConfig: {},
+  env: {},
+}));
+
+// formatVotes imports from the "helpers" barrel which triggers WalletConnect init.
+// Mock it, forwarding only what formatProposedAnswer uses. The other imports
+// (encryptMessage etc.) are stubbed — importing their real modules here would
+// deadlock, because they import the mocked "helpers" barrel themselves.
+vi.mock("helpers", async () => {
+  const polymarket = await import("helpers/voting/projects/polymarket");
+  return {
+    decodeMultipleQuery: polymarket.decodeMultipleQuery,
+    encryptMessage: vi.fn(),
+    getPrecisionForIdentifier: () => 18,
+    getRandomSignedInt: vi.fn(),
+    solidityKeccak256: vi.fn(),
+  };
+});
+
+import { formatProposedAnswer } from "helpers/voting/formatVotes";
+import { encodeMultipleQuery } from "helpers/voting/projects/polymarket";
+import { earlyRequestMagicNumber } from "constant/voting/earlyRequestMagicNumber";
+
+const yesOrNoOptions = [
+  { label: "No", value: "0", secondaryLabel: "p1" },
+  { label: "Yes", value: "1", secondaryLabel: "p2" },
+  { label: "Unknown", value: "0.5", secondaryLabel: "p3" },
+  {
+    label: "Early request",
+    value: earlyRequestMagicNumber,
+    secondaryLabel: "p4",
+  },
+  { label: "Custom", value: "custom" },
+];
+
+const oneEther = ethers.utils.parseEther("1").toString();
+const halfEther = ethers.utils.parseEther("0.5").toString();
+
+describe("formatProposedAnswer", () => {
+  it("returns undefined when there is no proposed price", () => {
+    expect(
+      formatProposedAnswer(undefined, "YES_OR_NO_QUERY", yesOrNoOptions)
+    ).toBeUndefined();
+  });
+
+  it("formats yes/no options with p-labels", () => {
+    expect(
+      formatProposedAnswer(oneEther, "YES_OR_NO_QUERY", yesOrNoOptions)
+    ).toBe("P2 (Yes)");
+    expect(formatProposedAnswer("0", "YES_OR_NO_QUERY", yesOrNoOptions)).toBe(
+      "P1 (No)"
+    );
+    expect(
+      formatProposedAnswer(halfEther, "YES_OR_NO_QUERY", yesOrNoOptions)
+    ).toBe("P3 (Unknown)");
+  });
+
+  it("formats dynamic market outcome labels", () => {
+    const options = [
+      { label: "Zimbabwe", value: "1", secondaryLabel: "p2" },
+      { label: "Zambia", value: "0", secondaryLabel: "p1" },
+    ];
+    expect(formatProposedAnswer(oneEther, "YES_OR_NO_QUERY", options)).toBe(
+      "P2 (Zimbabwe)"
+    );
+  });
+
+  it("formats the early request magic number via the p4 option", () => {
+    expect(
+      formatProposedAnswer(
+        ethers.constants.MinInt256.toString(),
+        "YES_OR_NO_QUERY",
+        yesOrNoOptions
+      )
+    ).toBe("P4 (Early request)");
+  });
+
+  it("falls back to friendly names for magic numbers without options", () => {
+    expect(
+      formatProposedAnswer(
+        ethers.constants.MinInt256.toString(),
+        "YES_OR_NO_QUERY",
+        undefined
+      )
+    ).toBe("Early request");
+    expect(
+      formatProposedAnswer(
+        ethers.constants.MaxInt256.toString(),
+        "YES_OR_NO_QUERY",
+        undefined
+      )
+    ).toBe("Unresolvable");
+  });
+
+  it("uses the bare label when the option has no p-style secondary label", () => {
+    const options = [{ label: "Valid", value: "1", secondaryLabel: "valid" }];
+    expect(formatProposedAnswer(oneEther, "YES_OR_NO_QUERY", options)).toBe(
+      "Valid"
+    );
+  });
+
+  it("falls back to the plain number when no option matches", () => {
+    expect(
+      formatProposedAnswer(
+        ethers.utils.parseEther("0.75").toString(),
+        "YES_OR_NO_QUERY",
+        yesOrNoOptions
+      )
+    ).toBe("0.75");
+  });
+
+  it("decodes MULTIPLE_VALUES prices into label/value pairs", () => {
+    const options = [
+      { label: "Lakers", value: "0" },
+      { label: "Celtics", value: "1" },
+    ];
+    const encoded = encodeMultipleQuery(["102", "99"]);
+    expect(formatProposedAnswer(encoded, "MULTIPLE_VALUES", options)).toBe(
+      "Lakers: 102, Celtics: 99"
+    );
+  });
+
+  it("handles magic numbers for MULTIPLE_VALUES", () => {
+    expect(
+      formatProposedAnswer(
+        ethers.constants.MinInt256.toString(),
+        "MULTIPLE_VALUES",
+        []
+      )
+    ).toBe("Early request");
+    expect(
+      formatProposedAnswer(
+        ethers.constants.MaxInt256.toString(),
+        "MULTIPLE_VALUES",
+        []
+      )
+    ).toBe("Unresolvable");
+  });
+});


### PR DESCRIPTION
## Motivation

When a disputed proposal reaches a DVM vote, the vote panel never shows what was originally proposed, which makes evaluating the dispute cumbersome (raised by Tony in Slack).

## Summary

Adds a **Proposed as:** line to the vote panel's Details tab, right above the Description section, e.g. `Proposed as: P2 (Yes)`.

## Details

- The `augment-request-gql` API already returns the originating OO request's `proposedPrice` for OOv2 / Managed OOv2 requests (which covers Polymarket), and `useAugmentedVoteData` already delivers it to the panel — until now it was only used internally to label `MULTIPLE_VALUES` results, never rendered.
- New helper `formatProposedAnswer` in `helpers/voting/formatVotes.ts`:
  - `P1 (No)` / `P2 (Yes)` / `P2 (Zimbabwe)` style when the vote has Polymarket-style options (matched via the option's `secondaryLabel`)
  - bare option label when the matched option has no p-style secondary label
  - `Early request` / `Unresolvable` for the min/max int256 magic numbers
  - decoded `Label: value` pairs for `MULTIPLE_VALUES` votes
  - plain formatted number when no option matches
  - hidden entirely when the augment API has no `proposedPrice` (OOv1 / Skinny / OOv3 requests)
- Unit tests for all of the above.

## Preview

Screenshot posted in the originating Slack thread (rendered against the live site with real data for vote #3934, which was proposed as `P2 (Yes)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)