### PR TITLE
chore: remove gas rebate announcement banner

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,6 +1,5 @@
 import {
   ErrorBanner,
-  GasRebateBanner,
   Header,
   OldDesignatedVotingAccountWarningBanner,
 } from "components";
@@ -21,7 +20,6 @@ export function Layout({ children, title }: Props) {
     <>
       <Meta title={title} />
       <Main>
-        <GasRebateBanner />
         <ErrorBanner />
         <OldDesignatedVotingAccountWarningBanner />
         <Header />


### PR DESCRIPTION
## Motivation

The June 2026 gas rebate announcement banner (voting-pool ineligibility starting June 15) has been live for well over a month. Per comms, it's safe to take down.

Requested by James in Slack.

## Summary

Removes `<GasRebateBanner />` (and its import) from `components/Layout/Layout.tsx`, following the standard enable/disable process used previously (#355, #459). The `GasRebateBanner` component itself is left in place for future reuse.

## Details

- localStorage key of the banner being retired: `show-gas-rebate-banner-june-2026`
- No other code paths reference the banner besides the barrel export in `components/index.ts`, which is intentionally kept (same as #355).

🤖 Generated with [Claude Code](https://claude.com/claude-code)